### PR TITLE
Add individual permissions for each gamemode

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildCommand.java
@@ -64,7 +64,7 @@ public class BuildCommand implements CommandExecutor {
             }
 
             case 1: {
-                if (!player.hasPermission("buildsystem.build.others")) {
+                if (!player.hasPermission("buildsystem.build.other")) {
                     plugin.sendPermissionMessage(player);
                     return true;
                 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
@@ -46,37 +46,35 @@ public class GamemodeCommand implements CommandExecutor {
         }
 
         Player player = (Player) sender;
-        if (!player.hasPermission("buildsystem.gamemode")) {
-            plugin.sendPermissionMessage(player);
+        if (args.length == 0) {
+            sendUsageMessage(player);
             return true;
         }
 
-        if (args.length != 0) {
-            switch (args[0].toLowerCase(Locale.ROOT)) {
-                case "survival":
-                case "s":
-                case "0":
-                    setGamemode(player, args, GameMode.SURVIVAL, Messages.getString("gamemode_survival", player));
-                    break;
-                case "creative":
-                case "c":
-                case "1":
-                    setGamemode(player, args, GameMode.CREATIVE, Messages.getString("gamemode_creative", player));
-                    break;
-                case "adventure":
-                case "a":
-                case "2":
-                    setGamemode(player, args, GameMode.ADVENTURE, Messages.getString("gamemode_adventure", player));
-                    break;
-                case "spectator":
-                case "sp":
-                case "3":
-                    setGamemode(player, args, GameMode.SPECTATOR, Messages.getString("gamemode_spectator", player));
-                    break;
-                default:
-                    sendUsageMessage(player);
-                    break;
-            }
+        switch (args[0].toLowerCase(Locale.ROOT)) {
+            case "survival":
+            case "s":
+            case "0":
+                setGamemode(player, args, GameMode.SURVIVAL, Messages.getString("gamemode_survival", player));
+                break;
+            case "creative":
+            case "c":
+            case "1":
+                setGamemode(player, args, GameMode.CREATIVE, Messages.getString("gamemode_creative", player));
+                break;
+            case "adventure":
+            case "a":
+            case "2":
+                setGamemode(player, args, GameMode.ADVENTURE, Messages.getString("gamemode_adventure", player));
+                break;
+            case "spectator":
+            case "sp":
+            case "3":
+                setGamemode(player, args, GameMode.SPECTATOR, Messages.getString("gamemode_spectator", player));
+                break;
+            default:
+                sendUsageMessage(player);
+                break;
         }
 
         return true;
@@ -92,6 +90,7 @@ public class GamemodeCommand implements CommandExecutor {
                 break;
             default:
                 this.sendUsageMessage(player);
+                break;
         }
     }
 
@@ -100,7 +99,7 @@ public class GamemodeCommand implements CommandExecutor {
     }
 
     private void setPlayerGamemode(Player player, GameMode gameMode, String gameModeName) {
-        if (!player.hasPermission("buildsystem.gamemode")) {
+        if (!player.hasPermission(String.format("buildsystem.gamemode.%s", gameMode.name().toLowerCase(Locale.ROOT)))) {
             plugin.sendPermissionMessage(player);
             return;
         }
@@ -110,7 +109,7 @@ public class GamemodeCommand implements CommandExecutor {
     }
 
     private void setTargetGamemode(Player player, String[] args, GameMode gameMode, String gameModeName) {
-        if (!player.hasPermission("buildsystem.gamemode.others")) {
+        if (!player.hasPermission(String.format("buildsystem.gamemode.%s.other", gameMode.name().toLowerCase(Locale.ROOT)))) {
             plugin.sendPermissionMessage(player);
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/BuildTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/BuildTabComplete.java
@@ -47,7 +47,7 @@ public class BuildTabComplete extends ArgumentSorter implements TabCompleter {
         }
 
         if (args.length == 1) {
-            if (!player.hasPermission("buildsystem.build.others")) {
+            if (!player.hasPermission("buildsystem.build.other")) {
                 Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[0], pl.getName(), arrayList));
             }
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.tabcomplete;
 
 import de.eintosti.buildsystem.BuildSystem;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import org.bukkit.Bukkit;
@@ -38,40 +39,45 @@ public class GamemodeTabComplete extends ArgumentSorter implements TabCompleter 
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         ArrayList<String> arrayList = new ArrayList<>();
-
         if (!(sender instanceof Player)) {
             return arrayList;
         }
+
         Player player = (Player) sender;
-
-        if (!player.hasPermission("buildsystem.gamemode")) {
-            return arrayList;
-        }
-
         if (args.length == 1) {
-            for (GameMode gameMode : GameMode.values()) {
-                addArgument(args[0], gameMode.name().toLowerCase(Locale.ROOT), arrayList);
-            }
+            Arrays.stream(GameMode.values())
+                    .map(gameMode -> gameMode.name().toLowerCase(Locale.ROOT))
+                    .filter(gameModeName -> player.hasPermission(String.format("buildsystem.gamemode.%s", gameModeName)))
+                    .forEach(gameModeName -> addArgument(args[0], gameModeName, arrayList));
         } else if (args.length == 2) {
-            if (!player.hasPermission("buildsystem.gamemode.others")) {
-                return arrayList;
-            }
-
+            String gameModeName;
             switch (args[0].toLowerCase(Locale.ROOT)) {
                 case "survival":
                 case "s":
                 case "0":
+                    gameModeName = GameMode.SURVIVAL.name().toLowerCase(Locale.ROOT);
+                    break;
                 case "creative":
                 case "c":
                 case "1":
+                    gameModeName = GameMode.CREATIVE.name().toLowerCase(Locale.ROOT);
+                    break;
                 case "adventure":
                 case "a":
                 case "2":
+                    gameModeName = GameMode.ADVENTURE.name().toLowerCase(Locale.ROOT);
+                    break;
                 case "spectator":
                 case "sp":
                 case "3":
-                    Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[1], pl.getName(), arrayList));
+                    gameModeName = GameMode.SPECTATOR.name().toLowerCase(Locale.ROOT);
                     break;
+                default:
+                    return arrayList;
+            }
+
+            if (player.hasPermission(String.format("buildsystem.gamemode.%s.other", gameModeName))) {
+                Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[1], pl.getName(), arrayList));
             }
         }
 

--- a/buildsystem-core/src/main/resources/plugin.yml
+++ b/buildsystem-core/src/main/resources/plugin.yml
@@ -99,6 +99,22 @@ permissions:
       - buildsystem.setstatus.notstarted
     default: op
     description: Permission for specific status states
+  buildsystem.gamemode:
+    children:
+      - buildsystem.gamemode.survival
+      - buildsystem.gamemode.creative
+      - buildsystem.gamemode.adventure
+      - buildsystem.gamemode.spectator
+    default: op
+    description: Permission for changing own gamemode
+  buildsystem.gamemode.other:
+    children:
+      - buildsystem.gamemode.survival.other
+      - buildsystem.gamemode.creative.other
+      - buildsystem.gamemode.adventure.other
+      - buildsystem.gamemode.spectator.other
+    default: op
+    description: Permission for changing other player's gamemode
   buildsystem.physics.message:
     description: Receive the message that physics are disabled in a world.
     default: true


### PR DESCRIPTION
The permission for `/gamemode` has been split up more precisely

- `buildsystem.gamemode` works as before
- Added individual permissions for each gamemode: `buildsystem.gamemode.<gamemode>` (e.g. `buildsystem.gamemode.creative`)
- `buildsystem.gamemode.others` has been renamed to `buildsystem.gamemode.other` for parity with other permissions
- Also added individual permissions for each gamemode when using the command on other players: `buildsystem.gamemode.<gamemode>.other` (e.g. `buildsystem.gamemode.creative.other`

Closes #327 