### PR TITLE
Fix uuid fetch bug in offline server

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/PlayerJoinListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/PlayerJoinListener.java
@@ -79,7 +79,6 @@ public class PlayerJoinListener implements Listener {
     @SuppressWarnings("deprecation")
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        UUIDFetcher.cacheUser(player.getUniqueId(), player.getName());
 
         BuildPlayer buildPlayer = playerManager.createBuildPlayer(player);
         manageHidePlayer(player, buildPlayer);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
@@ -39,12 +39,6 @@ import java.util.UUID;
 @SuppressWarnings("deprecation")
 public class UUIDFetcher {
 
-    private static final String UUID_URL = "https://api.mojang.com/users/profiles/minecraft/%s";
-    private static final String NAME_URL = "https://api.mojang.com/user/profiles/%s/names";
-
-    private static final Map<String, UUID> UUID_CACHE = new HashMap<>();
-    private static final Map<UUID, String> NAME_CACHE = new HashMap<>();
-
     /**
      * Fetches the uuid which belongs to the player with the give name synchronously and returns it.
      *
@@ -52,38 +46,7 @@ public class UUIDFetcher {
      * @return The uuid which belongs to the player
      */
     public static UUID getUUID(String name) {
-        String lowerCase = name.toLowerCase(Locale.ROOT);
-        if (UUID_CACHE.containsKey(lowerCase)) {
-            return UUID_CACHE.get(lowerCase);
-        }
-
-        if (!Bukkit.getServer().getOnlineMode()) {
-            return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8));
-        }
-
-        try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, UUID_URL, name)).openConnection();
-            connection.setReadTimeout(5000);
-
-            JsonObject jsonObject;
-            try {
-                // Support older versions of JSON used by Minecraft versions <1.18
-                jsonObject = new JsonParser().parse(new BufferedReader(new InputStreamReader(connection.getInputStream())))
-                        .getAsJsonObject();
-            } catch (IllegalStateException | FileNotFoundException ignored) {
-                return null;
-            }
-
-            UUID uuid = UUIDTypeAdapter.fromString(jsonObject.get("id").getAsString());
-            UUID_CACHE.put(lowerCase, uuid);
-            NAME_CACHE.put(uuid, name);
-
-            return uuid;
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return null;
+        return Bukkit.getOfflinePlayer(name).getUniqueId();
     }
 
     /**
@@ -93,58 +56,6 @@ public class UUIDFetcher {
      * @return The name which belongs to the player
      */
     public static String getName(UUID uuid) {
-        if (NAME_CACHE.containsKey(uuid)) {
-            return NAME_CACHE.get(uuid);
-        }
-
-        try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, NAME_URL, UUIDTypeAdapter.fromUUID(uuid))).openConnection();
-            connection.setReadTimeout(5000);
-            JsonArray nameHistory;
-            try {
-                // Support older versions of JSON used by Minecraft versions <1.18
-                nameHistory = new JsonParser().parse(new BufferedReader(new InputStreamReader(connection.getInputStream())))
-                        .getAsJsonArray();
-            } catch (IllegalStateException ignored) {
-                return null;
-            }
-            JsonObject currentNameData = nameHistory.get(nameHistory.size() - 1).getAsJsonObject();
-
-            String name = currentNameData.get("name").getAsString();
-            UUID_CACHE.put(name, uuid);
-            NAME_CACHE.put(uuid, name);
-
-            return name;
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return null;
-    }
-
-    public static void cacheUser(UUID uuid, String name) {
-        UUID_CACHE.put(name.toLowerCase(Locale.ROOT), uuid);
-        NAME_CACHE.put(uuid, name);
-    }
-
-    public static final class UUIDTypeAdapter extends TypeAdapter<UUID> {
-
-        public static String fromUUID(final UUID value) {
-            return value.toString().replace("-", "");
-        }
-
-        public static UUID fromString(final String input) {
-            return UUID.fromString(input.replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
-        }
-
-        @Override
-        public void write(JsonWriter out, final UUID value) throws IOException {
-            out.value(fromUUID(value));
-        }
-
-        @Override
-        public UUID read(JsonReader in) throws IOException {
-            return fromString(in.nextString());
-        }
+        return Bukkit.getOfflinePlayer(uuid).getName();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
@@ -17,12 +17,14 @@
  */
 package de.eintosti.buildsystem.util;
 
+import com.google.common.base.Charsets;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import org.bukkit.Bukkit;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -53,6 +55,10 @@ public class UUIDFetcher {
         String lowerCase = name.toLowerCase(Locale.ROOT);
         if (UUID_CACHE.containsKey(lowerCase)) {
             return UUID_CACHE.get(lowerCase);
+        }
+
+        if (!Bukkit.getServer().getOnlineMode()) {
+            return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8));
         }
 
         try {


### PR DESCRIPTION
The change is such simple
As the commit message, the origin method can not get the correct UUID in offline minecraft server and cause a series of problem (such as can't delete builders)
So we just need a judge of if server is offline mode : )