### PR TITLE
Add events for when world has (un-)loaded

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/world/BuildWorldLoadedEvent.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/world/BuildWorldLoadedEvent.java
@@ -1,0 +1,13 @@
+package de.eintosti.buildsystem.event.world;
+
+import de.eintosti.buildsystem.world.BuildWorld;
+
+/**
+ * Called after a {@link BuildWorld} has loaded.
+ */
+public class BuildWorldLoadedEvent extends BuildWorldEvent {
+
+    public BuildWorldLoadedEvent(BuildWorld buildWorld) {
+        super(buildWorld);
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/world/BuildWorldUnloadedEvent.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/world/BuildWorldUnloadedEvent.java
@@ -1,0 +1,13 @@
+package de.eintosti.buildsystem.event.world;
+
+import de.eintosti.buildsystem.world.BuildWorld;
+
+/**
+ * Called after a {@link BuildWorld} has unloaded.
+ */
+public class BuildWorldUnloadedEvent extends BuildWorldEvent {
+
+    public BuildWorldUnloadedEvent(BuildWorld buildWorld) {
+        super(buildWorld);
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
@@ -13,7 +13,9 @@ import de.eintosti.buildsystem.BuildSystem;
 import de.eintosti.buildsystem.Messages;
 import de.eintosti.buildsystem.config.ConfigValues;
 import de.eintosti.buildsystem.event.world.BuildWorldLoadEvent;
+import de.eintosti.buildsystem.event.world.BuildWorldLoadedEvent;
 import de.eintosti.buildsystem.event.world.BuildWorldUnloadEvent;
+import de.eintosti.buildsystem.event.world.BuildWorldUnloadedEvent;
 import de.eintosti.buildsystem.util.InventoryUtils;
 import de.eintosti.buildsystem.util.UUIDFetcher;
 import de.eintosti.buildsystem.world.data.WorldStatus;
@@ -838,6 +840,8 @@ public class BuildWorld implements ConfigurationSerializable {
         this.loaded = false;
         this.unloadTask = null;
 
+        Bukkit.getServer().getPluginManager().callEvent(new BuildWorldUnloadedEvent(this));
+
         plugin.getLogger().info("*** Unloaded world \"" + name + "\" ***");
     }
 
@@ -875,6 +879,8 @@ public class BuildWorld implements ConfigurationSerializable {
         plugin.getLogger().info("*** Loading world \"" + name + "\" ***");
         new BuildWorldCreator(plugin, this).generateBukkitWorld();
         this.loaded = true;
+
+        Bukkit.getServer().getPluginManager().callEvent(new BuildWorldLoadedEvent(this));
 
         resetUnloadTask();
     }


### PR DESCRIPTION
The events `BuildWorldLoadEvent` and `BuildWorldUnloadEvent` are called **before** a world has (un-)loaded, allowing for them to be cancelled.

`BuildWorldLoadedEvent` and `BuildWorldUnloadedEvent` are called **after** a world has (un-)loaded, therefore they cannot be cancelled.