### PR TITLE
Allow admins to specify further illegal characters in a world's name

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
@@ -62,11 +62,10 @@ public class ImportSubCommand implements SubCommand {
             return;
         }
 
-        if (Arrays.stream(worldName.split("")).anyMatch(c -> c.matches("[^A-Za-z\\d/_-]"))) {
-            Messages.sendMessage(player, "worlds_world_creation_invalid_characters");
-        }
-
-        String invalidChar = Arrays.stream(worldName.split("")).filter(c -> c.matches("[^A-Za-z\\d/_-]")).findFirst().orElse(null);
+        String invalidChar = Arrays.stream(worldName.split(""))
+                .filter(c -> c.matches("[^A-Za-z\\d/_-]") || c.matches(plugin.getConfigValues().getInvalidNameCharacters()))
+                .findFirst()
+                .orElse(null);
         if (invalidChar != null) {
             Messages.sendMessage(player, "worlds_import_invalid_character",
                     new AbstractMap.SimpleEntry<>("%world%", worldName),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
@@ -28,6 +28,7 @@ public class ConfigValues {
     private String timeUntilUnload;
     private String defaultPublicPermission;
     private String defaultPrivatePermission;
+    private String invalidNameCharacters;
 
     private XMaterial navigatorItem;
     private XMaterial worldEditWand;
@@ -96,6 +97,7 @@ public class ConfigValues {
         this.defaultPublicPermission = config.getString("world.default.permission.public", "-");
         this.defaultPrivatePermission = config.getString("world.default.permission.private", "-");
         this.lockWeather = config.getBoolean("world.lock-weather", true);
+        this.invalidNameCharacters = config.getString("world.invalid-characters", "^\b$");
         this.worldDifficulty = Difficulty.valueOf(config.getString("world.default.difficulty", "PEACEFUL").toUpperCase());
         this.sunriseTime = config.getInt("world.default.time.sunrise", 0);
         this.noonTime = config.getInt("world.default.time.noon", 6000);
@@ -309,5 +311,9 @@ public class ConfigValues {
 
     public String getDefaultPermission(boolean privateWorld) {
         return (privateWorld ? defaultPrivatePermission : defaultPublicPermission);
+    }
+
+    public String getInvalidNameCharacters() {
+        return invalidNameCharacters;
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
@@ -16,8 +16,8 @@ import de.eintosti.buildsystem.config.ConfigValues;
 import de.eintosti.buildsystem.config.WorldConfig;
 import de.eintosti.buildsystem.navigator.inventory.FilteredWorldsInventory.Visibility;
 import de.eintosti.buildsystem.util.FileUtils;
-import de.eintosti.buildsystem.util.UUIDFetcher;
 import de.eintosti.buildsystem.util.PlayerChatInput;
+import de.eintosti.buildsystem.util.UUIDFetcher;
 import de.eintosti.buildsystem.world.data.WorldStatus;
 import de.eintosti.buildsystem.world.data.WorldType;
 import de.eintosti.buildsystem.world.generator.CustomGenerator;
@@ -170,10 +170,14 @@ public class WorldManager {
     public void startWorldNameInput(Player player, WorldType worldType, @Nullable String template, boolean privateWorld) {
         player.closeInventory();
         new PlayerChatInput(plugin, player, "enter_world_name", input -> {
-            if (Arrays.stream(input.split("")).anyMatch(c -> c.matches("[^A-Za-z\\d/_-]"))) {
+            if (Arrays.stream(input.split("")).anyMatch(c -> c.matches("[^A-Za-z\\d/_-]") || c.matches(configValues.getInvalidNameCharacters()))) {
                 Messages.sendMessage(player, "worlds_world_creation_invalid_characters");
             }
-            String worldName = input.replaceAll("[^A-Za-z\\d/_-]", "").replace(" ", "_").trim();
+            String worldName = input
+                    .replaceAll("[^A-Za-z\\d/_-]", "")
+                    .replaceAll(configValues.getInvalidNameCharacters(), "")
+                    .replace(" ", "_")
+                    .trim();
             if (worldName.isEmpty()) {
                 Messages.sendMessage(player, "worlds_world_creation_name_bank");
                 return;
@@ -331,7 +335,10 @@ public class WorldManager {
                     return;
                 }
 
-                String invalidChar = Arrays.stream(worldName.split("")).filter(c -> c.matches("[^A-Za-z\\d/_-]")).findFirst().orElse(null);
+                String invalidChar = Arrays.stream(worldName.split(""))
+                        .filter(c -> c.matches("[^A-Za-z\\d/_-]") || c.matches(plugin.getConfigValues().getInvalidNameCharacters()))
+                        .findFirst()
+                        .orElse(null);
                 if (invalidChar != null) {
                     Messages.sendMessage(player, "worlds_importall_invalid_character",
                             new AbstractMap.SimpleEntry<>("%world%", worldName),
@@ -456,10 +463,14 @@ public class WorldManager {
             return;
         }
 
-        if (Arrays.stream(newName.split("")).anyMatch(c -> c.matches("[^A-Za-z\\d/_-]"))) {
+        if (Arrays.stream(newName.split("")).anyMatch(c -> c.matches("[^A-Za-z\\d/_-]") || c.matches(configValues.getInvalidNameCharacters()))) {
             Messages.sendMessage(player, "worlds_world_creation_invalid_characters");
         }
-        String parsedNewName = newName.replaceAll("[^A-Za-z\\d/_-]", "").replace(" ", "_").trim();
+        String parsedNewName = newName
+                .replaceAll("[^A-Za-z\\d/_-]", "")
+                .replaceAll(configValues.getInvalidNameCharacters(), "")
+                .replace(" ", "_")
+                .trim();
         if (parsedNewName.isEmpty()) {
             Messages.sendMessage(player, "worlds_world_creation_name_bank");
             return;

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -42,6 +42,7 @@ world:
         public: false
         private: true
   lock-weather: true
+  invalid-characters: ^\b$
   import-all:
     delay: 30
   max-amount:


### PR DESCRIPTION
New config option: `invalid-characters` (default: **^\b$** / no match)
If a character in the world's name matches the specified regex, it is removed

Closes #190 