### PR TITLE
Add config option for disabled world physics

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Folder.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Folder.java
@@ -90,6 +90,14 @@ public interface Folder extends Displayable {
     boolean containsWorld(BuildWorld buildWorld);
 
     /**
+     * Checks if this folder contains the {@link BuildWorld} with the specified UUID.
+     *
+     * @param uuid The unique identifier of the {@link BuildWorld} to check for
+     * @return {@code true} if the folder contains the world, {@code false} otherwise
+     */
+    boolean containsWorld(UUID uuid);
+
+    /**
      * Adds a {@link BuildWorld} to this folder.
      *
      * @param buildWorld The {@link BuildWorld} to add
@@ -102,6 +110,13 @@ public interface Folder extends Displayable {
      * @param buildWorld The {@link BuildWorld} to remove
      */
     void removeWorld(BuildWorld buildWorld);
+
+    /**
+     * Removes a {@link BuildWorld} with the specified UUID from this folder.
+     *
+     * @param uuid The unique identifier of the {@link BuildWorld} to remove
+     */
+    void removeWorld(UUID uuid);
 
     /**
      * Returns an unmodifiable list of all immediate subfolders contained within this folder.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -114,6 +114,8 @@ public class BuildSystemPlugin extends JavaPlugin {
     public static final int METRICS_ID = 7427;
     public static final String ADMIN_PERMISSION = "buildsystem.admin";
 
+    private static BuildSystemPlugin instance;
+
     private ArmorStandManager armorStandManager;
     private CustomBlockManager customBlockManager;
     private InventoryManager inventoryManager;
@@ -132,6 +134,8 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     @Override
     public void onLoad() {
+        instance = this;
+
         new ConfigMigrationManager(this).migrate();
         this.getConfig().options().copyDefaults(true);
         this.saveConfig();
@@ -196,6 +200,15 @@ public class BuildSystemPlugin extends JavaPlugin {
         Bukkit.getConsoleSender().sendMessage(
                 "%sBuildSystem » Plugin %sdisabled%s!".formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET)
         );
+
+        instance = null;
+    }
+
+    public static BuildSystemPlugin get() {
+        if (instance == null) {
+            throw new IllegalStateException("BuildSystemPlugin instance is not initialized. Make sure the plugin is enabled.");
+        }
+        return instance;
     }
 
     private void initClasses() {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/Messages.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/Messages.java
@@ -43,7 +43,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -51,7 +50,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class Messages {
 
-    private static final BuildSystemPlugin PLUGIN = JavaPlugin.getPlugin(BuildSystemPlugin.class);
+    private static final BuildSystemPlugin PLUGIN = BuildSystemPlugin.get();
     private static final Map<String, String> MESSAGES = new HashMap<>();
     private static final boolean PLACEHOLDER_API_ENABLED = Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
@@ -54,7 +54,7 @@ public class ExplosionsCommand implements CommandExecutor {
 
         String worldName = args.length == 0 ? player.getWorld().getName() : args[0];
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.explosions")) {
+        if (!WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.explosions")) {
             Messages.sendPermissionError(player);
             return true;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
@@ -54,7 +54,7 @@ public class NoAICommand implements CommandExecutor {
 
         String worldName = args.length == 0 ? player.getWorld().getName() : args[0];
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.noai")) {
+        if (!WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.noai")) {
             Messages.sendPermissionError(player);
             return true;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
@@ -54,7 +54,7 @@ public class PhysicsCommand implements CommandExecutor {
 
         String worldName = args.length == 0 ? player.getWorld().getName() : args[0];
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.physics")) {
+        if (!WorldPermissionsImpl.of(buildWorld).canPerformCommand(player, "buildsystem.physics")) {
             Messages.sendPermissionError(player);
             return true;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/Config.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/Config.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.backup.BackupStorage;
 import de.eintosti.buildsystem.config.Config.Settings.Archive;
 import de.eintosti.buildsystem.config.Config.Settings.BuildMode;
 import de.eintosti.buildsystem.config.Config.Settings.Builder;
+import de.eintosti.buildsystem.config.Config.Settings.DisabledPhysics;
 import de.eintosti.buildsystem.config.Config.Settings.Navigator;
 import de.eintosti.buildsystem.config.Config.Settings.SaveFromDeath;
 import de.eintosti.buildsystem.config.Config.World.Backup;
@@ -53,11 +54,9 @@ import org.bukkit.GameRule;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.LoggerFactory;
 
 /**
  * Manages the plugin's configuration, loading and providing access to various settings.
@@ -65,9 +64,8 @@ import org.slf4j.LoggerFactory;
 @NullMarked
 public class Config {
 
-    private static final BuildSystemPlugin PLUGIN = JavaPlugin.getPlugin(BuildSystemPlugin.class);
+    private static final BuildSystemPlugin PLUGIN = BuildSystemPlugin.get();
     private static final FileConfiguration CONFIG = PLUGIN.getConfig();
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(Config.class);
 
     /**
      * Gets the plugin's configuration.
@@ -149,6 +147,25 @@ public class Config {
              * The gamemode players are set to when entering an archived world.
              */
             public static GameMode worldGameMode = GameMode.ADVENTURE;
+        }
+
+        /**
+         * Stores settings related to worlds with disabled physics.
+         */
+        public static class DisabledPhysics {
+
+            /**
+             * Whether connections should be prevented in worlds with disabled physics.
+             */
+            public static boolean preventConnections = true;
+            /**
+             * Whether fluid flow should be prevented in worlds with disabled physics.
+             */
+            public static boolean preventFluidFlow = true;
+            /**
+             * Whether falling blocks should be prevented in worlds with disabled physics.
+             */
+            public static boolean preventFallingBlocks = true;
         }
 
         /**
@@ -437,6 +454,10 @@ public class Config {
         Archive.vanish = CONFIG.getBoolean("settings.archive.vanish", true);
         Archive.changeGamemode = CONFIG.getBoolean("settings.archive.change-gamemode", true);
         Archive.worldGameMode = parseGameMode(CONFIG.getString("settings.archive.world-gamemode"));
+        // Settings - Disabled physics
+        DisabledPhysics.preventConnections = CONFIG.getBoolean("settings.disabled-physics.prevent-connections", true);
+        DisabledPhysics.preventFluidFlow = CONFIG.getBoolean("settings.disabled-physics.prevent-fluid-flow", true);
+        DisabledPhysics.preventFallingBlocks = CONFIG.getBoolean("settings.disabled-physics.prevent-falling-blocks", true);
         // Settings - Save from death
         SaveFromDeath.enabled = CONFIG.getBoolean("settings.save-from-death.enabled", true);
         SaveFromDeath.teleportToMapSpawn = CONFIG.getBoolean("settings.save-from-death.teleport-to-map-spawn", true);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlock.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlock.java
@@ -24,7 +24,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -59,7 +58,7 @@ public enum CustomBlock {
     SMOOTH_STONE("blocks_smooth_stone", "8dd0cd158c2bb6618650e3954b2d29237f5b4c0ddc7d258e17380ab6979f071"),
     DEBUG_STICK("blocks_debug_stick", "badc048a7ce78f7dad72a07da27d85c0916881e5522eeed1e3daf217a38c1a");
 
-    public static final NamespacedKey CUSTOM_BLOCK_KEY = new NamespacedKey(JavaPlugin.getPlugin(BuildSystemPlugin.class), "custom-block");
+    public static final NamespacedKey CUSTOM_BLOCK_KEY = new NamespacedKey(BuildSystemPlugin.get(), "custom-block");
 
     private final String messageKey;
     private final String skullUrl;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
@@ -198,17 +198,21 @@ public abstract class WorldStorageImpl implements WorldStorage {
      * Must be called after all folders and worlds have been loaded.
      */
     private void assignWorldsToFolders() {
-        worldService.getFolderStorage().getFolders().forEach(folder ->
-                folder.getWorldUUIDs().stream()
-                        .map(worldUUID -> {
-                            BuildWorld buildWorld = getBuildWorld(worldUUID);
-                            if (buildWorld == null) {
-                                logger.warning("World with UUID " + worldUUID + " does not exist.");
-                            }
-                            return buildWorld;
-                        })
-                        .filter(Objects::nonNull)
-                        .forEach(buildWorld -> buildWorld.setFolder(folder))
+        worldService.getFolderStorage().getFolders().forEach(folder -> {
+                    List<UUID> invalidWorlds = new ArrayList<>();
+                    folder.getWorldUUIDs().stream()
+                            .map(worldUUID -> {
+                                BuildWorld buildWorld = getBuildWorld(worldUUID);
+                                if (buildWorld == null) {
+                                    invalidWorlds.add(worldUUID);
+                                    logger.warning("World with UUID " + worldUUID + " does not exist. Removing from folder: " + folder.getName());
+                                }
+                                return buildWorld;
+                            })
+                            .filter(Objects::nonNull)
+                            .forEach(buildWorld -> buildWorld.setFolder(folder));
+                    invalidWorlds.forEach(folder::removeWorld);
+                }
         );
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/FileUtils.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/FileUtils.java
@@ -40,14 +40,13 @@ import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.model.ExcludeFileFilter;
 import net.lingala.zip4j.model.ZipParameters;
 import org.bukkit.Bukkit;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class FileUtils {
 
-    private static final Logger LOGGER = JavaPlugin.getPlugin(BuildSystemPlugin.class).getLogger();
+    private static final Logger LOGGER = BuildSystemPlugin.get().getLogger();
     private static final Set<String> IGNORE_FILES = Sets.newHashSet("uid.dat", "session.lock");
 
     private FileUtils() {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -48,14 +48,11 @@ import org.bukkit.Difficulty;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class BuildWorldImpl implements BuildWorld {
-
-    private static final BuildSystemPlugin PLUGIN = JavaPlugin.getPlugin(BuildSystemPlugin.class);
 
     private final UUID uuid;
     private String name;
@@ -89,7 +86,7 @@ public final class BuildWorldImpl implements BuildWorld {
                 new WorldDataImpl(
                         name,
                         privateWorld,
-                        privateWorld ? XMaterial.PLAYER_HEAD : PLUGIN.getCustomizableIcons().getIcon(worldType)
+                        privateWorld ? XMaterial.PLAYER_HEAD : BuildSystemPlugin.get().getCustomizableIcons().getIcon(worldType)
                 ),
                 creator,
                 new ArrayList<>(),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -36,7 +36,6 @@ import java.util.function.Function;
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.Location;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -360,7 +359,7 @@ public class WorldDataImpl implements WorldData {
                 return super.get();
             }
 
-            WorldService worldService = JavaPlugin.getPlugin(BuildSystemPlugin.class).getWorldService();
+            WorldService worldService = BuildSystemPlugin.get().getWorldService();
             BuildWorld buildWorld = worldService.getWorldStorage().getBuildWorld(this.worldName);
             if (buildWorld != null) {
                 Folder assignedFolder = buildWorld.getFolder();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/FolderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/FolderImpl.java
@@ -18,6 +18,7 @@
 package de.eintosti.buildsystem.world.display;
 
 import com.cryptomorin.xseries.XMaterial;
+import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.Messages;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
@@ -164,7 +165,12 @@ public class FolderImpl implements Folder {
 
     @Override
     public boolean containsWorld(BuildWorld buildWorld) {
-        return this.worlds.contains(buildWorld.getUniqueId());
+        return containsWorld(buildWorld.getUniqueId());
+    }
+
+    @Override
+    public boolean containsWorld(UUID uuid) {
+        return this.worlds.contains(uuid);
     }
 
     @Override
@@ -178,11 +184,20 @@ public class FolderImpl implements Folder {
 
     @Override
     public void removeWorld(BuildWorld buildWorld) {
-        if (!containsWorld(buildWorld)) {
+        removeWorld(buildWorld.getUniqueId());
+    }
+
+    @Override
+    public void removeWorld(UUID uuid) {
+        if (!containsWorld(uuid)) {
             return;
         }
-        this.worlds.remove(buildWorld.getUniqueId());
-        buildWorld.setFolder(null);
+
+        this.worlds.remove(uuid);
+        BuildWorld buildWorld = BuildSystemPlugin.get().getWorldService().getWorldStorage().getBuildWorld(uuid);
+        if (buildWorld != null) {
+            buildWorld.setFolder(null);
+        }
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldLoaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldLoaderImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
@@ -39,7 +38,7 @@ public class WorldLoaderImpl implements WorldLoader {
     private final BuildWorld buildWorld;
 
     private WorldLoaderImpl(BuildWorld buildWorld) {
-        this.plugin = JavaPlugin.getPlugin(BuildSystemPlugin.class);
+        this.plugin = BuildSystemPlugin.get();
         this.buildWorld = buildWorld;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldPermissionsImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldPermissionsImpl.java
@@ -25,7 +25,6 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.util.WorldPermissions;
 import java.util.function.Supplier;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -145,7 +144,6 @@ public class WorldPermissionsImpl implements WorldPermissions {
 
     @Override
     public boolean canBypassBuildRestriction(Player player) {
-        BuildSystemPlugin plugin = JavaPlugin.getPlugin(BuildSystemPlugin.class);
-        return plugin.getPlayerService().isInBuildMode(player);
+        return BuildSystemPlugin.get().getPlayerService().isInBuildMode(player);
     }
 } 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldTeleporterImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldTeleporterImpl.java
@@ -31,7 +31,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
@@ -42,7 +41,7 @@ public class WorldTeleporterImpl implements WorldTeleporter {
     private final BuildWorld buildWorld;
 
     private WorldTeleporterImpl(BuildWorld buildWorld) {
-        this.plugin = JavaPlugin.getPlugin(BuildSystemPlugin.class);
+        this.plugin = BuildSystemPlugin.get();
         this.buildWorld = buildWorld;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldUnloaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/util/WorldUnloaderImpl.java
@@ -23,12 +23,12 @@ import de.eintosti.buildsystem.api.event.world.BuildWorldUnloadEvent;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.util.WorldUnloader;
 import de.eintosti.buildsystem.config.Config.World.Unload;
-import de.eintosti.buildsystem.world.SpawnManager;
 import java.util.Arrays;
+import java.util.Objects;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -45,7 +45,7 @@ public class WorldUnloaderImpl implements WorldUnloader {
     private BukkitTask unloadTask;
 
     private WorldUnloaderImpl(BuildWorld buildWorld) {
-        this.plugin = JavaPlugin.getPlugin(BuildSystemPlugin.class);
+        this.plugin = BuildSystemPlugin.get();
         this.buildWorld = buildWorld;
 
         this.secondsUntilUnload = calculateSecondsUntilUnload(Unload.timeUntilUnload);
@@ -146,11 +146,10 @@ public class WorldUnloaderImpl implements WorldUnloader {
     }
 
     private boolean isSpawnWorld(World bukkitWorld) {
-        SpawnManager spawnManager = plugin.getSpawnManager();
-        if (!spawnManager.spawnExists()) {
+        Location spawn = plugin.getSpawnManager().getSpawn();
+        if (spawn == null) {
             return false;
         }
-
-        return spawnManager.getSpawn().getWorld().equals(bukkitWorld);
+        return Objects.equals(spawn.getWorld(), bukkitWorld);
     }
 } 

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -10,6 +10,10 @@ settings:
     change-gamemode: true
     # Options: "SURVIVAL", "CREATIVE", "ADVENTURE", "SPECTATOR"
     world-gamemode: "ADVENTURE"
+  disabled-physics:
+    prevent-connections: true
+    prevent-fluid-flow: true
+    prevent-falling-blocks: true
   save-from-death:
     enabled: true
     teleport-to-map-spawn: true
@@ -65,6 +69,10 @@ world:
     - world
     - world_nether
     - worth_the_end
+  disabled-physics:
+    prevent-connections: true
+    prevent-fluid-flow: true
+    prevent-falling-blocks: true
   backup:
     max-backups-per-world: 5 # Maximum: 18
     auto-backup:


### PR DESCRIPTION
Introduces new config options, allowing server owners to fine tune what aspects are blocked when world physics are disabled.
 
```yaml
disabled-physics:
  prevent-connections: true
  prevent-fluid-flow: true
  prevent-falling-blocks: true
```

Closes #337