### PR TITLE
Add permission to individual status states (`/worlds setStatus`)

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
@@ -28,12 +28,11 @@ public class SetStatusSubCommand implements SubCommand {
 
     @Override
     public void execute(Player player, String[] args) {
-        WorldManager worldManager = plugin.getWorldManager();
-
         boolean hasPermission = player.getEffectivePermissions().stream()
             .anyMatch(effectivePermission -> effectivePermission.getPermission().contains("buildsystem.setstatus"));
 
-        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName) && !hasPermission) {
+        WorldManager worldManager = plugin.getWorldManager();
+        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName) || !hasPermission) {
             plugin.sendPermissionMessage(player);
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
@@ -28,11 +28,8 @@ public class SetStatusSubCommand implements SubCommand {
 
     @Override
     public void execute(Player player, String[] args) {
-        boolean hasPermission = player.getEffectivePermissions().stream()
-            .anyMatch(effectivePermission -> effectivePermission.getPermission().startsWith("buildsystem.setstatus"));
-
         WorldManager worldManager = plugin.getWorldManager();
-        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName) || !hasPermission) {
+        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName)) {
             plugin.sendPermissionMessage(player);
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
@@ -29,7 +29,7 @@ public class SetStatusSubCommand implements SubCommand {
     @Override
     public void execute(Player player, String[] args) {
         boolean hasPermission = player.getEffectivePermissions().stream()
-            .anyMatch(effectivePermission -> effectivePermission.getPermission().contains("buildsystem.setstatus"));
+            .anyMatch(effectivePermission -> effectivePermission.getPermission().startsWith("buildsystem.setstatus"));
 
         WorldManager worldManager = plugin.getWorldManager();
         if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName) || !hasPermission) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetStatusSubCommand.java
@@ -29,7 +29,11 @@ public class SetStatusSubCommand implements SubCommand {
     @Override
     public void execute(Player player, String[] args) {
         WorldManager worldManager = plugin.getWorldManager();
-        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName)) {
+
+        boolean hasPermission = player.getEffectivePermissions().stream()
+            .anyMatch(effectivePermission -> effectivePermission.getPermission().contains("buildsystem.setstatus"));
+
+        if (!worldManager.isPermitted(player, getArgument().getPermission(), worldName) && !hasPermission) {
             plugin.sendPermissionMessage(player);
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
@@ -124,29 +124,29 @@ public class StatusInventory implements Listener {
         }
 
         WorldData worldData = buildWorld.getData();
-        switch (event.getSlot()) {
-            case 10:
-                worldData.status().set(WorldStatus.NOT_STARTED);
-                break;
-            case 11:
-                worldData.status().set(WorldStatus.IN_PROGRESS);
-                break;
-            case 12:
-                worldData.status().set(WorldStatus.ALMOST_FINISHED);
-                break;
-            case 13:
-                worldData.status().set(WorldStatus.FINISHED);
-                break;
-            case 14:
-                worldData.status().set(WorldStatus.ARCHIVE);
-                break;
-            case 16:
-                worldData.status().set(WorldStatus.HIDDEN);
-                break;
-            default:
-                XSound.BLOCK_CHEST_OPEN.play(player);
-                plugin.getEditInventory().openInventory(player, buildWorld);
+        int slot = event.getSlot();
+
+        if (slot >= 10 && slot <= 14) {
+            String permissionNode = "buildsystem.setstatus." + getStatusFromSlot(slot);
+            if (!player.hasPermission(permissionNode)) {
+                Messages.sendMessage(player, "no_permissions");
+                event.setCancelled(true);
                 return;
+            } else {
+                worldData.status().set(WorldStatus.valueOf(getStatusFromSlot(slot).toUpperCase()));
+            }
+        } else if (slot == 16) {
+            if (!player.hasPermission("buildsystem.setstatus.hidden")) {
+                Messages.sendMessage(player, "no_permissions");
+                event.setCancelled(true);
+                return;
+            } else {
+                worldData.status().set(WorldStatus.HIDDEN);
+            }
+        } else {
+            XSound.BLOCK_CHEST_OPEN.play(player);
+            plugin.getEditInventory().openInventory(player, buildWorld);
+            return;
         }
 
         playerManager.forceUpdateSidebar(buildWorld);
@@ -158,5 +158,22 @@ public class StatusInventory implements Listener {
                 new AbstractMap.SimpleEntry<>("%status%", buildWorld.getData().status().get().getName())
         );
         playerManager.getBuildPlayer(player).setCachedWorld(null);
+    }
+
+    private String getStatusFromSlot(int slot) {
+        switch (slot) {
+            case 10:
+                return "not_started";
+            case 11:
+                return "in_progress";
+            case 12:
+                return "almost_finished";
+            case 13:
+                return "finished";
+            case 14:
+                return "archive";
+            default:
+                return "hidden";
+        }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
@@ -126,22 +126,14 @@ public class StatusInventory implements Listener {
         WorldData worldData = buildWorld.getData();
         int slot = event.getSlot();
 
-        if (slot >= 10 && slot <= 14) {
-            String permissionNode = "buildsystem.setstatus." + getStatusFromSlot(slot);
-            if (!player.hasPermission(permissionNode)) {
+        if (slot >= 10 && slot <= 14 || slot == 16) {
+            WorldStatus status = getStatusFromSlot(slot);
+            if (!player.hasPermission(status.getPermission())) {
                 Messages.sendMessage(player, "no_permissions");
                 event.setCancelled(true);
                 return;
             } else {
-                worldData.status().set(WorldStatus.valueOf(getStatusFromSlot(slot).toUpperCase()));
-            }
-        } else if (slot == 16) {
-            if (!player.hasPermission("buildsystem.setstatus.hidden")) {
-                Messages.sendMessage(player, "no_permissions");
-                event.setCancelled(true);
-                return;
-            } else {
-                worldData.status().set(WorldStatus.HIDDEN);
+                worldData.status().set(status);
             }
         } else {
             XSound.BLOCK_CHEST_OPEN.play(player);
@@ -160,20 +152,22 @@ public class StatusInventory implements Listener {
         playerManager.getBuildPlayer(player).setCachedWorld(null);
     }
 
-    private String getStatusFromSlot(int slot) {
+    private WorldStatus getStatusFromSlot(int slot) {
         switch (slot) {
             case 10:
-                return "not_started";
+                return WorldStatus.NOT_STARTED;
             case 11:
-                return "in_progress";
+                return WorldStatus.IN_PROGRESS;
             case 12:
-                return "almost_finished";
+                return WorldStatus.ALMOST_FINISHED;
             case 13:
-                return "finished";
+                return WorldStatus.FINISHED;
             case 14:
-                return "archive";
+                return WorldStatus.ARCHIVE;
+            case 16:
+                return WorldStatus.HIDDEN;
             default:
-                return "hidden";
+                throw new IllegalArgumentException("Slot " + slot + " does not correspond to status");
         }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
@@ -123,9 +123,7 @@ public class StatusInventory implements Listener {
             return;
         }
 
-        WorldData worldData = buildWorld.getData();
         int slot = event.getSlot();
-
         if (slot >= 10 && slot <= 14 || slot == 16) {
             WorldStatus status = getStatusFromSlot(slot);
             if (!player.hasPermission(status.getPermission())) {
@@ -133,7 +131,7 @@ public class StatusInventory implements Listener {
                 event.setCancelled(true);
                 return;
             } else {
-                worldData.status().set(status);
+                buildWorld.getData().status().set(status);
             }
         } else {
             XSound.BLOCK_CHEST_OPEN.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
@@ -11,10 +11,12 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.BuildSystem;
 import de.eintosti.buildsystem.Messages;
+import de.eintosti.buildsystem.player.BuildPlayer;
 import de.eintosti.buildsystem.player.PlayerManager;
 import de.eintosti.buildsystem.util.InventoryUtils;
 import de.eintosti.buildsystem.world.BuildWorld;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -51,12 +53,12 @@ public class StatusInventory implements Listener {
         Inventory inventory = Bukkit.createInventory(null, 27, title);
         fillGuiWithGlass(player, inventory);
 
-        addItem(player, inventory, 10, inventoryUtils.getStatusItem(WorldStatus.NOT_STARTED), Messages.getString("status_not_started"), WorldStatus.NOT_STARTED);
-        addItem(player, inventory, 11, inventoryUtils.getStatusItem(WorldStatus.IN_PROGRESS), Messages.getString("status_in_progress"), WorldStatus.IN_PROGRESS);
-        addItem(player, inventory, 12, inventoryUtils.getStatusItem(WorldStatus.ALMOST_FINISHED), Messages.getString("status_almost_finished"), WorldStatus.ALMOST_FINISHED);
-        addItem(player, inventory, 13, inventoryUtils.getStatusItem(WorldStatus.FINISHED), Messages.getString("status_finished"), WorldStatus.FINISHED);
-        addItem(player, inventory, 14, inventoryUtils.getStatusItem(WorldStatus.ARCHIVE), Messages.getString("status_archive"), WorldStatus.ARCHIVE);
-        addItem(player, inventory, 16, inventoryUtils.getStatusItem(WorldStatus.HIDDEN), Messages.getString("status_hidden"), WorldStatus.HIDDEN);
+        addStatusItem(player, inventory, 10, WorldStatus.NOT_STARTED, Messages.getString("status_not_started"));
+        addStatusItem(player, inventory, 11, WorldStatus.IN_PROGRESS, Messages.getString("status_in_progress"));
+        addStatusItem(player, inventory, 12, WorldStatus.ALMOST_FINISHED, Messages.getString("status_almost_finished"));
+        addStatusItem(player, inventory, 13, WorldStatus.FINISHED, Messages.getString("status_finished"));
+        addStatusItem(player, inventory, 14, WorldStatus.ARCHIVE, Messages.getString("status_archive"));
+        addStatusItem(player, inventory, 16, WorldStatus.HIDDEN, Messages.getString("status_hidden"));
 
         return inventory;
     }
@@ -74,14 +76,18 @@ public class StatusInventory implements Listener {
         }
     }
 
-    private void addItem(Player player, Inventory inventory, int position, XMaterial material, String displayName, WorldStatus worldStatus) {
+    private void addStatusItem(Player player, Inventory inventory, int position, WorldStatus worldStatus, String displayName) {
+        XMaterial material = inventoryUtils.getStatusItem(worldStatus);
+
+        if (!player.hasPermission(worldStatus.getPermission())) {
+            material = XMaterial.BARRIER;
+            displayName = "§c§m" + ChatColor.stripColor(displayName);
+        }
+
         ItemStack itemStack = material.parseItem();
         ItemMeta itemMeta = itemStack.getItemMeta();
-
-        if (itemMeta != null) {
-            itemMeta.setDisplayName(displayName);
-            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-        }
+        itemMeta.setDisplayName(displayName);
+        itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemStack.setItemMeta(itemMeta);
 
         BuildWorld cachedWorld = playerManager.getBuildPlayer(player).getCachedWorld();
@@ -116,7 +122,8 @@ public class StatusInventory implements Listener {
             return;
         }
 
-        BuildWorld buildWorld = playerManager.getBuildPlayer(player).getCachedWorld();
+        BuildPlayer buildPlayer = playerManager.getBuildPlayer(player);
+        BuildWorld buildWorld = buildPlayer.getCachedWorld();
         if (buildWorld == null) {
             player.closeInventory();
             Messages.sendMessage(player, "worlds_setstatus_error");
@@ -124,32 +131,36 @@ public class StatusInventory implements Listener {
         }
 
         int slot = event.getSlot();
-        if (slot >= 10 && slot <= 14 || slot == 16) {
-            WorldStatus status = getStatusFromSlot(slot);
-            if (!player.hasPermission(status.getPermission())) {
-                Messages.sendMessage(player, "no_permissions");
-                event.setCancelled(true);
-                return;
-            } else {
-                buildWorld.getData().status().set(status);
-            }
-        } else {
+        if (slot < 10 || slot > 14 && slot != 16) {
             XSound.BLOCK_CHEST_OPEN.play(player);
             plugin.getEditInventory().openInventory(player, buildWorld);
             return;
         }
 
-        playerManager.forceUpdateSidebar(buildWorld);
+        WorldStatus status = getStatusFromSlot(slot);
+        if (!player.hasPermission(status.getPermission())) {
+            XSound.ENTITY_ITEM_BREAK.play(player);
+            return;
+        }
+
         player.closeInventory();
+        buildPlayer.setCachedWorld(null);
+        buildWorld.getData().status().set(status);
+        playerManager.forceUpdateSidebar(buildWorld);
 
         XSound.ENTITY_CHICKEN_EGG.play(player);
         Messages.sendMessage(player, "worlds_setstatus_set",
                 new AbstractMap.SimpleEntry<>("%world%", buildWorld.getName()),
-                new AbstractMap.SimpleEntry<>("%status%", buildWorld.getData().status().get().getName())
+                new AbstractMap.SimpleEntry<>("%status%", status.getName())
         );
-        playerManager.getBuildPlayer(player).setCachedWorld(null);
     }
 
+    /**
+     * Gets the {@link WorldStatus} which is represented by the item at the given slot.
+     *
+     * @param slot The slot to get the status from
+     * @return The status which is represented by the item at the given slot
+     */
     private WorldStatus getStatusFromSlot(int slot) {
         switch (slot) {
             case 10:

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/StatusInventory.java
@@ -53,12 +53,12 @@ public class StatusInventory implements Listener {
         Inventory inventory = Bukkit.createInventory(null, 27, title);
         fillGuiWithGlass(player, inventory);
 
-        addStatusItem(player, inventory, 10, WorldStatus.NOT_STARTED, Messages.getString("status_not_started"));
-        addStatusItem(player, inventory, 11, WorldStatus.IN_PROGRESS, Messages.getString("status_in_progress"));
-        addStatusItem(player, inventory, 12, WorldStatus.ALMOST_FINISHED, Messages.getString("status_almost_finished"));
-        addStatusItem(player, inventory, 13, WorldStatus.FINISHED, Messages.getString("status_finished"));
-        addStatusItem(player, inventory, 14, WorldStatus.ARCHIVE, Messages.getString("status_archive"));
-        addStatusItem(player, inventory, 16, WorldStatus.HIDDEN, Messages.getString("status_hidden"));
+        addStatusItem(player, inventory, 10, WorldStatus.NOT_STARTED);
+        addStatusItem(player, inventory, 11, WorldStatus.IN_PROGRESS);
+        addStatusItem(player, inventory, 12, WorldStatus.ALMOST_FINISHED);
+        addStatusItem(player, inventory, 13, WorldStatus.FINISHED);
+        addStatusItem(player, inventory, 14, WorldStatus.ARCHIVE);
+        addStatusItem(player, inventory, 16, WorldStatus.HIDDEN);
 
         return inventory;
     }
@@ -76,10 +76,11 @@ public class StatusInventory implements Listener {
         }
     }
 
-    private void addStatusItem(Player player, Inventory inventory, int position, WorldStatus worldStatus, String displayName) {
-        XMaterial material = inventoryUtils.getStatusItem(worldStatus);
+    private void addStatusItem(Player player, Inventory inventory, int position, WorldStatus status) {
+        XMaterial material = inventoryUtils.getStatusItem(status);
+        String displayName = status.getName();
 
-        if (!player.hasPermission(worldStatus.getPermission())) {
+        if (!player.hasPermission(status.getPermission())) {
             material = XMaterial.BARRIER;
             displayName = "§c§m" + ChatColor.stripColor(displayName);
         }
@@ -91,7 +92,7 @@ public class StatusInventory implements Listener {
         itemStack.setItemMeta(itemMeta);
 
         BuildWorld cachedWorld = playerManager.getBuildPlayer(player).getCachedWorld();
-        if (cachedWorld != null && cachedWorld.getData().status().get() == worldStatus) {
+        if (cachedWorld != null && cachedWorld.getData().status().get() == status) {
             itemStack.addUnsafeEnchantment(Enchantment.DURABILITY, 1);
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatus.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatus.java
@@ -11,6 +11,7 @@ import de.eintosti.buildsystem.Messages;
 import de.eintosti.buildsystem.world.BuildWorld;
 
 public enum WorldStatus {
+
     /**
      * Represent a world that has not been modified.
      */
@@ -52,12 +53,21 @@ public enum WorldStatus {
     }
 
     /**
-     * Get the display name of the {@link WorldStatus}.
+     * Gets the display name of the status.
      *
      * @return The type's display name
      */
     public String getName() {
         return Messages.getString(typeNameKey);
+    }
+
+    /**
+     * Gets the permission needed to change the status.
+     * 
+     * @return The permission needed to change the status
+     */
+    public String getPermission() {
+        return "buildsystem.setstatus." + name().toLowerCase().replace("_", "");
     }
 
     /**

--- a/buildsystem-core/src/main/resources/plugin.yml
+++ b/buildsystem-core/src/main/resources/plugin.yml
@@ -67,40 +67,32 @@ commands:
     usage: /<command>
 
 permissions:
-  buildsystem.setstatus:
-    children:
-      - buildsystem.setstatus.hidden
-      - buildsystem.setstatus.archive
-      - buildsystem.setstatus.finished
-      - buildsystem.setstatus.almost_finished
-      - buildsystem.setstatus.in_progress
-      - buildsystem.setstatus.not_started
-    default: op
-    description: Permission for specific status states
   buildsystem.navigator:
     description: Open the worlds navigator.
     default: true
   buildsystem.navigator.item:
     description: Receive and use the naviagtor open.
     default: true
-  buildsystem.create.private:
-    description: Create a private world.
+  buildsystem.create:
+    children:
+      - buildsystem.create.private
+      - buildsystem.create.type.normal
+      - buildsystem.create.type.flat
+      - buildsystem.create.type.nether
+      - buildsystem.create.type.end
+      - buildsystem.create.type.void
     default: true
-  buildsystem.create.type.normal:
-    description: Create a normal world.
-    default: true
-  buildsystem.create.type.flat:
-    description: Create a flat world.
-    default: true
-  buildsystem.create.type.nether:
-    description: Create a nether world.
-    default: true
-  buildsystem.create.type.end:
-    description: Create an end world.
-    default: true
-  buildsystem.create.type.void:
-    description: Create a void world.
-    default: true
+    description: Permission for creating world types 
+  buildsystem.setstatus:
+    children:
+      - buildsystem.setstatus.hidden
+      - buildsystem.setstatus.archive
+      - buildsystem.setstatus.finished
+      - buildsystem.setstatus.almostfinished
+      - buildsystem.setstatus.inprogress
+      - buildsystem.setstatus.notstarted
+    default: op
+    description: Permission for specific status states  
   buildsystem.physics.message:
     description: Receive the message that physics are disabled in a world.
     default: true

--- a/buildsystem-core/src/main/resources/plugin.yml
+++ b/buildsystem-core/src/main/resources/plugin.yml
@@ -67,6 +67,16 @@ commands:
     usage: /<command>
 
 permissions:
+  buildsystem.setstatus:
+    children:
+      - buildsystem.setstatus.hidden
+      - buildsystem.setstatus.archive
+      - buildsystem.setstatus.finished
+      - buildsystem.setstatus.almost_finished
+      - buildsystem.setstatus.in_progress
+      - buildsystem.setstatus.not_started
+    default: op
+    description: Permission for specific status states
   buildsystem.navigator:
     description: Open the worlds navigator.
     default: true


### PR DESCRIPTION
The `/world setStatus` command has been revised to ensure that each individual state in the status has a corresponding permission. 

The default permission for changing the world status remains `buildsystem.setstatus`.
However, each status now has its own permission which can be removed by using a permission plugin (such as LuckPerms):
- `buildsystem.setstatus.notstarted` 
- `buildsystem.setstatus.inprogress` 
- `buildsystem.setstatus.almostfinished` 
- `buildsystem.setstatus.finished` 
- `buildsystem.setstatus.archive` 
- `buildsystem.setstatus.hidden`

Negating a permission stops the player from changing a worlds status to that one