### PR TITLE
Added world type to the import command and fixed a few things

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystem.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystem.java
@@ -162,6 +162,8 @@ public class BuildSystem extends JavaPlugin {
 
         registerStats();
 
+        Bukkit.getScheduler().runTaskTimer(this, this::saveBuildConfig, 6000L, 6000L);
+
         Bukkit.getConsoleSender().sendMessage(String.format(Locale.ROOT, "%sBuildSystem » Plugin %senabled%s!", ChatColor.RESET, ChatColor.GREEN, ChatColor.RESET));
     }
 
@@ -181,10 +183,7 @@ public class BuildSystem extends JavaPlugin {
         reloadConfigData(false);
         saveConfig();
 
-        worldManager.save();
-        playerManager.save();
-        spawnManager.save();
-        inventoryUtils.save();
+        saveBuildConfig();
 
         unregisterExpansions();
 
@@ -385,6 +384,13 @@ public class BuildSystem extends JavaPlugin {
         if (templateFolder.mkdirs()) {
             getLogger().info("Created \"templates\" folder");
         }
+    }
+
+    private void saveBuildConfig() {
+        worldManager.save();
+        playerManager.save();
+        spawnManager.save();
+        inventoryUtils.save();
     }
 
     public void sendPermissionMessage(CommandSender sender) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystem.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystem.java
@@ -81,6 +81,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -161,7 +162,7 @@ public class BuildSystem extends JavaPlugin {
 
         registerStats();
 
-        Bukkit.getConsoleSender().sendMessage(String.format("%sBuildSystem » Plugin %senabled%s!", ChatColor.RESET, ChatColor.GREEN, ChatColor.RESET));
+        Bukkit.getConsoleSender().sendMessage(String.format(Locale.ROOT, "%sBuildSystem » Plugin %senabled%s!", ChatColor.RESET, ChatColor.GREEN, ChatColor.RESET));
     }
 
     @Override
@@ -187,7 +188,7 @@ public class BuildSystem extends JavaPlugin {
 
         unregisterExpansions();
 
-        Bukkit.getConsoleSender().sendMessage(String.format("%sBuildSystem » Plugin %sdisabled%s!", ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
+        Bukkit.getConsoleSender().sendMessage(String.format(Locale.ROOT, "%sBuildSystem » Plugin %sdisabled%s!", ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
     }
 
     private boolean initVersionedClasses() {
@@ -204,7 +205,7 @@ public class BuildSystem extends JavaPlugin {
             return false;
         }
 
-        getLogger().info(String.format("Detected server version: %s (%s)", minecraftVersion, craftBukkitVersion.name()));
+        getLogger().info(String.format(Locale.ROOT, "Detected server version: %s (%s)", minecraftVersion, craftBukkitVersion.name()));
         this.customBlocks = craftBukkitVersion.initCustomBlocks();
         this.gameRules = craftBukkitVersion.initGameRules();
         return true;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ConfigCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ConfigCommand.java
@@ -14,6 +14,8 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Locale;
+
 public class ConfigCommand implements CommandExecutor {
 
     private final BuildSystem plugin;
@@ -35,7 +37,7 @@ public class ConfigCommand implements CommandExecutor {
             return true;
         }
 
-        switch (args[0].toLowerCase()) {
+        switch (args[0].toLowerCase(Locale.ROOT)) {
             case "rl":
             case "reload":
                 plugin.reloadConfig();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.AbstractMap;
+import java.util.Locale;
 
 public class GamemodeCommand implements CommandExecutor {
 
@@ -42,7 +43,7 @@ public class GamemodeCommand implements CommandExecutor {
         }
 
         if (args.length != 0) {
-            switch (args[0].toLowerCase()) {
+            switch (args[0].toLowerCase(Locale.ROOT)) {
                 case "survival":
                 case "s":
                 case "0":

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpawnCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpawnCommand.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.AbstractMap;
+import java.util.Locale;
 
 public class SpawnCommand implements CommandExecutor {
 
@@ -59,7 +60,7 @@ public class SpawnCommand implements CommandExecutor {
                     return true;
                 }
 
-                switch (args[0].toLowerCase()) {
+                switch (args[0].toLowerCase(Locale.ROOT)) {
                     case "set":
                         Location playerLocation = player.getLocation();
                         World bukkitWorld = playerLocation.getWorld();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TimeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TimeCommand.java
@@ -20,6 +20,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.AbstractMap;
+import java.util.Locale;
 
 public class TimeCommand implements CommandExecutor {
 
@@ -46,7 +47,7 @@ public class TimeCommand implements CommandExecutor {
         String worldName = args.length == 0 ? player.getWorld().getName() : args[0];
         World world = Bukkit.getWorld(worldName);
 
-        switch (label.toLowerCase()) {
+        switch (label.toLowerCase(Locale.ROOT)) {
             case "day": {
                 if (!worldManager.isPermitted(player, "buildsystem.day", worldName)) {
                     plugin.sendPermissionMessage(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportAllSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportAllSubCommand.java
@@ -21,6 +21,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.io.File;
+import java.util.Locale;
 import java.util.UUID;
 
 public class ImportAllSubCommand implements SubCommand {
@@ -79,7 +80,7 @@ public class ImportAllSubCommand implements SubCommand {
                 return;
             }
             try {
-                generator = Generator.valueOf(generatorArg.toUpperCase());
+                generator = Generator.valueOf(generatorArg.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException ignored) {
             }
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
@@ -24,6 +24,7 @@ import org.bukkit.entity.Player;
 import java.io.File;
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.UUID;
 
 public class ImportSubCommand implements SubCommand {
@@ -88,7 +89,7 @@ public class ImportSubCommand implements SubCommand {
                     return;
                 }
                 try {
-                    generator = Generator.valueOf(generatorArg.toUpperCase());
+                    generator = Generator.valueOf(generatorArg.toUpperCase(Locale.ROOT));
                 } catch (IllegalArgumentException ignored) {
                     generator = Generator.CUSTOM;
                     generatorName = generatorArg;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/ImportSubCommand.java
@@ -17,6 +17,7 @@ import de.eintosti.buildsystem.util.UUIDFetcher;
 import de.eintosti.buildsystem.world.BuildWorld;
 import de.eintosti.buildsystem.world.Builder;
 import de.eintosti.buildsystem.world.WorldManager;
+import de.eintosti.buildsystem.world.data.WorldType;
 import de.eintosti.buildsystem.world.generator.Generator;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -78,6 +79,7 @@ public class ImportSubCommand implements SubCommand {
         Builder creator = new Builder(null, "-");
         Generator generator = Generator.VOID;
         String generatorName = null;
+        WorldType worldType = WorldType.IMPORTED;
 
         if (args.length != 2) {
             ArgumentParser parser = new ArgumentParser(args);
@@ -109,10 +111,23 @@ public class ImportSubCommand implements SubCommand {
                 }
                 creator = new Builder(creatorId, creatorArg);
             }
+
+            if (parser.isArgument("t")) {
+                String worldTypeArg = parser.getValue("t");
+                if (worldTypeArg == null) {
+                    Messages.sendMessage(player, "worlds_import_usage");
+                    return;
+                }
+                try {
+                    worldType = WorldType.valueOf(worldTypeArg.toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException ignored) {
+
+                }
+            }
         }
 
         Messages.sendMessage(player, "worlds_import_started", new AbstractMap.SimpleEntry<>("%world%", worldName));
-        if (worldManager.importWorld(player, worldName, creator, generator, generatorName, true)) {
+        if (worldManager.importWorld(player, worldName, creator, generator, generatorName, true, worldType)) {
             Messages.sendMessage(player, "worlds_import_finished");
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigValues.java
@@ -17,6 +17,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ public class ConfigValues {
         this.defaultPrivatePermission = config.getString("world.default.permission.private", "-");
         this.lockWeather = config.getBoolean("world.lock-weather", true);
         this.invalidNameCharacters = config.getString("world.invalid-characters", "^\b$");
-        this.worldDifficulty = Difficulty.valueOf(config.getString("world.default.difficulty", "PEACEFUL").toUpperCase());
+        this.worldDifficulty = Difficulty.valueOf(config.getString("world.default.difficulty", "PEACEFUL").toUpperCase(Locale.ROOT));
         this.sunriseTime = config.getInt("world.default.time.sunrise", 0);
         this.noonTime = config.getInt("world.default.time.noon", 6000);
         this.nightTime = config.getInt("world.default.time.night", 18000);
@@ -171,7 +172,7 @@ public class ConfigValues {
         }
 
         String namespace = "minecraft:";
-        if (wand.toLowerCase().startsWith(namespace)) {
+        if (wand.toLowerCase(Locale.ROOT).startsWith(namespace)) {
             wand = wand.substring(namespace.length());
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/SetupConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/SetupConfig.java
@@ -12,6 +12,8 @@ import de.eintosti.buildsystem.BuildSystem;
 import de.eintosti.buildsystem.world.data.WorldStatus;
 import de.eintosti.buildsystem.world.data.WorldType;
 
+import java.util.Locale;
+
 public class SetupConfig extends ConfigurationFile {
 
     public SetupConfig(BuildSystem plugin) {
@@ -19,17 +21,17 @@ public class SetupConfig extends ConfigurationFile {
     }
 
     public void saveCreateItem(WorldType worldType, XMaterial material) {
-        getFile().set("setup.type." + worldType.name().toLowerCase() + ".create", material.name());
+        getFile().set("setup.type." + worldType.name().toLowerCase(Locale.ROOT) + ".create", material.name());
         saveFile();
     }
 
     public void saveDefaultItem(WorldType worldType, XMaterial material) {
-        getFile().set("setup.type." + worldType.name().toLowerCase() + ".default", material.name());
+        getFile().set("setup.type." + worldType.name().toLowerCase(Locale.ROOT) + ".default", material.name());
         saveFile();
     }
 
     public void saveStatusItem(WorldStatus worldStatus, XMaterial material) {
-        getFile().set("setup.status." + worldStatus.name().toLowerCase(), material.name());
+        getFile().set("setup.status." + worldStatus.name().toLowerCase(Locale.ROOT), material.name());
         saveFile();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/expansion/luckperms/calculators/RoleCalculator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/expansion/luckperms/calculators/RoleCalculator.java
@@ -18,6 +18,8 @@ import org.bukkit.entity.Player;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Locale;
+
 public class RoleCalculator implements ContextCalculator<Player> {
 
     private static final String KEY = "buildsystem:role";
@@ -76,7 +78,7 @@ public class RoleCalculator implements ContextCalculator<Player> {
 
         @Override
         public String toString() {
-            return this.name().toLowerCase();
+            return this.name().toLowerCase(Locale.ROOT);
         }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/expansion/placeholderapi/PlaceholderApiExpansion.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/expansion/placeholderapi/PlaceholderApiExpansion.java
@@ -19,6 +19,8 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 public class PlaceholderApiExpansion extends PlaceholderExpansion {
 
     private static final String SETTINGS_KEY = "settings";
@@ -129,7 +131,7 @@ public class PlaceholderApiExpansion extends PlaceholderExpansion {
         Settings settings = settingsManager.getSettings(player);
         String settingIdentifier = identifier.split("_")[1];
 
-        switch (settingIdentifier.toLowerCase()) {
+        switch (settingIdentifier.toLowerCase(Locale.ROOT)) {
             case "navigatortype":
                 return settings.getNavigatorType().toString();
             case "glasscolor":
@@ -192,7 +194,7 @@ public class PlaceholderApiExpansion extends PlaceholderExpansion {
         }
 
         WorldData worldData = buildWorld.getData();
-        switch (identifier.toLowerCase()) {
+        switch (identifier.toLowerCase(Locale.ROOT)) {
             case "blockbreaking":
                 return String.valueOf(worldData.blockBreaking().get());
             case "blockplacement":

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class GamemodeTabComplete extends ArgumentSorter implements TabCompleter {
 
@@ -40,14 +41,14 @@ public class GamemodeTabComplete extends ArgumentSorter implements TabCompleter 
 
         if (args.length == 1) {
             for (GameMode gameMode : GameMode.values()) {
-                addArgument(args[0], gameMode.name().toLowerCase(), arrayList);
+                addArgument(args[0], gameMode.name().toLowerCase(Locale.ROOT), arrayList);
             }
         } else if (args.length == 2) {
             if (!player.hasPermission("buildsystem.gamemode.others")) {
                 return arrayList;
             }
 
-            switch (args[0].toLowerCase()) {
+            switch (args[0].toLowerCase(Locale.ROOT)) {
                 case "survival":
                 case "s":
                 case "0":

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/TimeTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/TimeTabComplete.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class TimeTabComplete extends ArgumentSorter implements TabCompleter {
 
@@ -37,7 +38,7 @@ public class TimeTabComplete extends ArgumentSorter implements TabCompleter {
         }
         Player player = (Player) sender;
 
-        switch (label.toLowerCase()) {
+        switch (label.toLowerCase(Locale.ROOT)) {
             case "day":
                 worldManager.getBuildWorlds().forEach(world -> {
                     String worldName = world.getName();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/WorldsTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/WorldsTabComplete.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -60,7 +61,7 @@ public class WorldsTabComplete extends ArgumentSorter implements TabCompleter {
             }
 
             case 2: {
-                switch (args[0].toLowerCase()) {
+                switch (args[0].toLowerCase(Locale.ROOT)) {
                     case "builders":
                     case "edit":
                     case "info":
@@ -74,7 +75,7 @@ public class WorldsTabComplete extends ArgumentSorter implements TabCompleter {
                     case "unimport":
                         worldManager.getBuildWorlds().stream()
                                 .filter(world -> player.hasPermission(world.getData().permission().get()) || world.getData().permission().get().equalsIgnoreCase("-"))
-                                .filter(world -> worldManager.isPermitted(player, "buildsystem." + args[0].toLowerCase(), world.getName()))
+                                .filter(world -> worldManager.isPermitted(player, "buildsystem." + args[0].toLowerCase(Locale.ROOT), world.getName()))
                                 .forEach(world -> addArgument(args[1], world.getName(), arrayList));
                         break;
 
@@ -82,7 +83,7 @@ public class WorldsTabComplete extends ArgumentSorter implements TabCompleter {
                     case "delete":
                     case "removebuilder":
                         worldManager.getBuildWorlds().stream()
-                                .filter(world -> worldManager.isPermitted(player, "buildsystem." + args[0].toLowerCase(), world.getName()))
+                                .filter(world -> worldManager.isPermitted(player, "buildsystem." + args[0].toLowerCase(Locale.ROOT), world.getName()))
                                 .forEach(world -> addArgument(args[1], world.getName(), arrayList));
                         break;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/WorldsTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/WorldsTabComplete.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import de.eintosti.buildsystem.BuildSystem;
 import de.eintosti.buildsystem.command.subcommand.Argument;
 import de.eintosti.buildsystem.world.WorldManager;
+import de.eintosti.buildsystem.world.data.WorldType;
 import de.eintosti.buildsystem.world.generator.Generator;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -128,6 +129,7 @@ public class WorldsTabComplete extends ArgumentSorter implements TabCompleter {
                 Map<String, List<String>> arguments = new HashMap<String, List<String>>() {{
                     put("-g", Arrays.stream(Generator.values()).filter(generator -> generator != Generator.CUSTOM).map(Enum::name).collect(Collectors.toList()));
                     put("-c", Lists.newArrayList());
+                    put("-t", Arrays.stream(WorldType.values()).map(Enum::name).collect(Collectors.toList()));
                 }};
 
                 if (args.length % 2 == 1) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/InventoryUtils.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/InventoryUtils.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -365,17 +366,17 @@ public class InventoryUtils {
 
         switch (worldDisplay.getWorldSort()) {
             default: // NAME_A_TO_Z
-                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getName().toLowerCase()));
+                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getName().toLowerCase(Locale.ROOT)));
                 break;
             case NAME_Z_TO_A:
-                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getName().toLowerCase()));
+                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getName().toLowerCase(Locale.ROOT)));
                 Collections.reverse(buildWorlds);
                 break;
             case PROJECT_A_TO_Z:
-                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getData().project().get().toLowerCase()));
+                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getData().project().get().toLowerCase(Locale.ROOT)));
                 break;
             case PROJECT_Z_TO_A:
-                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getData().project().get().toLowerCase()));
+                buildWorlds.sort(Comparator.comparing(worldA -> worldA.getData().project().get().toLowerCase(Locale.ROOT)));
                 Collections.reverse(buildWorlds);
                 break;
             case STATUS_NOT_STARTED:
@@ -761,13 +762,13 @@ public class InventoryUtils {
             String createMaterialString = configuration.getString("setup.type." + worldType + ".create");
             if (createMaterialString != null) {
                 Optional<XMaterial> xMaterial = XMaterial.matchXMaterial(createMaterialString);
-                xMaterial.ifPresent(material -> setCreateItem(WorldType.valueOf(worldType.toUpperCase()), material));
+                xMaterial.ifPresent(material -> setCreateItem(WorldType.valueOf(worldType.toUpperCase(Locale.ROOT)), material));
             }
 
             String defaultMaterialString = configuration.getString("setup.type." + worldType + ".default");
             if (defaultMaterialString != null) {
                 Optional<XMaterial> xMaterial = XMaterial.matchXMaterial(defaultMaterialString);
-                xMaterial.ifPresent(material -> setDefaultItem(WorldType.valueOf(worldType.toUpperCase()), material));
+                xMaterial.ifPresent(material -> setDefaultItem(WorldType.valueOf(worldType.toUpperCase(Locale.ROOT)), material));
             }
         }
     }
@@ -792,7 +793,7 @@ public class InventoryUtils {
             String statusString = configuration.getString("setup.status." + status);
             if (statusString != null) {
                 Optional<XMaterial> xMaterial = XMaterial.matchXMaterial(statusString);
-                xMaterial.ifPresent(material -> setStatusItem(WorldStatus.valueOf(status.toUpperCase()), material));
+                xMaterial.ifPresent(material -> setStatusItem(WorldStatus.valueOf(status.toUpperCase(Locale.ROOT)), material));
             }
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/InventoryUtils.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/InventoryUtils.java
@@ -455,7 +455,7 @@ public class InventoryUtils {
      * @param player     The player used to format the placeholders
      * @param buildWorld The world which provides the builders
      * @return The formatted list of builders which have been added to the given world
-     * @see BuildWorld#getBuildersInfo()
+     * @see BuildWorld#getBuilders()
      */
     private List<String> formatBuilders(Player player, BuildWorld buildWorld) {
         String template = Messages.getString("world_item_builders_builder_template", player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
@@ -21,6 +21,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,13 +41,13 @@ public class UUIDFetcher {
      * @return The uuid which belongs to the player
      */
     public static UUID getUUID(String name) {
-        String lowerCase = name.toLowerCase();
+        String lowerCase = name.toLowerCase(Locale.ROOT);
         if (UUID_CACHE.containsKey(lowerCase)) {
             return UUID_CACHE.get(lowerCase);
         }
 
         try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(UUID_URL, name)).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, UUID_URL, name)).openConnection();
             connection.setReadTimeout(5000);
 
             JsonObject jsonObject;
@@ -81,7 +82,7 @@ public class UUIDFetcher {
         }
 
         try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(NAME_URL, UUIDTypeAdapter.fromUUID(uuid))).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, NAME_URL, UUIDTypeAdapter.fromUUID(uuid))).openConnection();
             connection.setReadTimeout(5000);
             JsonArray nameHistory;
             try {
@@ -105,7 +106,7 @@ public class UUIDFetcher {
     }
 
     public static void cacheUser(UUID uuid, String name) {
-        UUID_CACHE.put(name.toLowerCase(), uuid);
+        UUID_CACHE.put(name.toLowerCase(Locale.ROOT), uuid);
         NAME_CACHE.put(uuid, name);
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UpdateChecker.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UpdateChecker.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -148,7 +149,7 @@ public final class UpdateChecker {
             int responseCode;
 
             try {
-                URL url = new URL(String.format(UPDATE_URL, pluginID));
+                URL url = new URL(String.format(Locale.ROOT, UPDATE_URL, pluginID));
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.addRequestProperty("User-Agent", USER_AGENT);
                 responseCode = connection.getResponseCode();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldCreator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldCreator.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.Locale;
 
 /**
  * @author Trichtern
@@ -252,7 +253,7 @@ public class BuildWorldCreator {
     @Nullable
     public World generateBukkitWorld(boolean checkVersion) {
         if (checkVersion && isHigherVersion()) {
-            plugin.getLogger().warning(String.format("\"%s\" was created in a newer version of Minecraft (%s > %s). Skipping...", worldName, parseDataVersion(), plugin.getCraftBukkitVersion().getDataVersion()));
+            plugin.getLogger().warning(String.format(Locale.ROOT, "\"%s\" was created in a newer version of Minecraft (%s > %s). Skipping...", worldName, parseDataVersion(), plugin.getCraftBukkitVersion().getDataVersion()));
             return null;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
@@ -280,9 +280,10 @@ public class WorldManager {
      * @param generator     The generator type used by the world
      * @param generatorName The name of the custom generator if generator type is {@link Generator#CUSTOM}
      * @param single        Is only one world being imported? Used for message sent to the player
+     * @param worldType     The type of the world to import
      * @return {@code true} if the world was successfully imported, otherwise {@code false}
      */
-    public boolean importWorld(Player player, String worldName, Builder creator, Generator generator, String generatorName, boolean single) {
+    public boolean importWorld(Player player, String worldName, Builder creator, Generator generator, String generatorName, boolean single, WorldType worldType) {
         ChunkGenerator chunkGenerator = null;
         if (generator == Generator.CUSTOM) {
             String[] generatorInfo = generatorName.split(":");
@@ -298,7 +299,7 @@ public class WorldManager {
         }
 
         BuildWorldCreator worldCreator = new BuildWorldCreator(plugin, worldName)
-                .setType(WorldType.IMPORTED)
+                .setType(worldType)
                 .setCreator(creator)
                 .setCustomGenerator(new CustomGenerator(generatorName, chunkGenerator))
                 .setPrivate(false)
@@ -359,7 +360,7 @@ public class WorldManager {
                     return;
                 }
 
-                if (importWorld(player, worldName, creator, generator, null, false)) {
+                if (importWorld(player, worldName, creator, generator, null, false, WorldType.IMPORTED)) {
                     Messages.sendMessage(player, "worlds_importall_world_imported", new AbstractMap.SimpleEntry<>("%world%", worldName));
                 }
             }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java
@@ -50,6 +50,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -734,7 +735,7 @@ public class WorldManager {
             String permission = configuration.getString("worlds." + worldName + ".permission");
             String project = configuration.getString("worlds." + worldName + ".project");
 
-            Difficulty difficulty = Difficulty.valueOf(configuration.getString("worlds." + worldName + ".difficulty", "PEACEFUL").toUpperCase());
+            Difficulty difficulty = Difficulty.valueOf(configuration.getString("worlds." + worldName + ".difficulty", "PEACEFUL").toUpperCase(Locale.ROOT));
             XMaterial material = parseMaterial(configuration, "worlds." + worldName + ".item", worldName);
             WorldStatus worldStatus = WorldStatus.valueOf(configuration.getString("worlds." + worldName + ".status"));
 
@@ -758,7 +759,7 @@ public class WorldManager {
         String permission = configuration.getString(path + ".permission");
         String project = configuration.getString(path + ".project");
 
-        Difficulty difficulty = Difficulty.valueOf(configuration.getString(path + ".difficulty").toUpperCase());
+        Difficulty difficulty = Difficulty.valueOf(configuration.getString(path + ".difficulty").toUpperCase(Locale.ROOT));
         XMaterial material = parseMaterial(configuration, path + ".material", worldName);
         WorldStatus worldStatus = WorldStatus.valueOf(configuration.getString(path + ".status"));
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatus.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatus.java
@@ -11,6 +11,8 @@ import de.eintosti.buildsystem.Messages;
 import de.eintosti.buildsystem.world.BuildWorld;
 import org.bukkit.entity.Player;
 
+import java.util.Locale;
+
 public enum WorldStatus {
 
     /**
@@ -69,7 +71,7 @@ public enum WorldStatus {
      * @return The permission needed to change the status
      */
     public String getPermission() {
-        return "buildsystem.setstatus." + name().toLowerCase().replace("_", "");
+        return "buildsystem.setstatus." + name().toLowerCase(Locale.ROOT).replace("_", "");
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/modification/CreateInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/modification/CreateInventory.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.ItemStack;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.AbstractMap;
+import java.util.Locale;
 
 public class CreateInventory extends PaginatedInventory implements Listener {
 
@@ -98,7 +99,7 @@ public class CreateInventory extends PaginatedInventory implements Listener {
     private void addPredefinedWorldItem(Player player, Inventory inventory, int position, WorldType worldType, String displayName) {
         XMaterial material = inventoryUtils.getCreateItem(worldType);
 
-        if (!player.hasPermission("buildsystem.create.type." + worldType.name().toLowerCase())) {
+        if (!player.hasPermission("buildsystem.create.type." + worldType.name().toLowerCase(Locale.ROOT))) {
             material = XMaterial.BARRIER;
             displayName = "§c§m" + ChatColor.stripColor(displayName);
         }
@@ -218,7 +219,7 @@ public class CreateInventory extends PaginatedInventory implements Listener {
                         break;
                 }
 
-                if (worldType == null || !player.hasPermission("buildsystem.create.type." + worldType.name().toLowerCase())) {
+                if (worldType == null || !player.hasPermission("buildsystem.create.type." + worldType.name().toLowerCase(Locale.ROOT))) {
                     XSound.ENTITY_ITEM_BREAK.play(player);
                     return;
                 }


### PR DESCRIPTION
This PR changes the following:
- Fixed some `String.toLowercase()`, `String.toUppercase()` and `String.format(...)` not having the locale set to `Locale.ROOT`. Not setting it would make Java use the current active locale, and could result in weird strings in some specific languages (like in Turkish).
- Fixed a wrong method name in Javadoc, prolly because it has been changed _(I just saw it while developing other stuff, thought could be good to fix)_.
- Made the configuration save every 5 minutes, in case the server crashes or gets killed, to not lose any world data, since it's only saved on clean shutdown atm (We've had a few similar issues in the past, the host crashed and the worlds.yml was weeks old, had to reimport all the worlds we worked on).
- Added a `-t` parameter to the `/worlds import` command to specify the world type. Useful when trying to load a world that has been previously created with a void generator, or the END world type as well.

On a side note, I think the `-g` parameter in `/worlds import` would be good to rework at some point, right now all values are basically doing nothing except when using CUSTOM generator (see [here](https://github.com/Ekalia/BuildSystem/blob/10c6d127e3440097f7ddd11c853ef4fa08a362a8/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldManager.java#L286), the `generator` argument is not used if not set to CUSTOM).

The `-t` parameter has been tested using the END one btw.

-----

- [X] Have you explained what your changes do, and why they add value to BuildSystem?
