### PR TITLE
Fix template worlds not keeping world generator settings

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
@@ -59,6 +59,7 @@ public interface WorldService {
      *
      * @param buildWorld The world to unimport
      * @param save       Whether to save the world before unloading
+     * @return A future that completes when the unimport operation is finished
      */
     CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, boolean save);
 
@@ -66,6 +67,7 @@ public interface WorldService {
      * Delete an existing {@link BuildWorld}. In comparison to {@link #unimportWorld(BuildWorld, boolean)}, deleting a world deletes the world's directory.
      *
      * @param buildWorld The world to be deleted
+     * @return A future that completes when the delete operation is finished
      */
     CompletableFuture<Void> deleteWorld(BuildWorld buildWorld);
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/generator/CustomGenerator.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/generator/CustomGenerator.java
@@ -30,11 +30,18 @@ import org.jspecify.annotations.NullMarked;
 public interface CustomGenerator {
 
     /**
+     * Gets the name plugin providing the chunk generator.
+     *
+     * @return The name of the plugin
+     */
+    String pluginName();
+
+    /**
      * Gets the name of the chunk generator.
      *
-     * @return The name
+     * @return The name of the chunk generator
      */
-    String name();
+    String chunkGeneratorName();
 
     /**
      * Gets the chunk generator.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -97,7 +97,6 @@ import de.eintosti.buildsystem.world.backup.BackupService;
 import de.eintosti.buildsystem.world.display.CustomizableIcons;
 import java.io.File;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import org.bstats.bukkit.Metrics;
@@ -169,10 +168,9 @@ public class BuildSystemPlugin extends JavaPlugin {
 
         Bukkit.getScheduler().runTaskTimer(this, this::saveBuildConfig, 6000L, 6000L);
 
-        Bukkit.getConsoleSender().sendMessage(String.format(Locale.ROOT,
-                "%sBuildSystem » Plugin %senabled%s!",
-                ChatColor.RESET, ChatColor.GREEN, ChatColor.RESET
-        ));
+        Bukkit.getConsoleSender().sendMessage(
+                "%sBuildSystem » Plugin %senabled%s!".formatted(ChatColor.RESET, ChatColor.GREEN, ChatColor.RESET)
+        );
     }
 
     @Override
@@ -196,10 +194,9 @@ public class BuildSystemPlugin extends JavaPlugin {
         unregisterExpansions();
         this.api.unregister();
 
-        Bukkit.getConsoleSender().sendMessage(String.format(Locale.ROOT,
-                "%sBuildSystem » Plugin %sdisabled%s!",
-                ChatColor.RESET, ChatColor.RED, ChatColor.RESET
-        ));
+        Bukkit.getConsoleSender().sendMessage(
+                "%sBuildSystem » Plugin %sdisabled%s!".formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET)
+        );
     }
 
     private void initClasses() {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
@@ -93,7 +93,7 @@ public class GamemodeCommand implements CommandExecutor {
     }
 
     private void setPlayerGamemode(Player player, GameMode gameMode, String gameModeName) {
-        if (!player.hasPermission(String.format("buildsystem.gamemode.%s", gameMode.name().toLowerCase(Locale.ROOT)))) {
+        if (!player.hasPermission("buildsystem.gamemode.%s".formatted(gameMode.name().toLowerCase(Locale.ROOT)))) {
             Messages.sendPermissionError(player);
             return;
         }
@@ -103,7 +103,7 @@ public class GamemodeCommand implements CommandExecutor {
     }
 
     private void setTargetGamemode(Player player, String[] args, GameMode gameMode, String gameModeName) {
-        if (!player.hasPermission(String.format("buildsystem.gamemode.%s.other", gameMode.name().toLowerCase(Locale.ROOT)))) {
+        if (!player.hasPermission("buildsystem.gamemode.%s.other".formatted(gameMode.name().toLowerCase(Locale.ROOT)))) {
             Messages.sendPermissionError(player);
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetSpawnSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetSpawnSubCommand.java
@@ -52,7 +52,7 @@ public class SetSpawnSubCommand implements SubCommand {
         }
 
         Location playerLocation = player.getLocation();
-        buildWorld.getData().customSpawn().set(String.format("%s;%s;%s;%s;%s",
+        buildWorld.getData().customSpawn().set("%s;%s;%s;%s;%s".formatted(
                 playerLocation.getX(), playerLocation.getY(), playerLocation.getZ(), playerLocation.getYaw(), playerLocation.getPitch()
         ));
         Messages.sendMessage(player, "worlds_setspawn_world_spawn_set",

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
@@ -107,7 +107,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
         world.put("date", buildWorld.getCreation());
         world.put("builders", serializeBuilders(builders.getAllBuilders()));
         if (buildWorld.getCustomGenerator() != null) {
-            world.put("chunk-generator", buildWorld.getCustomGenerator().name());
+            world.put("chunk-generator", buildWorld.getCustomGenerator().toString());
         }
 
         return world;
@@ -170,7 +170,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
         List<Builder> builders = parseBuilders(worldName);
         String generatorName = config.getString("worlds." + worldName + ".chunk-generator");
         CustomGeneratorImpl customGenerator = generatorName != null
-                ? new CustomGeneratorImpl(generatorName, parseChunkGenerator(worldName, generatorName))
+                ? CustomGeneratorImpl.of(generatorName, worldName)
                 : null;
 
         return new BuildWorldImpl(
@@ -282,19 +282,6 @@ public class YamlWorldStorage extends WorldStorageImpl {
         }
 
         return builders;
-    }
-
-    /**
-     * @author Ein_Jojo, einTosti
-     */
-    @Nullable
-    private ChunkGenerator parseChunkGenerator(String worldName, String generatorName) {
-        String[] generatorInfo = generatorName.split(":");
-        if (generatorInfo.length == 1) {
-            generatorInfo = new String[]{generatorInfo[0], generatorInfo[0]};
-        }
-
-        return getChunkGenerator(generatorInfo[0], generatorInfo[1], worldName);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/tabcomplete/GamemodeTabComplete.java
@@ -47,7 +47,7 @@ public class GamemodeTabComplete extends ArgumentSorter implements TabCompleter 
         if (args.length == 1) {
             Arrays.stream(GameMode.values())
                     .map(gameMode -> gameMode.name().toLowerCase(Locale.ROOT))
-                    .filter(gameModeName -> player.hasPermission(String.format("buildsystem.gamemode.%s", gameModeName)))
+                    .filter(gameModeName -> player.hasPermission("buildsystem.gamemode.%s".formatted(gameModeName)))
                     .forEach(gameModeName -> addArgument(args[0], gameModeName, arrayList));
         } else if (args.length == 2) {
             String gameModeName = switch (args[0].toLowerCase(Locale.ROOT)) {
@@ -58,7 +58,7 @@ public class GamemodeTabComplete extends ArgumentSorter implements TabCompleter 
                 default -> null;
             };
 
-            if (gameModeName != null && player.hasPermission(String.format("buildsystem.gamemode.%s.other", gameModeName))) {
+            if (gameModeName != null && player.hasPermission("buildsystem.gamemode.%s.other".formatted(gameModeName))) {
                 Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[1], pl.getName(), arrayList));
             }
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UUIDFetcher.java
@@ -68,7 +68,7 @@ public class UUIDFetcher {
         }
 
         try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, UUID_URL, name)).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(UUID_URL.formatted(name)).openConnection();
             connection.setReadTimeout(5000);
 
             JsonObject jsonObject;
@@ -110,7 +110,7 @@ public class UUIDFetcher {
         }
 
         try {
-            HttpURLConnection connection = (HttpURLConnection) new URL(String.format(Locale.ROOT, NAME_URL, UUIDTypeAdapter.fromUUID(uuid))).openConnection();
+            HttpURLConnection connection = (HttpURLConnection) new URL(NAME_URL.formatted(UUIDTypeAdapter.fromUUID(uuid))).openConnection();
             connection.setReadTimeout(5000);
 
             JsonArray nameHistory;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UpdateChecker.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/UpdateChecker.java
@@ -26,7 +26,6 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -153,7 +152,7 @@ public final class UpdateChecker {
             int responseCode;
 
             try {
-                URL url = URI.create(String.format(Locale.ROOT, UPDATE_URL, pluginID)).toURL();
+                URL url = URI.create(UPDATE_URL.formatted(pluginID)).toURL();
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.addRequestProperty("User-Agent", USER_AGENT);
                 responseCode = connection.getResponseCode();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/LocalBackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/LocalBackupStorage.java
@@ -90,7 +90,7 @@ public class LocalBackupStorage implements BackupStorage {
                 throw new RuntimeException("Failed to complete the backup for " + buildWorld.getName());
             }
 
-            plugin.getLogger().info(String.format("Backed up world '%s'. Took %sms", buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
+            plugin.getLogger().info("Backed up world '%s'. Took %sms".formatted(buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
             return new BackupImpl(
                     plugin.getBackupService().getProfile(buildWorld),
                     timestamp,

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
@@ -136,7 +136,7 @@ public class S3BackupStorage implements BackupStorage {
                                 .build(),
                         RequestBody.fromBytes(zipBytes)
                 );
-                plugin.getLogger().info(String.format("Backed up world '%s'. Took %sms", buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
+                plugin.getLogger().info("Backed up world '%s'. Took %sms".formatted(buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
                 return new BackupImpl(plugin.getBackupService().getProfile(buildWorld), timestamp, key);
             } catch (S3Exception | SdkClientException e) {
                 throw new RuntimeException("Failed to upload backup for " + buildWorld.getName(), e);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/SftpBackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/SftpBackupStorage.java
@@ -221,7 +221,7 @@ public class SftpBackupStorage implements BackupStorage {
                     bufferedOut.flush();
                 }
 
-                plugin.getLogger().info(String.format("Backed up world '%s'. Took %sms", buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
+                plugin.getLogger().info("Backed up world '%s'. Took %sms".formatted(buildWorld.getName(), (System.currentTimeMillis() - timestamp)));
                 return new BackupImpl(plugin.getBackupService().getProfile(buildWorld), timestamp, remotePath);
             } catch (IOException e) {
                 disconnectAll();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/CreateInventory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/CreateInventory.java
@@ -183,8 +183,8 @@ public class CreateInventory extends PaginatedInventory {
                 InventoryUtils.addGlassPane(player, inventory, 33);
                 break;
             case TEMPLATES:
-                inventory.setItem(38, InventoryUtils.createSkull(Messages.getString("gui_previous_page", player), Profileable.detect("f7aacad193e2226971ed95302dba433438be4644fbab5ebf818054061667fbe2")));
-                inventory.setItem(42, InventoryUtils.createSkull(Messages.getString("gui_next_page", player), Profileable.detect("d34ef0638537222b20f480694dadc0f85fbe0759d581aa7fcdf2e43139377158")));
+                inventory.setItem(28, InventoryUtils.createSkull(Messages.getString("gui_previous_page", player), Profileable.detect("f7aacad193e2226971ed95302dba433438be4644fbab5ebf818054061667fbe2")));
+                inventory.setItem(34, InventoryUtils.createSkull(Messages.getString("gui_next_page", player), Profileable.detect("d34ef0638537222b20f480694dadc0f85fbe0759d581aa7fcdf2e43139377158")));
                 break;
         }
     }
@@ -247,9 +247,9 @@ public class CreateInventory extends PaginatedInventory {
                         this.worldService.startWorldNameInput(player, BuildWorldType.TEMPLATE, itemStack.getItemMeta().getDisplayName(), this.createPrivateWorld, this.folder);
                         break;
                     case PLAYER_HEAD:
-                        if (slot == 38 && !decrementInv(player, numTemplates, MAX_TEMPLATES)) {
+                        if (slot == 28 && !decrementInv(player, numTemplates, MAX_TEMPLATES)) {
                             return;
-                        } else if (slot == 42 && !incrementInv(player, numTemplates, MAX_TEMPLATES)) {
+                        } else if (slot == 34 && !incrementInv(player, numTemplates, MAX_TEMPLATES)) {
                             return;
                         }
                         openInventory(player, CreateInventory.Page.TEMPLATES);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/generator/CustomGeneratorImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/generator/CustomGeneratorImpl.java
@@ -18,11 +18,61 @@
 package de.eintosti.buildsystem.world.creation.generator;
 
 import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
+import org.bukkit.Bukkit;
 import org.bukkit.generator.ChunkGenerator;
+import org.bukkit.plugin.Plugin;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Represents a custom chunk generator identified by its plugin name and generator name. This record provides immutable storage for these identifiers and an optional reference to
+ * the actual {@link ChunkGenerator} instance if it could be loaded.
+ * <p>
+ * The {@code pluginName} typically refers to the name of the plugin that provides the custom chunk generator. The {@code chunkGeneratorName} is the specific name or ID of the
+ * generator within that plugin.
+ *
+ * @param pluginName         The name of the plugin providing the chunk generator (e.g., "MyPlugin")
+ * @param chunkGeneratorName The specific name of the chunk generator within the plugin (e.g., "MyGenerator" or an empty string for default)
+ * @param chunkGenerator     An optional reference to the actual Bukkit {@link ChunkGenerator} instance, or {@code null} if it could not be retrieved or is not needed
+ */
 @NullMarked
-public record CustomGeneratorImpl(String name, @Nullable ChunkGenerator chunkGenerator) implements CustomGenerator {
+public record CustomGeneratorImpl(String pluginName, String chunkGeneratorName, @Nullable ChunkGenerator chunkGenerator) implements CustomGenerator {
 
+    /**
+     * Attempts to create a {@link CustomGeneratorImpl} instance by parsing an identifier string and loading the corresponding {@link ChunkGenerator}.
+     * <p>
+     * The {@code identifier} string is expected to be in one of two formats:
+     * <ul>
+     * <li>{@code "pluginName:chunkGeneratorName"} (e.g., "MyPlugin:MyGenerator")</li>
+     * <li>{@code "pluginName"} (e.g., "MyPlugin") - In this case, {@code chunkGeneratorName} is inferred to be the same as {@code pluginName}, which is a common convention for single-plugin generators.</li>
+     * </ul>
+     * The method attempts to find the specified plugin and then retrieve its default world generator.
+     *
+     * @param identifier The string identifier of the custom generator (e.g., "MyPlugin:MyGenerator" or "MyPlugin")
+     * @param worldName  The name of the world for which the generator is being loaded
+     * @return A {@link CustomGeneratorImpl} instance if the plugin is found and the generator information is parsed; {@code null} if the plugin specified in the identifier does
+     * not exist or if the identifier format is unexpectedly empty
+     */
+    @Nullable
+    public static CustomGeneratorImpl of(String identifier, String worldName) {
+        String[] generatorInfo = identifier.split(":");
+        if (generatorInfo.length == 1) {
+            generatorInfo = new String[]{generatorInfo[0], generatorInfo[0]};
+        }
+
+        String pluginName = generatorInfo[0];
+        String chunkGeneratorName = generatorInfo[1];
+
+        Plugin plugin = Bukkit.getPluginManager().getPlugin(pluginName);
+        if (plugin == null) {
+            return null;
+        }
+
+        return new CustomGeneratorImpl(pluginName, chunkGeneratorName, plugin.getDefaultWorldGenerator(worldName, chunkGeneratorName));
+    }
+
+    @Override
+    public String toString() {
+        return "%s:%s".formatted(pluginName(), chunkGeneratorName());
+    }
 }


### PR DESCRIPTION
To achieve this, a new file (`.buildsystem-generator-date.txt`) is stored in the world's directory. 
The content of this file can be one of two values:
- The predefined generator (`NORMAL`, `FLAT`, `VOID`, etc.)
- The custom generator used to create the world

This file is then used for custom worlds to determine which chunk generator is to be used for generation

Fixes #244 