### PR TITLE
Enable unload of unused worlds by default

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
@@ -127,7 +127,7 @@ public class ConfigValues {
                 config.getBoolean("world.default.settings.builders-enabled.private", true)
         };
 
-        this.unloadWorlds = config.getBoolean("world.unload.enabled", false);
+        this.unloadWorlds = config.getBoolean("world.unload.enabled", true);
         this.timeUntilUnload = config.getString("world.unload.time-until-unload", "01:00:00");
         this.blackListedWorldsToUnload = new HashSet<>(config.getStringList("world.unload.blacklisted-worlds"));
 

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -49,7 +49,7 @@ world:
     public: -1
     private: -1
   unload:
-    enabled: false
+    enabled: true
     time-until-unload: "01:00:00"
     blacklisted-worlds:
       - world


### PR DESCRIPTION
I've set unloading of unused worlds to be enabled by default. It works smoothly and greatly preserves the RAM as well as the overall server performance. Furthermore, it helps the server start much faster.