### PR TITLE
fix: initialize config and messages in onEnable to prevent null Messages NPE

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.AdvancedPie;
@@ -86,20 +87,23 @@ public class BuildSystemPlugin extends JavaPlugin {
     private BukkitTask configSaveTask;
 
     @Override
-    public void onLoad() {
-        this.configService = new ConfigService(this);
-        new ConfigMigrationManager(this).migrate();
-        this.getConfig().options().copyDefaults(true);
-        this.saveConfig();
-        this.configService.load();
-
-        this.messages = new Messages(this, configService);
-        this.messages.load();
-        createTemplateFolder();
-    }
-
-    @Override
     public void onEnable() {
+        try {
+            this.configService = new ConfigService(this);
+            new ConfigMigrationManager(this).migrate();
+            this.getConfig().options().copyDefaults(true);
+            this.saveConfig();
+            this.configService.load();
+
+            this.messages = new Messages(this, configService);
+            this.messages.load();
+            createTemplateFolder();
+        } catch (Exception ex) {
+            getLogger().log(Level.SEVERE, "Failed to initialize BuildSystem; disabling.", ex);
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
         initClasses();
 
         new CommandRegistrar(this).registerAll();


### PR DESCRIPTION
## The bug

Joining a server (Paper 26.1) or running `/worlds` throws `NullPointerException` because `BuildSystemPlugin.getMessages()` returns null at event/command time:

```
Cannot invoke "...Messages.getString(...)" because the return value of "...BuildSystemPlugin.getMessages()" is null
  at ...PlayerJoinListener.sendPlayerJoinMessage
  at ...SettingsService.displayScoreboard
  at ...NavigatorMenu.<init>  (via /worlds)
```

## Root cause

Critical initialization ran in `onLoad()`: it set `configService` and ran the config chain (`migrate()`, `getConfig()`, `saveConfig()`, `configService.load()`) **first**, and only **then** built `messages`. If anything in that earlier chain is skipped or throws on the platform, `onLoad` aborts **before** `messages` is assigned — but the plugin still enables and registers its listeners/commands, so every join and command then NPEs on a null `Messages`. (Tellingly, `getConfigService()` works on the same code path while `getMessages()` is null — exactly the partial-`onLoad` signature.)

## The fix

- **Move all critical init into `onEnable()`**, before `initClasses()` and before the command/listener registrars — preserving the exact statement order. `onLoad()` is removed. This guarantees `messages` is non-null before any listener or command can run.
- **Fail loudly, not silently:** the init block is wrapped in try/catch — on any failure it logs `SEVERE` and `disablePlugin(this)` instead of leaving the plugin half-enabled. This also surfaces the real underlying exception (previously swallowed by the `onLoad`/`onEnable` split) so future config/migration issues are diagnosable.

Verified nothing in the moved block requires `onLoad` timing (no world-generator registration — it's only config/messages/template-folder setup).

`./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)