### PR TITLE
feat: fine-grained permission controls for /settings, templates/generators, and world locks (#250, #323, #322)

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
@@ -49,7 +49,23 @@ public class SetPermissionSubCommand extends AbstractSubCommand {
 
     public void getPermissionInput(Player player, BuildWorld buildWorld, boolean closeInventory) {
         new PlayerChatInput(plugin, player, "enter_world_permission", input -> {
-            buildWorld.getData().permission().set(input.trim());
+            String permission = input.trim();
+
+            List<String> whitelist =
+                    plugin.getConfigService().current().settings().worldPermissionWhitelist();
+            if (!isPermissionAllowed(permission, whitelist)) {
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                messages.sendMessage(player, "worlds_setpermission_not_allowed");
+
+                if (closeInventory) {
+                    player.closeInventory();
+                } else {
+                    new EditMenu(plugin, buildWorld, player).open(player);
+                }
+                return;
+            }
+
+            buildWorld.getData().permission().set(permission);
             plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
             XSound.ENTITY_PLAYER_LEVELUP.play(player);
@@ -61,6 +77,20 @@ public class SetPermissionSubCommand extends AbstractSubCommand {
                 new EditMenu(plugin, buildWorld, player).open(player);
             }
         });
+    }
+
+    /**
+     * Determines whether a permission lock may be set via {@code /worlds setPermission}.
+     *
+     * <p>An empty whitelist imposes no restriction (today's behavior). When the whitelist is non-empty, only listed
+     * values and the {@code "-"} sentinel (which clears the permission) are allowed.
+     *
+     * @param input The trimmed permission input
+     * @param whitelist The configured whitelist of permitted permission strings
+     * @return {@code true} if the permission may be set, {@code false} otherwise
+     */
+    static boolean isPermissionAllowed(String input, List<String> whitelist) {
+        return whitelist.isEmpty() || input.equals("-") || whitelist.contains(input);
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
@@ -149,6 +149,7 @@ public class ConfigService {
         return new PluginConfig.Settings(
                 config.getBoolean("settings.update-checker", true),
                 config.getBoolean("settings.scoreboard", true),
+                config.getBoolean("settings.per-option-permissions", false),
                 config.getBoolean("settings.spawn-teleport-message", false),
                 config.getBoolean("settings.join-quit-messages", true),
                 Objects.requireNonNullElse(config.getString("settings.date-format"), "dd/MM/yyyy"),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
@@ -150,6 +150,8 @@ public class ConfigService {
                 config.getBoolean("settings.update-checker", true),
                 config.getBoolean("settings.scoreboard", true),
                 config.getBoolean("settings.per-option-permissions", false),
+                config.getStringList("settings.world-permission-whitelist"),
+                config.getBoolean("settings.restrict-template-access", false),
                 config.getBoolean("settings.spawn-teleport-message", false),
                 config.getBoolean("settings.join-quit-messages", true),
                 Objects.requireNonNullElse(config.getString("settings.date-format"), "dd/MM/yyyy"),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -32,6 +32,7 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
     public record Settings(
             boolean updateChecker,
             boolean scoreboard,
+            boolean perOptionPermissions,
             boolean spawnTeleportMessage,
             boolean joinQuitMessages,
             String dateFormat,

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -33,6 +33,8 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
             boolean updateChecker,
             boolean scoreboard,
             boolean perOptionPermissions,
+            List<String> worldPermissionWhitelist,
+            boolean restrictTemplateAccess,
             boolean spawnTeleportMessage,
             boolean joinQuitMessages,
             String dateFormat,

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/ConfigMigrationManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/ConfigMigrationManager.java
@@ -31,7 +31,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class ConfigMigrationManager {
 
-    public static final int LATEST_VERSION = 3;
+    public static final int LATEST_VERSION = 4;
 
     private final BuildSystemPlugin plugin;
     private final Map<Integer, Migration> migrations;
@@ -47,6 +47,7 @@ public class ConfigMigrationManager {
 
         registerMigration(1, new MigrationV1ToV2());
         registerMigration(2, new MigrationV2ToV3());
+        registerMigration(3, new MigrationV3ToV4());
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
@@ -17,15 +17,20 @@
  */
 package de.eintosti.buildsystem.config.migration;
 
+import java.util.List;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Migrates config from v3 to v4: introduces per-option {@code /settings} permission checks.
+ * Migrates config from v3 to v4: introduces additional permission-granularity controls.
  *
  * <ul>
  *   <li>Adds {@code settings.per-option-permissions} (default {@code false}) so existing servers keep today's behavior
  *       until an admin opts in.
+ *   <li>Adds {@code settings.world-permission-whitelist} (default empty list) so by default any permission lock may be
+ *       set via {@code /worlds setPermission}.
+ *   <li>Adds {@code settings.restrict-template-access} (default {@code false}) so template and generator use is
+ *       unrestricted until an admin opts in.
  * </ul>
  */
 @NullMarked
@@ -34,6 +39,8 @@ public class MigrationV3ToV4 implements Migration {
     @Override
     public void migrate(FileConfiguration config) {
         addIfMissing(config, "settings.per-option-permissions", false);
+        addIfMissing(config, "settings.world-permission-whitelist", List.of());
+        addIfMissing(config, "settings.restrict-template-access", false);
     }
 
     private static void addIfMissing(FileConfiguration config, String path, Object value) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.config.migration;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Migrates config from v3 to v4: introduces per-option {@code /settings} permission checks.
+ *
+ * <ul>
+ *   <li>Adds {@code settings.per-option-permissions} (default {@code false}) so existing servers keep today's behavior
+ *       until an admin opts in.
+ * </ul>
+ */
+@NullMarked
+public class MigrationV3ToV4 implements Migration {
+
+    @Override
+    public void migrate(FileConfiguration config) {
+        addIfMissing(config, "settings.per-option-permissions", false);
+    }
+
+    private static void addIfMissing(FileConfiguration config, String path, Object value) {
+        if (!config.contains(path)) {
+            config.set(path, value);
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
@@ -62,10 +62,16 @@ public class SettingsMenu extends Menu {
      * any side effects) and returns {@code false} when the click is rejected, in which case the menu is not reopened.
      */
     private record Toggle(
-            XMaterial material, boolean enabled, String itemKey, String loreKey, BooleanSupplier onToggle) {
+            XMaterial material,
+            boolean enabled,
+            String itemKey,
+            String loreKey,
+            String node,
+            BooleanSupplier onToggle) {
 
-        static Toggle of(XMaterial material, boolean enabled, String itemKey, String loreKey, Runnable flip) {
-            return new Toggle(material, enabled, itemKey, loreKey, () -> {
+        static Toggle of(
+                XMaterial material, boolean enabled, String itemKey, String loreKey, String node, Runnable flip) {
+            return new Toggle(material, enabled, itemKey, loreKey, node, () -> {
                 flip.run();
                 return true;
             });
@@ -83,6 +89,7 @@ public class SettingsMenu extends Menu {
                                 settings.isClearInventory(),
                                 "settings_clear_inventory_item",
                                 "settings_clear_inventory_lore",
+                                "clear-inventory",
                                 () -> settings.setClearInventory(!settings.isClearInventory()))),
                 entry(
                         13,
@@ -91,6 +98,7 @@ public class SettingsMenu extends Menu {
                                 settings.isDisableInteract(),
                                 "settings_disableinteract_item",
                                 "settings_disableinteract_lore",
+                                "disable-interact",
                                 () -> settings.setDisableInteract(!settings.isDisableInteract()))),
                 entry(
                         14,
@@ -99,6 +107,7 @@ public class SettingsMenu extends Menu {
                                 settings.isHidePlayers(),
                                 "settings_hideplayers_item",
                                 "settings_hideplayers_lore",
+                                "hide-players",
                                 () -> {
                                     settings.setHidePlayers(!settings.isHidePlayers());
                                     toggleHidePlayers(player, settings);
@@ -110,6 +119,7 @@ public class SettingsMenu extends Menu {
                                 settings.isInstantPlaceSigns(),
                                 "settings_instantplacesigns_item",
                                 "settings_instantplacesigns_lore",
+                                "instant-place-signs",
                                 () -> settings.setInstantPlaceSigns(!settings.isInstantPlaceSigns()))),
                 entry(
                         20,
@@ -118,6 +128,7 @@ public class SettingsMenu extends Menu {
                                 settings.isKeepNavigator(),
                                 "settings_keep_navigator_item",
                                 "settings_keep_navigator_lore",
+                                "keep-navigator",
                                 () -> settings.setKeepNavigator(!settings.isKeepNavigator()))),
                 entry(
                         21,
@@ -130,6 +141,7 @@ public class SettingsMenu extends Menu {
                                 settings.getNavigatorType() == NavigatorType.NEW,
                                 "settings_new_navigator_item",
                                 "settings_new_navigator_lore",
+                                "navigator-type",
                                 () -> toggleNavigatorType(player, settings))),
                 entry(
                         22,
@@ -138,6 +150,7 @@ public class SettingsMenu extends Menu {
                                 settings.isNightVision(),
                                 "settings_nightvision_item",
                                 "settings_nightvision_lore",
+                                "night-vision",
                                 () -> toggleNightVision(player, settings))),
                 entry(
                         23,
@@ -146,6 +159,7 @@ public class SettingsMenu extends Menu {
                                 settings.isNoClip(),
                                 "settings_no_clip_item",
                                 "settings_no_clip_lore",
+                                "no-clip",
                                 () -> toggleNoClip(player, settings))),
                 entry(
                         24,
@@ -154,6 +168,7 @@ public class SettingsMenu extends Menu {
                                 settings.isOpenTrapDoors(),
                                 "settings_open_trapdoors_item",
                                 "settings_open_trapdoors_lore",
+                                "open-trapdoors",
                                 () -> settings.setOpenTrapDoors(!settings.isOpenTrapDoors()))),
                 entry(
                         29,
@@ -162,6 +177,7 @@ public class SettingsMenu extends Menu {
                                 settings.isPlacePlants(),
                                 "settings_placeplants_item",
                                 "settings_placeplants_lore",
+                                "place-plants",
                                 () -> settings.setPlacePlants(!settings.isPlacePlants()))),
                 entry(
                         30,
@@ -170,6 +186,7 @@ public class SettingsMenu extends Menu {
                                 settings.isScoreboard(),
                                 scoreboardEnabled ? "settings_scoreboard_item" : "settings_scoreboard_disabled_item",
                                 scoreboardEnabled ? "settings_scoreboard_lore" : "settings_scoreboard_disabled_lore",
+                                "scoreboard",
                                 () -> toggleScoreboard(player, settings, scoreboardEnabled))),
                 entry(
                         31,
@@ -178,6 +195,7 @@ public class SettingsMenu extends Menu {
                                 settings.isSlabBreaking(),
                                 "settings_slab_breaking_item",
                                 "settings_slab_breaking_lore",
+                                "slab-breaking",
                                 () -> settings.setSlabBreaking(!settings.isSlabBreaking()))),
                 entry(
                         32,
@@ -186,6 +204,7 @@ public class SettingsMenu extends Menu {
                                 settings.isSpawnTeleport(),
                                 "settings_spawnteleport_item",
                                 "settings_spawnteleport_lore",
+                                "spawn-teleport",
                                 () -> settings.setSpawnTeleport(!settings.isSpawnTeleport()))));
     }
 
@@ -238,6 +257,14 @@ public class SettingsMenu extends Menu {
         Settings settings = settingsManager.getSettings(player);
         Toggle toggle = toggles(player, settings).get(event.getSlot());
         if (toggle == null) {
+            return;
+        }
+
+        boolean perOptionPermissions =
+                plugin.getConfigService().current().settings().perOptionPermissions();
+        if (perOptionPermissions && !player.hasPermission("buildsystem.setting." + toggle.node())) {
+            messages.sendPermissionError(player);
+            XSound.ENTITY_ITEM_BREAK.play(player);
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -242,6 +242,14 @@ public class WorldServiceImpl implements WorldService {
     private void startCustomGeneratorInput(
             Player player, String worldName, @Nullable String template, boolean privateWorld, @Nullable Folder folder) {
         new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
+            boolean restrictTemplateAccess =
+                    plugin.getConfigService().current().settings().restrictTemplateAccess();
+            if (restrictTemplateAccess && !player.hasPermission("buildsystem.create.generator." + input.trim())) {
+                plugin.getMessages().sendPermissionError(player);
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                return;
+            }
+
             CustomGenerator customGenerator = CustomGeneratorImpl.of(input, worldName);
             if (customGenerator == null) {
                 plugin.getMessages().sendMessage(player, "worlds_import_unknown_generator");

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
@@ -32,6 +32,7 @@ import de.eintosti.buildsystem.util.FileUtils;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.bukkit.ChatColor;
@@ -56,6 +57,10 @@ public class CreateMenu extends PaginatedMenu {
     private int numTemplates = 0;
 
     private File @Nullable [] templateFiles;
+
+    // Maps the slot a template item occupies on the current page to its raw directory name, so click handling can
+    // resolve the unformatted template name for permission checks without parsing the display string.
+    private final Map<Integer, String> templateSlots = new HashMap<>();
 
     public CreateMenu(
             BuildSystemPlugin plugin, Page initialPage, Visibility visibility, @Nullable Folder folder, Player player) {
@@ -142,6 +147,10 @@ public class CreateMenu extends PaginatedMenu {
                 "buildsystem.create.type." + worldType.name().toLowerCase(Locale.ROOT));
     }
 
+    private boolean restrictTemplateAccess() {
+        return plugin.getConfigService().current().settings().restrictTemplateAccess();
+    }
+
     private void populateGenerator(Player player) {
         plugin.getMenuItems().addGlassPane(player, getInventory(), 29);
         plugin.getMenuItems().addGlassPane(player, getInventory(), 30);
@@ -194,17 +203,19 @@ public class CreateMenu extends PaginatedMenu {
             return;
         }
 
+        this.templateSlots.clear();
         int startIndex = page() * MAX_TEMPLATES;
         for (int i = 0; i < MAX_TEMPLATES && startIndex + i < templateFiles.length; i++) {
+            String rawTemplateName = templateFiles[startIndex + i].getName();
+            int slot = 29 + i;
+            this.templateSlots.put(slot, rawTemplateName);
             getInventory()
                     .setItem(
-                            29 + i,
+                            slot,
                             InventoryUtils.createItem(
                                     XMaterial.FILLED_MAP,
                                     messages.getString(
-                                            "create_template",
-                                            player,
-                                            Map.entry("%template%", templateFiles[startIndex + i].getName()))));
+                                            "create_template", player, Map.entry("%template%", rawTemplateName))));
         }
     }
 
@@ -253,6 +264,14 @@ public class CreateMenu extends PaginatedMenu {
                 XMaterial xMaterial = XMaterial.matchXMaterial(itemStack);
                 switch (xMaterial) {
                     case FILLED_MAP:
+                        if (restrictTemplateAccess()) {
+                            String rawTemplateName = this.templateSlots.get(slot);
+                            if (rawTemplateName == null
+                                    || !player.hasPermission("buildsystem.create.template." + rawTemplateName)) {
+                                XSound.ENTITY_ITEM_BREAK.play(player);
+                                return;
+                            }
+                        }
                         this.worldService.startWorldNameInput(
                                 player,
                                 BuildWorldType.TEMPLATE,

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -5,6 +5,12 @@ settings:
   update-checker: true
   scoreboard: true
   per-option-permissions: false
+  # When non-empty, only the listed permission strings (plus "-" to clear) may be set
+  # via /worlds setPermission. Empty list means no restriction.
+  world-permission-whitelist: []
+  # When true, selecting a template requires buildsystem.create.template.<name> and using
+  # a custom generator requires buildsystem.create.generator.<name>.
+  restrict-template-access: false
   spawn-teleport-message: false
   join-quit-messages: true
   date-format: "dd/MM/yyyy"

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -4,6 +4,7 @@
 settings:
   update-checker: true
   scoreboard: true
+  per-option-permissions: false
   spawn-teleport-message: false
   join-quit-messages: true
   date-format: "dd/MM/yyyy"

--- a/buildsystem-core/src/main/resources/messages.yml
+++ b/buildsystem-core/src/main/resources/messages.yml
@@ -338,6 +338,7 @@ worlds_setpermission_usage: "%prefix% &7Usage: &b/worlds setPermission <world>"
 worlds_setpermission_unknown_world: "%prefix% &cUnknown world."
 worlds_setpermission_error: "%prefix% &cPlease try again."
 worlds_setpermission_set: "%prefix% &b%world%&7's permission was successfully changed."
+worlds_setpermission_not_allowed: "%prefix% &cThat permission is not allowed."
 
 worlds_setspawn_world_not_imported: "%prefix% &cWorld must be imported: /worlds import <world>"
 worlds_setspawn_world_spawn_set: "%prefix% &b%world%&7's spawnpoint was set."

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommandTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommandTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.command.subcommand.worlds;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SetPermissionSubCommandTest {
+
+    @Test
+    void isPermissionAllowed_emptyWhitelist_allowsAnything() {
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("worlds.lobby", List.of()));
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("anything.at.all", List.of()));
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("-", List.of()));
+    }
+
+    @Test
+    void isPermissionAllowed_nonEmptyWhitelist_allowsOnlyListed() {
+        List<String> whitelist = List.of("worlds.lobby", "worlds.spawn");
+
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("worlds.lobby", whitelist));
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("worlds.spawn", whitelist));
+        assertFalse(SetPermissionSubCommand.isPermissionAllowed("worlds.secret", whitelist));
+    }
+
+    @Test
+    void isPermissionAllowed_nonEmptyWhitelist_alwaysAllowsClearSentinel() {
+        List<String> whitelist = List.of("worlds.lobby");
+
+        assertTrue(SetPermissionSubCommand.isPermissionAllowed("-", whitelist));
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.config.migration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+class MigrationV3ToV4Test {
+
+    @Test
+    void migrate_perOptionPermissions_addedWithDefaultFalse() {
+        YamlConfiguration config = new YamlConfiguration();
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertTrue(config.contains("settings.per-option-permissions"));
+        assertFalse(config.getBoolean("settings.per-option-permissions"));
+    }
+
+    @Test
+    void migrate_existingKeys_preserved() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("settings.scoreboard", false);
+        config.set("settings.date-format", "yyyy-MM-dd");
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertFalse(config.getBoolean("settings.scoreboard"));
+        assertEquals("yyyy-MM-dd", config.getString("settings.date-format"));
+        assertFalse(config.getBoolean("settings.per-option-permissions"));
+    }
+
+    @Test
+    void migrate_existingPerOptionPermissions_notOverwritten() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("settings.per-option-permissions", true);
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertTrue(config.getBoolean("settings.per-option-permissions"));
+    }
+
+    @Test
+    void migrate_missingKeys_noException() {
+        YamlConfiguration config = new YamlConfiguration();
+        assertDoesNotThrow(() -> new MigrationV3ToV4().migrate(config));
+    }
+
+    @Test
+    void migrate_idempotent_secondRunNoOp() {
+        YamlConfiguration config = new YamlConfiguration();
+
+        MigrationV3ToV4 migration = new MigrationV3ToV4();
+        migration.migrate(config);
+        migration.migrate(config);
+
+        assertFalse(config.getBoolean("settings.per-option-permissions"));
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
@@ -35,6 +35,26 @@ class MigrationV3ToV4Test {
     }
 
     @Test
+    void migrate_worldPermissionWhitelist_addedWithDefaultEmpty() {
+        YamlConfiguration config = new YamlConfiguration();
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertTrue(config.contains("settings.world-permission-whitelist"));
+        assertTrue(config.getStringList("settings.world-permission-whitelist").isEmpty());
+    }
+
+    @Test
+    void migrate_restrictTemplateAccess_addedWithDefaultFalse() {
+        YamlConfiguration config = new YamlConfiguration();
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertTrue(config.contains("settings.restrict-template-access"));
+        assertFalse(config.getBoolean("settings.restrict-template-access"));
+    }
+
+    @Test
     void migrate_existingKeys_preserved() {
         YamlConfiguration config = new YamlConfiguration();
         config.set("settings.scoreboard", false);
@@ -45,6 +65,20 @@ class MigrationV3ToV4Test {
         assertFalse(config.getBoolean("settings.scoreboard"));
         assertEquals("yyyy-MM-dd", config.getString("settings.date-format"));
         assertFalse(config.getBoolean("settings.per-option-permissions"));
+        assertTrue(config.getStringList("settings.world-permission-whitelist").isEmpty());
+        assertFalse(config.getBoolean("settings.restrict-template-access"));
+    }
+
+    @Test
+    void migrate_existingNewKeys_notOverwritten() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("settings.world-permission-whitelist", java.util.List.of("worlds.lobby"));
+        config.set("settings.restrict-template-access", true);
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertEquals(java.util.List.of("worlds.lobby"), config.getStringList("settings.world-permission-whitelist"));
+        assertTrue(config.getBoolean("settings.restrict-template-access"));
     }
 
     @Test


### PR DESCRIPTION
## What

Adds three **opt-in** admin permission controls that share one theme — finer-grained control over what ranks can do. Each defaults to **today's behavior**, so a server that upgrades and changes nothing sees no difference until it opts in.

| Issue | Control | Config (default) |
|-------|---------|------------------|
| #250 | Per-option `/settings` permissions | `settings.per-option-permissions: false` |
| #323 | Per-template / per-generator use permissions | `settings.restrict-template-access: false` |
| #322 | Restrict which world permission locks can be set | `settings.world-permission-whitelist: []` |

## How

### #250 — per-`/settings`-option permissions
When enabled, each toggle in the settings menu requires `buildsystem.setting.<option>`; lacking it rejects the click with the standard permission error. Nodes: `clear-inventory`, `disable-interact`, `hide-players`, `instant-place-signs`, `keep-navigator`, `navigator-type`, `night-vision`, `no-clip`, `open-trapdoors`, `place-plants`, `scoreboard`, `slab-breaking`, `spawn-teleport` (all under `buildsystem.setting.`).

### #323 — per-template / per-generator use
When enabled:
- selecting a template in the create menu requires `buildsystem.create.template.<name>` (raw directory name, resolved via a slot→name map so the unformatted name is used);
- using a custom generator requires `buildsystem.create.generator.<name>`, checked at the point the free-text generator name is entered (`WorldServiceImpl.startCustomGeneratorInput`).

### #322 — restrict settable permission locks
`/worlds setPermission` validates input against `world-permission-whitelist`. Empty list = no restriction (back-compat); when non-empty, only listed values and `-` (clear) are accepted, else the set is rejected with `worlds_setpermission_not_allowed`. The decision is a pure, unit-tested helper `isPermissionAllowed(input, whitelist)`.

## Config / migration

All three keys are added through the existing migration framework (`MigrationV3ToV4`, registered; `LATEST_VERSION` = 4) so existing user `config.yml` files gain them on upgrade with backward-compatible defaults, plus the bundled `config.yml`, `PluginConfig.Settings`, and `ConfigService`.

## Tests

- `MigrationV3ToV4Test` — all three keys added with correct defaults, existing keys preserved, pre-existing values not overwritten, idempotent.
- `SetPermissionSubCommandTest` — the `isPermissionAllowed` whitelist predicate (empty allows all; non-empty allows only listed + `-`).

`./gradlew clean build` + `spotlessCheck` pass.

## Notes

- Back-compat is the invariant throughout: every control is off/empty by default.
- `restrict-template-access` governs both the template and generator gates (they're the same "what can this rank create from" concern); split into two switches later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)