### PR TITLE
saving the world before the chunks are getting unloaded

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
@@ -541,6 +541,8 @@ public class BuildWorld implements ConfigurationSerializable {
             return;
         }
 
+        if (save) bukkitWorld.save();
+
         for (Chunk chunk : bukkitWorld.getLoadedChunks()) {
             chunk.unload(save);
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorld.java
@@ -541,7 +541,9 @@ public class BuildWorld implements ConfigurationSerializable {
             return;
         }
 
-        if (save) bukkitWorld.save();
+        if (save) {
+            bukkitWorld.save();
+        }
 
         for (Chunk chunk : bukkitWorld.getLoadedChunks()) {
             chunk.unload(save);


### PR DESCRIPTION
-----

- Due to a bug at my server, that the worlds are not being saved if they get unloaded, we needed to fix it by this way.
- Therefore the worlds are now saved 100% properly

**Please note: we will close your Pull Request without comment if you do not check the box above and provide ALL
requested information.**
