### PR TITLE
refactor(api)!: rename Type to Property, split persistence out of the data API, add flat accessors

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Capability.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Capability.java
@@ -18,7 +18,7 @@
 package de.eintosti.buildsystem.api.data;
 
 /**
- * A marker interface for a "capability" or "attachment" that can be added to a {@link Type}.
+ * A marker interface for a "capability" or "attachment" that can be added to a {@link Property}.
  *
  * @since 3.0.1
  */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Overridable.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Overridable.java
@@ -23,7 +23,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A {@link Capability} that marks a {@link Type} as being overridable by an external source.
+ * A {@link Capability} that marks a {@link Property} as being overridable by an external source.
  *
  * @param <T> The type of the value being overridden
  * @param isEnabled A supplier that returns {@code true} if the override is active

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Property.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Property.java
@@ -21,21 +21,21 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A generic interface representing a configurable data type.
+ * A generic interface representing a single configurable world property.
  *
- * @param <T> The type of the value held by this data point
+ * @param <T> The type of the value held by this property
  */
 @NullMarked
-public interface Type<T> {
+public interface Property<T> {
 
     /**
-     * An immutable implementation of the {@link Type} interface using a Java Record. This class holds a final,
+     * An immutable implementation of the {@link Property} interface using a Java Record. This class holds a final,
      * read-only value.
      *
      * @param <T> The type of the value held
      * @param value The immutable value
      */
-    record ImmutableType<T>(T value) implements Type<T> {
+    record Immutable<T>(T value) implements Property<T> {
 
         /**
          * Gets the immutable value.
@@ -48,52 +48,34 @@ public interface Type<T> {
         }
 
         /**
-         * Throws {@link UnsupportedOperationException} as this type is immutable.
+         * Throws {@link UnsupportedOperationException} as this property is immutable.
          *
          * @param value The value to set (which is ignored)
-         * @throws UnsupportedOperationException Always, as this type cannot be modified
+         * @throws UnsupportedOperationException Always, as this property cannot be modified
          */
         @Contract("_ -> fail")
         @Override
         public void set(T value) {
-            throw new UnsupportedOperationException("This Type is immutable and cannot be modified.");
-        }
-
-        /**
-         * Gets the immutable value formatted for storage.
-         *
-         * @return The immutable value
-         */
-        @Override
-        public Object getConfigFormat() {
-            return value;
+            throw new UnsupportedOperationException("This property is immutable and cannot be modified.");
         }
     }
 
     /**
-     * An immutable {@link Type} representing the boolean value {@code true}.
+     * An immutable {@link Property} representing the boolean value {@code true}.
      */
-    Type<Boolean> TRUE = new ImmutableType<>(true);
+    Property<Boolean> TRUE = new Immutable<>(true);
 
     /**
-     * Gets the current value of this data point.
+     * Gets the current value of this property.
      *
      * @return The current value
      */
     T get();
 
     /**
-     * Sets the value of this data point.
+     * Sets the value of this property.
      *
      * @param value The new value to set
      */
     void set(T value);
-
-    /**
-     * Gets the value of this data point formatted for storage in a configuration file. This might involve converting
-     * complex objects into simpler types (e.g., enums to strings).
-     *
-     * @return The value formatted for a config file
-     */
-    Object getConfigFormat();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
@@ -17,7 +17,7 @@
  */
 package de.eintosti.buildsystem.api.world.access;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -77,7 +77,7 @@ public interface WorldPermissions {
      * @param check The specific data type representing the modification to be checked
      * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
      */
-    boolean canModify(Player player, Type<Boolean> check);
+    boolean canModify(Player player, Property<Boolean> check);
 
     /**
      * Checks if the given {@link Player} is permitted to execute a specific command within the context of the current

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
@@ -18,18 +18,20 @@
 package de.eintosti.buildsystem.api.world.data;
 
 import com.cryptomorin.xseries.XMaterial;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.Backup;
-import java.util.Map;
 import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Manages and provides access to various data points and settings for a {@link BuildWorld}. This interface allows for
+ * Manages and provides access to various properties and settings for a {@link BuildWorld}. This interface allows for
  * reading and modifying world-specific configurations.
+ *
+ * <p>For the common case, prefer the flat accessors (e.g. {@link #getStatus()} / {@link #setStatus(BuildWorldStatus)}).
+ * The {@link Property} objects (e.g. {@link #status()}) remain available for advanced capability use.
  *
  * @since 3.0.0
  */
@@ -37,13 +39,13 @@ import org.jspecify.annotations.Nullable;
 public interface WorldData {
 
     /**
-     * Retrieves a {@link Type} object representing the custom spawn location of the {@link BuildWorld}. The value is
+     * Retrieves a {@link Property} object representing the custom spawn location of the {@link BuildWorld}. The value is
      * stored as a string in the format {@code x;y;z;yaw;pitch}.
      *
-     * @return A {@link Type} containing the custom spawn string
+     * @return A {@link Property} containing the custom spawn string
      * @see #getCustomSpawnLocation()
      */
-    Type<String> customSpawn();
+    Property<String> customSpawn();
 
     /**
      * Gets the {@link BuildWorld}'s custom spawn as a {@link Location} object.
@@ -53,141 +55,405 @@ public interface WorldData {
     @Nullable Location getCustomSpawnLocation();
 
     /**
-     * Retrieves a {@link Type} object representing the permission required to enter the {@link BuildWorld}. Returns "-"
-     * if no specific permission is required.
+     * Retrieves a {@link Property} object representing the permission required to enter the {@link BuildWorld}. Returns
+     * "-" if no specific permission is required.
      *
-     * @return A {@link Type} containing the permission string
+     * @return A {@link Property} containing the permission string
      */
-    Type<String> permission();
+    Property<String> permission();
 
     /**
-     * Retrieves a {@link Type} object representing the project description of the {@link BuildWorld}. This typically
+     * Gets the permission required to enter the {@link BuildWorld}.
+     *
+     * @return The permission string, or "-" if no specific permission is required
+     * @since TODO
+     */
+    String getPermission();
+
+    /**
+     * Sets the permission required to enter the {@link BuildWorld}.
+     *
+     * @param permission The permission string, or "-" if no specific permission is required
+     * @since TODO
+     */
+    void setPermission(String permission);
+
+    /**
+     * Retrieves a {@link Property} object representing the project description of the {@link BuildWorld}. This typically
      * provides a brief overview or purpose of the world.
      *
-     * @return A {@link Type} containing the project description string
+     * @return A {@link Property} containing the project description string
      */
-    Type<String> project();
+    Property<String> project();
 
     /**
-     * Retrieves a {@link Type} object representing the {@link Difficulty} of the {@link BuildWorld}.
+     * Gets the project description of the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing the world's difficulty setting
+     * @return The project description string
+     * @since TODO
      */
-    Type<Difficulty> difficulty();
+    String getProject();
 
     /**
-     * Retrieves a {@link Type} object representing the {@link XMaterial} used to display the {@link BuildWorld} in the
-     * navigator menus.
+     * Sets the project description of the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing the material used for display
+     * @param project The project description string
+     * @since TODO
      */
-    Type<XMaterial> material();
+    void setProject(String project);
 
     /**
-     * Retrieves a {@link Type} object representing the current {@link BuildWorldStatus} of the world. This indicates
+     * Retrieves a {@link Property} object representing the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing the world's difficulty setting
+     */
+    Property<Difficulty> difficulty();
+
+    /**
+     * Gets the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @return The world's difficulty setting
+     * @since TODO
+     */
+    Difficulty getDifficulty();
+
+    /**
+     * Sets the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @param difficulty The world's difficulty setting
+     * @since TODO
+     */
+    void setDifficulty(Difficulty difficulty);
+
+    /**
+     * Retrieves a {@link Property} object representing the {@link XMaterial} used to display the {@link BuildWorld} in
+     * the navigator menus.
+     *
+     * @return A {@link Property} containing the material used for display
+     */
+    Property<XMaterial> material();
+
+    /**
+     * Gets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
+     *
+     * @return The material used for display
+     * @since TODO
+     */
+    XMaterial getMaterial();
+
+    /**
+     * Sets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
+     *
+     * @param material The material used for display
+     * @since TODO
+     */
+    void setMaterial(XMaterial material);
+
+    /**
+     * Retrieves a {@link Property} object representing the current {@link BuildWorldStatus} of the world. This indicates
      * the building progression or state of the world.
      *
-     * @return A {@link Type} containing the current build status
+     * @return A {@link Property} containing the current build status
      */
-    Type<BuildWorldStatus> status();
+    Property<BuildWorldStatus> status();
 
     /**
-     * Retrieves a {@link Type} object indicating whether block breaking is allowed in the {@link BuildWorld}.
+     * Gets the current {@link BuildWorldStatus} of the world.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if allowed, otherwise {@code false}
+     * @return The current build status
+     * @since TODO
      */
-    Type<Boolean> blockBreaking();
+    BuildWorldStatus getStatus();
 
     /**
-     * Retrieves a {@link Type} object indicating whether block interactions (e.g., opening doors, chests) are enabled
-     * in the {@link BuildWorld}.
+     * Sets the current {@link BuildWorldStatus} of the world.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     * @param status The current build status
+     * @since TODO
      */
-    Type<Boolean> blockInteractions();
+    void setStatus(BuildWorldStatus status);
 
     /**
-     * Retrieves a {@link Type} object indicating whether block placement is allowed in the {@link BuildWorld}.
+     * Retrieves a {@link Property} object indicating whether block breaking is allowed in the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if allowed, otherwise {@code false}
+     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
      */
-    Type<Boolean> blockPlacement();
+    Property<Boolean> blockBreaking();
 
     /**
-     * Retrieves a {@link Type} object indicating whether the "builders feature" is enabled in the {@link BuildWorld}.
-     * When enabled, only designated builders can modify the world.
+     * Gets whether block breaking is allowed in the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     * @return {@code true} if allowed, otherwise {@code false}
+     * @since TODO
      */
-    Type<Boolean> buildersEnabled();
+    boolean isBlockBreaking();
 
     /**
-     * Retrieves a {@link Type} object indicating whether explosions are enabled in the {@link BuildWorld}.
+     * Sets whether block breaking is allowed in the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     * @param blockBreaking {@code true} if allowed, otherwise {@code false}
+     * @since TODO
      */
-    Type<Boolean> explosions();
+    void setBlockBreaking(boolean blockBreaking);
 
     /**
-     * Retrieves a {@link Type} object indicating whether entities in the {@link BuildWorld} have artificial
+     * Retrieves a {@link Property} object indicating whether block interactions (e.g., opening doors, chests) are
+     * enabled in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> blockInteractions();
+
+    /**
+     * Gets whether block interactions (e.g., opening doors, chests) are enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isBlockInteractions();
+
+    /**
+     * Sets whether block interactions (e.g., opening doors, chests) are enabled in the {@link BuildWorld}.
+     *
+     * @param blockInteractions {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    void setBlockInteractions(boolean blockInteractions);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
+     */
+    Property<Boolean> blockPlacement();
+
+    /**
+     * Gets whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @return {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isBlockPlacement();
+
+    /**
+     * Sets whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @param blockPlacement {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    void setBlockPlacement(boolean blockPlacement);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether the "builders feature" is enabled in the
+     * {@link BuildWorld}. When enabled, only designated builders can modify the world.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> buildersEnabled();
+
+    /**
+     * Gets whether the "builders feature" is enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isBuildersEnabled();
+
+    /**
+     * Sets whether the "builders feature" is enabled in the {@link BuildWorld}.
+     *
+     * @param buildersEnabled {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    void setBuildersEnabled(boolean buildersEnabled);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> explosions();
+
+    /**
+     * Gets whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isExplosions();
+
+    /**
+     * Sets whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @param explosions {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    void setExplosions(boolean explosions);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether entities in the {@link BuildWorld} have artificial
      * intelligence.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
      */
-    Type<Boolean> mobAi();
+    Property<Boolean> mobAi();
 
     /**
-     * Retrieves a {@link Type} object indicating whether physics (e.g., gravity, fluid flow) is applied to blocks in
+     * Gets whether entities in the {@link BuildWorld} have artificial intelligence.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isMobAi();
+
+    /**
+     * Sets whether entities in the {@link BuildWorld} have artificial intelligence.
+     *
+     * @param mobAi {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    void setMobAi(boolean mobAi);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether physics (e.g., gravity, fluid flow) is applied to blocks in
      * the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
      */
-    Type<Boolean> physics();
+    Property<Boolean> physics();
 
     /**
-     * Retrieves a {@link Type} object indicating whether the {@link BuildWorld} is set to private visibility. A private
-     * world is typically only accessible to its creator and designated builders.
+     * Gets whether physics (e.g., gravity, fluid flow) is applied to blocks in the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if private, otherwise {@code false}
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
      */
-    Type<Boolean> privateWorld();
+    boolean isPhysics();
+
+    /**
+     * Sets whether physics (e.g., gravity, fluid flow) is applied to blocks in the {@link BuildWorld}.
+     *
+     * @param physics {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    void setPhysics(boolean physics);
+
+    /**
+     * Retrieves a {@link Property} object indicating whether the {@link BuildWorld} is set to private visibility. A
+     * private world is typically only accessible to its creator and designated builders.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if private, otherwise {@code false}
+     */
+    Property<Boolean> privateWorld();
+
+    /**
+     * Gets whether the {@link BuildWorld} is set to private visibility.
+     *
+     * @return {@code true} if private, otherwise {@code false}
+     * @since TODO
+     */
+    boolean isPrivateWorld();
+
+    /**
+     * Sets whether the {@link BuildWorld} is set to private visibility.
+     *
+     * @param privateWorld {@code true} if private, otherwise {@code false}
+     * @since TODO
+     */
+    void setPrivateWorld(boolean privateWorld);
 
     /**
      * Gets the number of seconds that have passed since that last {@link Backup} of the {@link BuildWorld} was created.
      *
      * @return The number of seconds since the last backup
      */
-    Type<Integer> timeSinceBackup();
+    Property<Integer> timeSinceBackup();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
+     *
+     * @return The number of seconds since the last backup
+     * @since TODO
+     */
+    int getTimeSinceBackup();
+
+    /**
+     * Sets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
+     *
+     * @param timeSinceBackup The number of seconds since the last backup
+     * @since TODO
+     */
+    void setTimeSinceBackup(int timeSinceBackup);
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was edited.
      *
-     * @return A {@link Type} containing the last edited timestamp
+     * @return A {@link Property} containing the last edited timestamp
      */
-    Type<Long> lastEdited();
+    Property<Long> lastEdited();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
+     *
+     * @return The last edited timestamp
+     * @since TODO
+     */
+    long getLastEdited();
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
+     *
+     * @param lastEdited The last edited timestamp
+     * @since TODO
+     */
+    void setLastEdited(long lastEdited);
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was loaded.
      *
-     * @return A {@link Type} containing the last loaded timestamp
+     * @return A {@link Property} containing the last loaded timestamp
      */
-    Type<Long> lastLoaded();
+    Property<Long> lastLoaded();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
+     *
+     * @return The last loaded timestamp
+     * @since TODO
+     */
+    long getLastLoaded();
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
+     *
+     * @param lastLoaded The last loaded timestamp
+     * @since TODO
+     */
+    void setLastLoaded(long lastLoaded);
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was unloaded.
      *
-     * @return A {@link Type} containing the last unloaded timestamp
+     * @return A {@link Property} containing the last unloaded timestamp
      */
-    Type<Long> lastUnloaded();
+    Property<Long> lastUnloaded();
 
     /**
-     * Gets a map of all configurable data points for the {@link BuildWorld}.
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
      *
-     * @return An unmodifiable map where keys are data point names and values are their corresponding {@link Type}
-     *     objects
+     * @return The last unloaded timestamp
+     * @since TODO
      */
-    Map<String, Type<?>> getAllData();
+    long getLastUnloaded();
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
+     *
+     * @param lastUnloaded The last unloaded timestamp
+     * @since TODO
+     */
+    void setLastUnloaded(long lastUnloaded);
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
@@ -81,11 +81,11 @@ public class ExplosionsCommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (!worldData.explosions().get()) {
-            worldData.explosions().set(true);
+        if (!worldData.isExplosions()) {
+            worldData.setExplosions(true);
             messages.sendMessage(player, "explosions_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.explosions().set(false);
+            worldData.setExplosions(false);
             messages.sendMessage(player, "explosions_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
@@ -81,15 +81,15 @@ public class NoAICommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (worldData.mobAi().get()) {
-            worldData.mobAi().set(false);
+        if (worldData.isMobAi()) {
+            worldData.setMobAi(false);
             messages.sendMessage(player, "noai_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.mobAi().set(true);
+            worldData.setMobAi(true);
             messages.sendMessage(player, "noai_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
 
-        boolean hasAi = worldData.mobAi().get();
+        boolean hasAi = worldData.isMobAi();
         world.getLivingEntities().forEach(entity -> entity.setAI(hasAi));
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
@@ -57,7 +57,7 @@ public class PhysicsCommand extends CommandBase {
                 if (args[0].equalsIgnoreCase("all") && !worldStorage.worldExists("all")) {
                     worldStorage
                             .getBuildWorlds()
-                            .forEach(world -> world.getData().physics().set(true));
+                            .forEach(world -> world.getData().setPhysics(true));
                     messages.sendMessage(player, "physics_activated_all");
                 } else {
                     togglePhysics(player, Bukkit.getWorld(args[0]));
@@ -91,11 +91,11 @@ public class PhysicsCommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (!worldData.physics().get()) {
-            worldData.physics().set(true);
+        if (!worldData.isPhysics()) {
+            worldData.setPhysics(true);
             messages.sendMessage(player, "physics_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.physics().set(false);
+            worldData.setPhysics(false);
             messages.sendMessage(player, "physics_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/InfoSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/InfoSubCommand.java
@@ -55,34 +55,25 @@ public class InfoSubCommand extends AbstractSubCommand {
                 Map.entry("%world%", buildWorld.getName()),
                 Map.entry("%uuid%", buildWorld.getUniqueId().toString()),
                 Map.entry("%creator%", getCreator(builders)),
-                Map.entry("%item%", worldData.material().get().name()),
+                Map.entry("%item%", worldData.getMaterial().name()),
                 Map.entry("%type%", messages.getString(Messages.getMessageKey(buildWorld.getType()), player)),
-                Map.entry("%private%", worldData.privateWorld().get()),
-                Map.entry("%builders_enabled%", worldData.buildersEnabled().get()),
+                Map.entry("%private%", worldData.isPrivateWorld()),
+                Map.entry("%builders_enabled%", worldData.isBuildersEnabled()),
                 Map.entry("%builders%", builders.asPlaceholder(player)),
-                Map.entry("%block_breaking%", worldData.blockBreaking().get()),
-                Map.entry("%block_placement%", worldData.blockPlacement().get()),
-                Map.entry(
-                        "%status%",
-                        messages.getString(
-                                Messages.getMessageKey(worldData.status().get()), player)),
-                Map.entry("%project%", worldData.project().get()),
-                Map.entry("%permission%", worldData.permission().get()),
+                Map.entry("%block_breaking%", worldData.isBlockBreaking()),
+                Map.entry("%block_placement%", worldData.isBlockPlacement()),
+                Map.entry("%status%", messages.getString(Messages.getMessageKey(worldData.getStatus()), player)),
+                Map.entry("%project%", worldData.getProject()),
+                Map.entry("%permission%", worldData.getPermission()),
                 Map.entry("%time%", buildWorld.getWorldTime()),
                 Map.entry("%creation%", messages.formatDate(buildWorld.getCreation())),
-                Map.entry("%physics%", worldData.physics().get()),
-                Map.entry("%explosions%", worldData.explosions().get()),
-                Map.entry("%mobai%", worldData.mobAi().get()),
+                Map.entry("%physics%", worldData.isPhysics()),
+                Map.entry("%explosions%", worldData.isExplosions()),
+                Map.entry("%mobai%", worldData.isMobAi()),
                 Map.entry("%custom_spawn%", getCustomSpawn(buildWorld)),
-                Map.entry(
-                        "%lastedited%",
-                        messages.formatDate(worldData.lastEdited().get())),
-                Map.entry(
-                        "%lastloaded%",
-                        messages.formatDate(worldData.lastLoaded().get())),
-                Map.entry(
-                        "%lastunloaded%",
-                        messages.formatDate(worldData.lastUnloaded().get())));
+                Map.entry("%lastedited%", messages.formatDate(worldData.getLastEdited())),
+                Map.entry("%lastloaded%", messages.formatDate(worldData.getLastLoaded())),
+                Map.entry("%lastunloaded%", messages.formatDate(worldData.getLastUnloaded())));
     }
 
     private String getCreator(Builders builders) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetItemSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetItemSubCommand.java
@@ -50,7 +50,7 @@ public class SetItemSubCommand extends AbstractSubCommand {
             return;
         }
 
-        buildWorld.getData().material().set(XMaterial.matchXMaterial(itemStack));
+        buildWorld.getData().setMaterial(XMaterial.matchXMaterial(itemStack));
         messages.sendMessage(player, "worlds_setitem_set", Map.entry("%world%", buildWorld.getName()));
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
@@ -49,7 +49,7 @@ public class SetPermissionSubCommand extends AbstractSubCommand {
 
     public void getPermissionInput(Player player, BuildWorld buildWorld, boolean closeInventory) {
         new PlayerChatInput(plugin, player, "enter_world_permission", input -> {
-            buildWorld.getData().permission().set(input.trim());
+            buildWorld.getData().setPermission(input.trim());
             plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
             XSound.ENTITY_PLAYER_LEVELUP.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetProjectSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetProjectSubCommand.java
@@ -49,7 +49,7 @@ public class SetProjectSubCommand extends AbstractSubCommand {
 
     public void getProjectInput(Player player, BuildWorld buildWorld, boolean closeInventory) {
         new PlayerChatInput(plugin, player, "enter_world_project", input -> {
-            buildWorld.getData().project().set(input.trim());
+            buildWorld.getData().setProject(input.trim());
             plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
             XSound.ENTITY_PLAYER_LEVELUP.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
@@ -39,7 +39,7 @@ final class WorldsCompletions {
             Player player, WorldStorage worldStorage, @Nullable String commandPermission, String input) {
         List<String> result = new ArrayList<>();
         for (BuildWorld world : worldStorage.getBuildWorlds()) {
-            String worldPerm = world.getData().permission().get();
+            String worldPerm = world.getData().getPermission();
             if ((player.hasPermission(worldPerm) || worldPerm.equalsIgnoreCase("-"))
                     && world.getPermissions().canPerformCommand(player, commandPermission)) {
                 addIfStartsWith(input, world.getName(), result);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansion.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansion.java
@@ -142,28 +142,27 @@ public class PlaceholderApiExpansion extends PlaceholderExpansion {
         Builders builders = buildWorld.getBuilders();
         WorldData worldData = buildWorld.getData();
         return switch (identifier.toLowerCase(Locale.ROOT)) {
-            case "blockbreaking" -> String.valueOf(worldData.blockBreaking().get());
-            case "blockplacement" -> String.valueOf(worldData.blockPlacement().get());
+            case "blockbreaking" -> String.valueOf(worldData.isBlockBreaking());
+            case "blockplacement" -> String.valueOf(worldData.isBlockPlacement());
             case "builders" -> builders.asPlaceholder(player);
-            case "buildersenabled" -> String.valueOf(worldData.buildersEnabled().get());
+            case "buildersenabled" -> String.valueOf(worldData.isBuildersEnabled());
             case "creation" -> messages.formatDate(buildWorld.getCreation());
             case "creator" -> builders.hasCreator() ? builders.getCreator().getName() : "-";
             case "creatorid" ->
                 builders.hasCreator() ? String.valueOf(builders.getCreator().getUniqueId()) : "-";
-            case "explosions" -> String.valueOf(worldData.explosions().get());
-            case "lastedited" -> messages.formatDate(worldData.lastEdited().get());
-            case "lastloaded" -> messages.formatDate(worldData.lastLoaded().get());
-            case "lastunloaded" -> messages.formatDate(worldData.lastUnloaded().get());
+            case "explosions" -> String.valueOf(worldData.isExplosions());
+            case "lastedited" -> messages.formatDate(worldData.getLastEdited());
+            case "lastloaded" -> messages.formatDate(worldData.getLastLoaded());
+            case "lastunloaded" -> messages.formatDate(worldData.getLastUnloaded());
             case "loaded" -> String.valueOf(buildWorld.isLoaded());
-            case "material" -> worldData.material().get().name();
-            case "mobai" -> String.valueOf(worldData.mobAi().get());
-            case "permission" -> worldData.permission().get();
-            case "private" -> String.valueOf(worldData.privateWorld().get());
-            case "project" -> worldData.project().get();
-            case "physics" -> String.valueOf(worldData.physics().get());
+            case "material" -> worldData.getMaterial().name();
+            case "mobai" -> String.valueOf(worldData.isMobAi());
+            case "permission" -> worldData.getPermission();
+            case "private" -> String.valueOf(worldData.isPrivateWorld());
+            case "project" -> worldData.getProject();
+            case "physics" -> String.valueOf(worldData.isPhysics());
             case "spawn" -> worldData.customSpawn().get();
-            case "status" ->
-                messages.getString(Messages.getMessageKey(worldData.status().get()), player);
+            case "status" -> messages.getString(Messages.getMessageKey(worldData.getStatus()), player);
             case "time" -> buildWorld.getWorldTime();
             case "type" -> messages.getString(Messages.getMessageKey(buildWorld.getType()), player);
             case "world" -> buildWorld.getName();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/worldedit/EditSessionListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/worldedit/EditSessionListener.java
@@ -67,7 +67,7 @@ public class EditSessionListener implements Listener {
         }
 
         if (buildWorld.getPermissions().hasAdminPermission(player)) {
-            buildWorld.getData().lastEdited().set(System.currentTimeMillis());
+            buildWorld.getData().setLastEdited(System.currentTimeMillis());
             return;
         }
 
@@ -81,6 +81,6 @@ public class EditSessionListener implements Listener {
             return;
         }
 
-        buildWorld.getData().lastEdited().set(System.currentTimeMillis());
+        buildWorld.getData().setLastEdited(System.currentTimeMillis());
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
@@ -211,7 +211,7 @@ public class NavigatorListener implements Listener {
      */
     private void disableArchivedWorlds(Player player, Cancellable cancellable) {
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld());
-        if (buildWorld == null || buildWorld.getData().status().get() != BuildWorldStatus.ARCHIVE) {
+        if (buildWorld == null || buildWorld.getData().getStatus() != BuildWorldStatus.ARCHIVE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
@@ -74,7 +74,7 @@ public class PlayerChangedWorldListener implements Listener {
 
         BuildWorld newWorld = worldStorage.getBuildWorld(worldName);
         if (newWorld != null
-                && !newWorld.getData().physics().get()
+                && !newWorld.getData().isPhysics()
                 && player.hasPermission("buildsystem.physics.message")) {
             plugin.getMessages()
                     .sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", newWorld.getName()));
@@ -112,7 +112,7 @@ public class PlayerChangedWorldListener implements Listener {
     private void setGoldBlock(@Nullable BuildWorld buildWorld) {
         if (buildWorld == null
                 || buildWorld.getType() != BuildWorldType.VOID
-                || buildWorld.getData().status().get() != BuildWorldStatus.NOT_STARTED) {
+                || buildWorld.getData().getStatus() != BuildWorldStatus.NOT_STARTED) {
             return;
         }
 
@@ -136,7 +136,7 @@ public class PlayerChangedWorldListener implements Listener {
                 .getCachedValues();
         cachedValues.resetArchiveStateIfPresent(player);
 
-        if (buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             cachedValues.saveArchiveState(player);
 
             removeArmorContent(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
@@ -89,13 +89,13 @@ public class PlayerJoinListener implements Listener {
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
         if (buildWorld != null) {
             WorldData worldData = buildWorld.getData();
-            if (!worldData.physics().get() && player.hasPermission("buildsystem.physics.message")) {
+            if (!worldData.isPhysics() && player.hasPermission("buildsystem.physics.message")) {
                 plugin.getMessages()
                         .sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", worldName));
             }
 
             if (plugin.getConfigService().current().settings().archive().vanish()
-                    && worldData.status().get() == BuildWorldStatus.ARCHIVE) {
+                    && worldData.getStatus() == BuildWorldStatus.ARCHIVE) {
                 player.addPotionEffect(
                         new PotionEffect(XPotion.INVISIBILITY.get(), PotionEffect.INFINITE_DURATION, 0, false, false),
                         false);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
@@ -50,7 +50,7 @@ public class BlockPhysicsListener implements Listener {
 
     private boolean physicsAllowed(World world) {
         BuildWorld buildWorld = worldStorage.getBuildWorld(world);
-        return buildWorld == null || buildWorld.getData().physics().get();
+        return buildWorld == null || buildWorld.getData().isPhysics();
     }
 
     @EventHandler

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/EntitySpawnListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/EntitySpawnListener.java
@@ -44,7 +44,7 @@ public class EntitySpawnListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(bukkitWorld.getName());
-        if (buildWorld == null || buildWorld.getData().mobAi().get()) {
+        if (buildWorld == null || buildWorld.getData().isMobAi()) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/FoodLevelChangeListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/FoodLevelChangeListener.java
@@ -43,7 +43,7 @@ public class FoodLevelChangeListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld());
-        if (buildWorld != null && buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (buildWorld != null && buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             event.setCancelled(true);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
@@ -19,7 +19,7 @@ package de.eintosti.buildsystem.listener.world;
 
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
@@ -97,7 +97,7 @@ public class WorldManipulateListener implements Listener {
 
         dispatcher.tryDispatchManipulationEvent(player, event);
 
-        if (!buildWorld.getData().physics().get() && event.getClickedBlock() != null) {
+        if (!buildWorld.getData().isPhysics() && event.getClickedBlock() != null) {
             if (event.getAction() == Action.PHYSICAL && event.getClickedBlock().getType() == XMaterial.FARMLAND.get()) {
                 event.setCancelled(true);
             }
@@ -115,18 +115,18 @@ public class WorldManipulateListener implements Listener {
         WorldData worldData = buildWorld.getData();
         Cancellable parentEvent = event.getParentEvent();
 
-        Type<Boolean> setting = worldSettingFor(parentEvent, worldData);
+        Property<Boolean> setting = worldSettingFor(parentEvent, worldData);
         if (!buildWorld.getPermissions().canModify(player, setting)) {
             parentEvent.setCancelled(true);
             denyPlayerInteraction(event);
             return;
         }
 
-        worldData.lastEdited().set(System.currentTimeMillis());
+        worldData.setLastEdited(System.currentTimeMillis());
         updateStatus(worldData, player);
     }
 
-    private Type<Boolean> worldSettingFor(Cancellable event, WorldData data) {
+    private Property<Boolean> worldSettingFor(Cancellable event, WorldData data) {
         return switch (event) {
             case BlockBreakEvent ignored -> data.blockBreaking();
             case BlockPlaceEvent ignored -> data.blockPlacement();
@@ -142,8 +142,8 @@ public class WorldManipulateListener implements Listener {
     }
 
     private void updateStatus(WorldData worldData, Player player) {
-        if (worldData.status().get() == BuildWorldStatus.NOT_STARTED) {
-            worldData.status().set(BuildWorldStatus.IN_PROGRESS);
+        if (worldData.getStatus() == BuildWorldStatus.NOT_STARTED) {
+            worldData.setStatus(BuildWorldStatus.IN_PROGRESS);
             plugin.getSettingsService().forceUpdateSidebar(player);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -110,7 +110,7 @@ public final class MenuItems {
      */
     public void addWorldItem(
             Inventory inventory, int slot, BuildWorld buildWorld, String displayName, List<String> lore) {
-        XMaterial material = buildWorld.getData().material().get();
+        XMaterial material = buildWorld.getData().getMaterial();
         if (material != XMaterial.PLAYER_HEAD) {
             inventory.setItem(slot, InventoryUtils.createItem(material, displayName, lore));
             return;
@@ -122,7 +122,7 @@ public final class MenuItems {
 
         XSkull.createItem()
                 .profile(
-                        buildWorld.getData().privateWorld().get()
+                        buildWorld.getData().isPrivateWorld()
                                 ? buildWorld.asProfilable()
                                 : Profileable.username(buildWorld.getName()))
                 .fallback(buildWorld.asProfilable())

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockManager.java
@@ -75,15 +75,15 @@ public class CustomBlockManager implements Listener {
         }
 
         boolean hadToDisablePhysics = false;
-        if (isBuildWorld && !buildWorld.getData().physics().get()) {
+        if (isBuildWorld && !buildWorld.getData().isPhysics()) {
             hadToDisablePhysics = true;
-            buildWorld.getData().physics().set(true);
+            buildWorld.getData().setPhysics(true);
         }
 
         setBlock(event, customBlock);
 
         if (isBuildWorld && hadToDisablePhysics) {
-            buildWorld.getData().physics().set(false);
+            buildWorld.getData().setPhysics(false);
         }
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/settings/SettingsService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/settings/SettingsService.java
@@ -132,16 +132,14 @@ public class SettingsService {
             WorldData worldData = buildWorld.getData();
             Builders builders = buildWorld.getBuilders();
 
-            status = plugin.getMessages()
-                    .getString(Messages.getMessageKey(worldData.status().get()), player);
-            permission = worldData.permission().get();
-            project = worldData.project().get();
+            status = plugin.getMessages().getString(Messages.getMessageKey(worldData.getStatus()), player);
+            permission = worldData.getPermission();
+            project = worldData.getProject();
             creator = builders.hasCreator() ? builders.getCreator().getName() : "-";
             creation = plugin.getMessages().formatDate(buildWorld.getCreation());
-            lastEdited = plugin.getMessages().formatDate(worldData.lastEdited().get());
-            lastLoaded = plugin.getMessages().formatDate(worldData.lastLoaded().get());
-            lastUnloaded =
-                    plugin.getMessages().formatDate(worldData.lastUnloaded().get());
+            lastEdited = plugin.getMessages().formatDate(worldData.getLastEdited());
+            lastLoaded = plugin.getMessages().formatDate(worldData.getLastLoaded());
+            lastUnloaded = plugin.getMessages().formatDate(worldData.getLastUnloaded());
         }
 
         return new Map.Entry[] {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
@@ -17,7 +17,7 @@
  */
 package de.eintosti.buildsystem.protection;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -40,7 +40,7 @@ public final class WorldProtectionPolicy {
             return Denial.NONE;
         }
 
-        if (world.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (world.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             return Denial.ARCHIVED;
         }
 
@@ -58,14 +58,14 @@ public final class WorldProtectionPolicy {
             return Denial.NONE;
         }
 
-        if (world.getData().buildersEnabled().get() && !builders.isBuilder(player)) {
+        if (world.getData().isBuildersEnabled() && !builders.isBuilder(player)) {
             return Denial.NOT_A_BUILDER;
         }
 
         return Denial.NONE;
     }
 
-    public Denial checkSetting(Player player, BuildWorld world, Type<Boolean> setting) {
+    public Denial checkSetting(Player player, BuildWorld world, Property<Boolean> setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }
@@ -90,7 +90,7 @@ public final class WorldProtectionPolicy {
         return checkBuilders(player, world);
     }
 
-    public Denial mayModify(Player player, BuildWorld world, Type<Boolean> setting) {
+    public Denial mayModify(Player player, BuildWorld world, Property<Boolean> setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
@@ -130,8 +130,7 @@ public abstract class WorldStorageImpl implements WorldStorage {
     @Unmodifiable
     public List<BuildWorld> getBuildWorldsCreatedByPlayer(Player player, Visibility visibility) {
         return getBuildWorldsCreatedByPlayer(player).stream()
-                .filter(buildWorld ->
-                        isCorrectVisibility(buildWorld.getData().privateWorld().get(), visibility))
+                .filter(buildWorld -> isCorrectVisibility(buildWorld.getData().isPrivateWorld(), visibility))
                 .toList();
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
@@ -24,7 +24,6 @@ import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
-import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
 import de.eintosti.buildsystem.world.BuildWorldImpl;
 import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
@@ -95,7 +94,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
             world.put("creator", builders.getCreator().toString());
         }
         world.put("type", buildWorld.getType().name());
-        world.put("data", serializeWorldData(buildWorld.getData()));
+        world.put("data", serializeWorldData((WorldDataImpl) buildWorld.getData()));
         world.put("date", buildWorld.getCreation());
         world.put("builders", serializeBuilders(builders.getAllBuilders()));
         if (buildWorld.getCustomGenerator() != null) {
@@ -105,7 +104,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
         return world;
     }
 
-    private Map<String, Object> serializeWorldData(WorldData worldData) {
+    private Map<String, Object> serializeWorldData(WorldDataImpl worldData) {
         return worldData.getAllData().entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey, entry -> entry.getValue().getConfigFormat()));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -181,12 +181,12 @@ public final class BuildWorldImpl implements BuildWorld {
 
     @Override
     public XMaterial getIcon() {
-        return this.worldData.material().get();
+        return this.worldData.getMaterial();
     }
 
     @Override
     public void setIcon(XMaterial material) {
-        this.worldData.material().set(material);
+        this.worldData.setMaterial(material);
     }
 
     @Override
@@ -200,29 +200,16 @@ public final class BuildWorldImpl implements BuildWorld {
         Map.Entry<String, Object>[] placeholders = List.of(
                         Map.entry(
                                 "%status%",
-                                plugin.getMessages()
-                                        .getString(
-                                                Messages.getMessageKey(
-                                                        worldData.status().get()),
-                                                player)),
-                        Map.entry("%project%", worldData.project().get()),
-                        Map.entry("%permission%", worldData.permission().get()),
+                                plugin.getMessages().getString(Messages.getMessageKey(worldData.getStatus()), player)),
+                        Map.entry("%project%", worldData.getProject()),
+                        Map.entry("%permission%", worldData.getPermission()),
                         Map.entry(
                                 "%creator%",
                                 builders.hasCreator() ? builders.getCreator().getName() : "-"),
                         Map.entry("%creation%", plugin.getMessages().formatDate(getCreation())),
-                        Map.entry(
-                                "%lastedited%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastEdited().get())),
-                        Map.entry(
-                                "%lastloaded%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastLoaded().get())),
-                        Map.entry(
-                                "%lastunloaded%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastUnloaded().get())))
+                        Map.entry("%lastedited%", plugin.getMessages().formatDate(worldData.getLastEdited())),
+                        Map.entry("%lastloaded%", plugin.getMessages().formatDate(worldData.getLastLoaded())),
+                        Map.entry("%lastunloaded%", plugin.getMessages().formatDate(worldData.getLastUnloaded())))
                 .toArray(Map.Entry[]::new);
 
         List<String> messageList = getPermissions().canPerformCommand(player, WorldsArgument.EDIT.getPermission())
@@ -285,13 +272,13 @@ public final class BuildWorldImpl implements BuildWorld {
     @Override
     public Difficulty cycleDifficulty() {
         Difficulty newDifficulty =
-                switch (worldData.difficulty().get()) {
+                switch (worldData.getDifficulty()) {
                     case PEACEFUL -> Difficulty.EASY;
                     case EASY -> Difficulty.NORMAL;
                     case NORMAL -> Difficulty.HARD;
                     case HARD -> Difficulty.PEACEFUL;
                 };
-        worldData.difficulty().set(newDifficulty);
+        worldData.setDifficulty(newDifficulty);
         return newDifficulty;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -166,7 +166,7 @@ public class WorldServiceImpl implements WorldService {
             return LoadResult.FAILED;
         }
 
-        buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
+        buildWorld.getData().setLastLoaded(System.currentTimeMillis());
         plugin.getLogger().info("✔ World loaded: " + worldName);
         return LoadResult.LOADED;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
@@ -10,7 +10,7 @@ package de.eintosti.buildsystem.world.backup;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.BackupProfile;
@@ -153,7 +153,7 @@ public class BackupService {
         if (autoBackup.onlyActiveWorlds()) {
             for (Player pl : Bukkit.getOnlinePlayers()) {
                 BuildWorld buildWorld = worldStorage.getBuildWorld(pl.getWorld().getName());
-                if (buildWorld != null && buildWorld.getPermissions().canModify(pl, Type.TRUE)) {
+                if (buildWorld != null && buildWorld.getPermissions().canModify(pl, Property.TRUE)) {
                     worlds.add(buildWorld);
                 }
             }
@@ -162,7 +162,7 @@ public class BackupService {
         }
 
         worlds.forEach(buildWorld -> {
-            Type<Integer> timeSinceBackup = buildWorld.getData().timeSinceBackup();
+            Property<Integer> timeSinceBackup = buildWorld.getData().timeSinceBackup();
             timeSinceBackup.set((int) (timeSinceBackup.get() + UPDATE_PERIOD));
 
             if (timeSinceBackup.get() > autoBackup.interval()) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
@@ -78,7 +78,7 @@ abstract class AbstractWorldCreator {
             folder.addWorld(bw);
         }
 
-        bw.getData().lastLoaded().set(System.currentTimeMillis());
+        bw.getData().setLastLoaded(System.currentTimeMillis());
         worldStorage.addBuildWorld(bw);
         return bw;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -20,11 +20,12 @@ package de.eintosti.buildsystem.world.data;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.data.Bypassable;
 import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.display.Folder;
-import de.eintosti.buildsystem.world.data.type.ConfigurableType;
+import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
+import de.eintosti.buildsystem.world.data.type.PersistentProperty;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -39,40 +40,40 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class WorldDataImpl implements WorldData {
 
-    private final Map<String, Type<?>> data = new HashMap<>();
+    private final Map<String, PersistentProperty<?>> data = new HashMap<>();
     private String worldName;
 
     private @Nullable Supplier<@Nullable Folder> folderResolver;
 
-    private final Type<String> customSpawn;
-    private final Type<String> permission;
-    private final Type<String> project;
+    private final Property<String> customSpawn;
+    private final Property<String> permission;
+    private final Property<String> project;
 
-    private final Type<Difficulty> difficulty;
-    private final Type<XMaterial> material;
-    private final Type<BuildWorldStatus> status;
+    private final Property<Difficulty> difficulty;
+    private final Property<XMaterial> material;
+    private final Property<BuildWorldStatus> status;
 
-    private final Type<Boolean> blockBreaking;
-    private final Type<Boolean> blockInteractions;
-    private final Type<Boolean> blockPlacement;
-    private final Type<Boolean> buildersEnabled;
-    private final Type<Boolean> explosions;
-    private final Type<Boolean> mobAi;
-    private final Type<Boolean> physics;
-    private final Type<Boolean> privateWorld;
+    private final Property<Boolean> blockBreaking;
+    private final Property<Boolean> blockInteractions;
+    private final Property<Boolean> blockPlacement;
+    private final Property<Boolean> buildersEnabled;
+    private final Property<Boolean> explosions;
+    private final Property<Boolean> mobAi;
+    private final Property<Boolean> physics;
+    private final Property<Boolean> privateWorld;
 
-    private final Type<Integer> timeSinceBackup;
-    private final Type<Long> lastEdited;
-    private final Type<Long> lastLoaded;
-    private final Type<Long> lastUnloaded;
+    private final Property<Integer> timeSinceBackup;
+    private final Property<Long> lastEdited;
+    private final Property<Long> lastLoaded;
+    private final Property<Long> lastUnloaded;
 
     private WorldDataImpl(WorldDataBuilder builder) {
         this.worldName = builder.worldName;
 
-        this.customSpawn = register("spawn", new ConfigurableType<>(builder.customSpawn));
+        this.customSpawn = register("spawn", new ConfigurableProperty<>(builder.customSpawn));
         this.permission = register(
                 "permission",
-                new ConfigurableType<>(builder.permission)
+                new ConfigurableProperty<>(builder.permission)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.permission"))
                         .withCapability(Overridable.class, new Overridable<>(builder.permissionOverrideEnabled, () -> {
                             Folder folder = getAssignedFolder();
@@ -80,44 +81,44 @@ public class WorldDataImpl implements WorldData {
                         })));
         this.project = register(
                 "project",
-                new ConfigurableType<>(builder.project)
+                new ConfigurableProperty<>(builder.project)
                         .withCapability(Overridable.class, new Overridable<>(builder.projectOverrideEnabled, () -> {
                             Folder folder = getAssignedFolder();
                             return (folder != null) ? folder.getProject() : null;
                         })));
 
         this.difficulty = register(
-                "difficulty", new ConfigurableType<>(builder.difficulty).withConfigFormatter(Difficulty::name));
+                "difficulty", new ConfigurableProperty<>(builder.difficulty).withConfigFormatter(Difficulty::name));
         this.material =
-                register("material", new ConfigurableType<>(builder.material).withConfigFormatter(XMaterial::name));
+                register("material", new ConfigurableProperty<>(builder.material).withConfigFormatter(XMaterial::name));
         this.status = register(
                 "status",
-                new ConfigurableType<>(builder.status)
+                new ConfigurableProperty<>(builder.status)
                         .withConfigFormatter(BuildWorldStatus::name)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.archive")));
 
         this.blockBreaking = register(
                 "block-breaking",
-                new ConfigurableType<>(builder.blockBreaking)
+                new ConfigurableProperty<>(builder.blockBreaking)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
         this.blockInteractions = register(
                 "block-interactions",
-                new ConfigurableType<>(builder.blockInteractions)
+                new ConfigurableProperty<>(builder.blockInteractions)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
         this.blockPlacement = register(
                 "block-placement",
-                new ConfigurableType<>(builder.blockPlacement)
+                new ConfigurableProperty<>(builder.blockPlacement)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
-        this.buildersEnabled = register("builders-enabled", new ConfigurableType<>(builder.buildersEnabled));
-        this.explosions = register("explosions", new ConfigurableType<>(builder.explosions));
-        this.mobAi = register("mob-ai", new ConfigurableType<>(builder.mobAi));
-        this.physics = register("physics", new ConfigurableType<>(builder.physics));
-        this.privateWorld = register("private", new ConfigurableType<>(builder.privateWorld));
+        this.buildersEnabled = register("builders-enabled", new ConfigurableProperty<>(builder.buildersEnabled));
+        this.explosions = register("explosions", new ConfigurableProperty<>(builder.explosions));
+        this.mobAi = register("mob-ai", new ConfigurableProperty<>(builder.mobAi));
+        this.physics = register("physics", new ConfigurableProperty<>(builder.physics));
+        this.privateWorld = register("private", new ConfigurableProperty<>(builder.privateWorld));
 
-        this.timeSinceBackup = register("time-since-backup", new ConfigurableType<>(builder.timeSinceBackup));
-        this.lastEdited = register("last-edited", new ConfigurableType<>(builder.lastEdited));
-        this.lastLoaded = register("last-loaded", new ConfigurableType<>(builder.lastLoaded));
-        this.lastUnloaded = register("last-unloaded", new ConfigurableType<>(builder.lastUnloaded));
+        this.timeSinceBackup = register("time-since-backup", new ConfigurableProperty<>(builder.timeSinceBackup));
+        this.lastEdited = register("last-edited", new ConfigurableProperty<>(builder.lastEdited));
+        this.lastLoaded = register("last-loaded", new ConfigurableProperty<>(builder.lastLoaded));
+        this.lastUnloaded = register("last-unloaded", new ConfigurableProperty<>(builder.lastUnloaded));
     }
 
     public void setFolderResolver(Supplier<@Nullable Folder> resolver) {
@@ -129,13 +130,13 @@ public class WorldDataImpl implements WorldData {
         return resolver != null ? resolver.get() : null;
     }
 
-    private <T> ConfigurableType<T> register(String key, ConfigurableType<T> type) {
-        this.data.put(key, type);
-        return type;
+    private <T> ConfigurableProperty<T> register(String key, ConfigurableProperty<T> property) {
+        this.data.put(key, property);
+        return property;
     }
 
     @Override
-    public Type<String> customSpawn() {
+    public Property<String> customSpawn() {
         return customSpawn;
     }
 
@@ -157,96 +158,271 @@ public class WorldDataImpl implements WorldData {
     }
 
     @Override
-    public Type<String> permission() {
+    public Property<String> permission() {
         return permission;
     }
 
     @Override
-    public Type<String> project() {
+    public String getPermission() {
+        return permission.get();
+    }
+
+    @Override
+    public void setPermission(String permission) {
+        this.permission.set(permission);
+    }
+
+    @Override
+    public Property<String> project() {
         return project;
     }
 
     @Override
-    public Type<Difficulty> difficulty() {
+    public String getProject() {
+        return project.get();
+    }
+
+    @Override
+    public void setProject(String project) {
+        this.project.set(project);
+    }
+
+    @Override
+    public Property<Difficulty> difficulty() {
         return difficulty;
     }
 
     @Override
-    public Type<XMaterial> material() {
+    public Difficulty getDifficulty() {
+        return difficulty.get();
+    }
+
+    @Override
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty.set(difficulty);
+    }
+
+    @Override
+    public Property<XMaterial> material() {
         return material;
     }
 
     @Override
-    public Type<BuildWorldStatus> status() {
+    public XMaterial getMaterial() {
+        return material.get();
+    }
+
+    @Override
+    public void setMaterial(XMaterial material) {
+        this.material.set(material);
+    }
+
+    @Override
+    public Property<BuildWorldStatus> status() {
         return status;
     }
 
     @Override
-    public Type<Boolean> blockBreaking() {
+    public BuildWorldStatus getStatus() {
+        return status.get();
+    }
+
+    @Override
+    public void setStatus(BuildWorldStatus status) {
+        this.status.set(status);
+    }
+
+    @Override
+    public Property<Boolean> blockBreaking() {
         return blockBreaking;
     }
 
     @Override
-    public Type<Boolean> blockInteractions() {
+    public boolean isBlockBreaking() {
+        return blockBreaking.get();
+    }
+
+    @Override
+    public void setBlockBreaking(boolean blockBreaking) {
+        this.blockBreaking.set(blockBreaking);
+    }
+
+    @Override
+    public Property<Boolean> blockInteractions() {
         return blockInteractions;
     }
 
     @Override
-    public Type<Boolean> blockPlacement() {
+    public boolean isBlockInteractions() {
+        return blockInteractions.get();
+    }
+
+    @Override
+    public void setBlockInteractions(boolean blockInteractions) {
+        this.blockInteractions.set(blockInteractions);
+    }
+
+    @Override
+    public Property<Boolean> blockPlacement() {
         return blockPlacement;
     }
 
     @Override
-    public Type<Boolean> buildersEnabled() {
+    public boolean isBlockPlacement() {
+        return blockPlacement.get();
+    }
+
+    @Override
+    public void setBlockPlacement(boolean blockPlacement) {
+        this.blockPlacement.set(blockPlacement);
+    }
+
+    @Override
+    public Property<Boolean> buildersEnabled() {
         return buildersEnabled;
     }
 
     @Override
-    public Type<Boolean> explosions() {
+    public boolean isBuildersEnabled() {
+        return buildersEnabled.get();
+    }
+
+    @Override
+    public void setBuildersEnabled(boolean buildersEnabled) {
+        this.buildersEnabled.set(buildersEnabled);
+    }
+
+    @Override
+    public Property<Boolean> explosions() {
         return explosions;
     }
 
     @Override
-    public Type<Boolean> mobAi() {
+    public boolean isExplosions() {
+        return explosions.get();
+    }
+
+    @Override
+    public void setExplosions(boolean explosions) {
+        this.explosions.set(explosions);
+    }
+
+    @Override
+    public Property<Boolean> mobAi() {
         return mobAi;
     }
 
     @Override
-    public Type<Boolean> physics() {
+    public boolean isMobAi() {
+        return mobAi.get();
+    }
+
+    @Override
+    public void setMobAi(boolean mobAi) {
+        this.mobAi.set(mobAi);
+    }
+
+    @Override
+    public Property<Boolean> physics() {
         return physics;
     }
 
     @Override
-    public Type<Boolean> privateWorld() {
+    public boolean isPhysics() {
+        return physics.get();
+    }
+
+    @Override
+    public void setPhysics(boolean physics) {
+        this.physics.set(physics);
+    }
+
+    @Override
+    public Property<Boolean> privateWorld() {
         return privateWorld;
     }
 
     @Override
-    public Type<Integer> timeSinceBackup() {
+    public boolean isPrivateWorld() {
+        return privateWorld.get();
+    }
+
+    @Override
+    public void setPrivateWorld(boolean privateWorld) {
+        this.privateWorld.set(privateWorld);
+    }
+
+    @Override
+    public Property<Integer> timeSinceBackup() {
         return timeSinceBackup;
     }
 
     @Override
-    public Type<Long> lastEdited() {
+    public int getTimeSinceBackup() {
+        return timeSinceBackup.get();
+    }
+
+    @Override
+    public void setTimeSinceBackup(int timeSinceBackup) {
+        this.timeSinceBackup.set(timeSinceBackup);
+    }
+
+    @Override
+    public Property<Long> lastEdited() {
         return lastEdited;
     }
 
     @Override
-    public Type<Long> lastLoaded() {
+    public long getLastEdited() {
+        return lastEdited.get();
+    }
+
+    @Override
+    public void setLastEdited(long lastEdited) {
+        this.lastEdited.set(lastEdited);
+    }
+
+    @Override
+    public Property<Long> lastLoaded() {
         return lastLoaded;
     }
 
     @Override
-    public Type<Long> lastUnloaded() {
+    public long getLastLoaded() {
+        return lastLoaded.get();
+    }
+
+    @Override
+    public void setLastLoaded(long lastLoaded) {
+        this.lastLoaded.set(lastLoaded);
+    }
+
+    @Override
+    public Property<Long> lastUnloaded() {
         return lastUnloaded;
+    }
+
+    @Override
+    public long getLastUnloaded() {
+        return lastUnloaded.get();
+    }
+
+    @Override
+    public void setLastUnloaded(long lastUnloaded) {
+        this.lastUnloaded.set(lastUnloaded);
     }
 
     public void setWorldName(String worldName) {
         this.worldName = worldName;
     }
 
-    @Override
-    public Map<String, Type<?>> getAllData() {
+    /**
+     * Gets a map of all persistent properties for the world, keyed by their storage name. This is an internal
+     * serialization hook used by the storage layer and is intentionally not part of the public {@link WorldData} API.
+     *
+     * @return The map of storage keys to their persistent properties
+     */
+    public Map<String, PersistentProperty<?>> getAllData() {
         return data;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
@@ -19,7 +19,6 @@ package de.eintosti.buildsystem.world.data.type;
 
 import de.eintosti.buildsystem.api.data.Capability;
 import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -27,12 +26,13 @@ import java.util.function.Function;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A single, concrete implementation of {@link Type} that uses a composition-based {@link Capability} model.
+ * A single, concrete implementation of {@link PersistentProperty} that uses a composition-based {@link Capability}
+ * model.
  *
  * @param <T> The type of the value held.
  */
 @NullMarked
-public class ConfigurableType<T> implements Type<T> {
+public class ConfigurableProperty<T> implements PersistentProperty<T> {
 
     private T value;
     private Function<T, Object> configFormatter = (value) -> (Object) value;
@@ -40,37 +40,38 @@ public class ConfigurableType<T> implements Type<T> {
     private final Map<Class<? extends Capability>, Capability> capabilities = new HashMap<>();
 
     /**
-     * Creates a simple type.
+     * Creates a simple property.
      */
-    public ConfigurableType(T defaultValue) {
+    public ConfigurableProperty(T defaultValue) {
         this.value = defaultValue;
     }
 
     /**
-     * Sets a custom config formatter for this type.
+     * Sets a custom config formatter for this property.
      *
      * @param configFormatter A function that formats the value for config storage
      * @return This object, for fluent chaining
      */
-    public ConfigurableType<T> withConfigFormatter(Function<T, Object> configFormatter) {
+    public ConfigurableProperty<T> withConfigFormatter(Function<T, Object> configFormatter) {
         this.configFormatter = configFormatter;
         return this;
     }
 
     /**
-     * Attaches a new capability to this type.
+     * Attaches a new capability to this property.
      *
      * @param capabilityType The class of the capability
      * @param capabilityInstance The instance of the capability
      * @return This object, for fluent chaining
      */
-    public <C extends Capability> ConfigurableType<T> withCapability(Class<C> capabilityType, C capabilityInstance) {
+    public <C extends Capability> ConfigurableProperty<T> withCapability(
+            Class<C> capabilityType, C capabilityInstance) {
         this.capabilities.put(capabilityType, capabilityInstance);
         return this;
     }
 
     /**
-     * Checks if this type has a specific capability.
+     * Checks if this property has a specific capability.
      *
      * @param capability The class of the capability
      * @return {@code true} if the capability is present, {@code false} otherwise
@@ -90,7 +91,7 @@ public class ConfigurableType<T> implements Type<T> {
     }
 
     /**
-     * Gets the effective value for this type, taking into account any active {@link Overridable} capability.
+     * Gets the effective value for this property, taking into account any active {@link Overridable} capability.
      *
      * @return The current value
      */
@@ -105,7 +106,7 @@ public class ConfigurableType<T> implements Type<T> {
     }
 
     /**
-     * Sets the base value for this type.
+     * Sets the base value for this property.
      *
      * <p>Note: This sets the underlying value. If an {@link Overridable} capability is active, {@link #get()} will
      * still return the overridden value.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
@@ -15,15 +15,25 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
+import de.eintosti.buildsystem.api.data.Property;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A {@link Capability} that marks a {@link Property} as being bypassable with a specific permission.
+ * An internal extension of {@link Property} that can produce a storage representation of its value. This persistence
+ * concern is intentionally kept out of the public API.
  *
- * @param permission The permission node required to bypass this type
- * @since 3.0.1
+ * @param <T> The type of the value held by this property
  */
 @NullMarked
-public record Bypassable(String permission) implements Capability {}
+public interface PersistentProperty<T> extends Property<T> {
+
+    /**
+     * Gets the value of this property formatted for storage in a configuration file. This might involve converting
+     * complex objects into simpler types (e.g., enums to strings).
+     *
+     * @return The value formatted for a config file
+     */
+    Object getConfigFormat();
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoaderImpl.java
@@ -84,7 +84,7 @@ public class WorldLoaderImpl implements WorldLoader {
             return;
         }
 
-        this.buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
+        this.buildWorld.getData().setLastLoaded(System.currentTimeMillis());
         this.buildWorld.setLoaded(true);
 
         Bukkit.getServer().getPluginManager().callEvent(new BuildWorldPostLoadEvent(this.buildWorld));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
@@ -19,13 +19,13 @@ package de.eintosti.buildsystem.world.lifecycle;
 
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.data.Bypassable;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
-import de.eintosti.buildsystem.world.data.type.ConfigurableType;
+import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -63,7 +63,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
             return true;
         }
 
-        String permission = buildWorld.getData().permission().get();
+        String permission = buildWorld.getData().getPermission();
         if (permission.equals("-")) {
             return true;
         }
@@ -72,7 +72,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
     }
 
     @Override
-    public boolean canModify(Player player, Type<Boolean> check) {
+    public boolean canModify(Player player, Property<Boolean> check) {
         if (buildWorld == null) {
             return true;
         }
@@ -81,7 +81,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
             return true;
         }
 
-        if (buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE
+        if (buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE
                 && !player.hasPermission("buildsystem.bypass.archive")) {
             return false;
         }
@@ -98,7 +98,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
         return builders.isCreator(player)
                 || builders.isBuilder(player)
                 || player.hasPermission("buildsystem.bypass.builders")
-                || !buildWorld.getData().buildersEnabled().get();
+                || !buildWorld.getData().isBuildersEnabled();
     }
 
     /**
@@ -108,8 +108,8 @@ public class WorldPermissionsImpl implements WorldPermissions {
      * @param check The specific data type representing the modification to be checked
      * @return {@code true} if the player can bypass the modification, otherwise {@code false}
      */
-    private boolean canBypassModification(Player player, Type<Boolean> check) {
-        if (!(check instanceof ConfigurableType<Boolean> configurableType)) {
+    private boolean canBypassModification(Player player, Property<Boolean> check) {
+        if (!(check instanceof ConfigurableProperty<Boolean> configurableType)) {
             return false;
         }
 
@@ -155,11 +155,11 @@ public class WorldPermissionsImpl implements WorldPermissions {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (worldData.status().get() == BuildWorldStatus.ARCHIVE) {
+        if (worldData.getStatus() == BuildWorldStatus.ARCHIVE) {
             return player.hasPermission("buildsystem.bypass.permission.archive");
         }
 
-        return worldData.privateWorld().get()
+        return worldData.isPrivateWorld()
                 ? player.hasPermission("buildsystem.bypass.permission.private")
                 : player.hasPermission("buildsystem.bypass.permission.public");
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
@@ -151,7 +151,7 @@ public class WorldUnloaderImpl implements WorldUnloader {
             return;
         }
 
-        this.buildWorld.getData().lastUnloaded().set(System.currentTimeMillis());
+        this.buildWorld.getData().setLastUnloaded(System.currentTimeMillis());
         this.buildWorld.setLoaded(false);
         this.unloadTask = null;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
@@ -130,7 +130,7 @@ public class BackupsMenu extends Menu {
                 .backup()
                 .autoBackup()
                 .interval();
-        int timeSinceBackup = buildWorld.getData().timeSinceBackup().get();
+        int timeSinceBackup = buildWorld.getData().getTimeSinceBackup();
 
         int secondsRemaining = Math.max(0, timeUntilBackup - timeSinceBackup);
         return "%02d:%02d".formatted(secondsRemaining / 60, secondsRemaining % 60);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
@@ -188,10 +188,10 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
 
     private boolean isWorldValidForDisplay(BuildWorld buildWorld) {
         WorldData worldData = buildWorld.getData();
-        if (!this.worldStorage.isCorrectVisibility(worldData.privateWorld().get(), this.requiredVisibility)) {
+        if (!this.worldStorage.isCorrectVisibility(worldData.isPrivateWorld(), this.requiredVisibility)) {
             return false;
         }
-        if (!this.validStatuses.contains(worldData.status().get())) {
+        if (!this.validStatuses.contains(worldData.getStatus())) {
             return false;
         }
         if (!buildWorld.getPermissions().canEnter(this.player)) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -24,7 +24,7 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.google.common.collect.Sets;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
@@ -127,7 +127,7 @@ public class EditMenu extends Menu {
             String permission,
             String itemKey,
             String loreKey,
-            Function<WorldData, Type<Boolean>> data) {}
+            Function<WorldData, Property<Boolean>> data) {}
 
     private final BuildSystemPlugin plugin;
     private final PlayerServiceImpl playerManager;
@@ -177,7 +177,7 @@ public class EditMenu extends Menu {
         inv.setItem(
                 40,
                 InventoryUtils.createItem(
-                        plugin.getCustomizableIcons().getIcon(worldData.status().get()),
+                        plugin.getCustomizableIcons().getIcon(worldData.getStatus()),
                         messages.getString("worldeditor_status_item", player),
                         messages.getStringList(
                                 "worldeditor_status_lore",
@@ -198,9 +198,7 @@ public class EditMenu extends Menu {
                         messages.getStringList(
                                 "worldeditor_project_lore",
                                 player,
-                                Map.entry(
-                                        "%project%",
-                                        buildWorld.getData().project().get()))));
+                                Map.entry("%project%", buildWorld.getData().getProject()))));
         inv.setItem(
                 42,
                 InventoryUtils.createItem(
@@ -209,15 +207,13 @@ public class EditMenu extends Menu {
                         messages.getStringList(
                                 "worldeditor_permission_lore",
                                 player,
-                                Map.entry(
-                                        "%permission%",
-                                        buildWorld.getData().permission().get()))));
+                                Map.entry("%permission%", buildWorld.getData().getPermission()))));
     }
 
     private void addBuildWorldInfoItem(Player player, Inventory inventory) {
         String worldName = buildWorld.getName();
         String displayName = messages.getString("worldeditor_world_item", player, Map.entry("%world%", worldName));
-        XMaterial material = buildWorld.getData().material().get();
+        XMaterial material = buildWorld.getData().getMaterial();
 
         if (material == XMaterial.PLAYER_HEAD) {
             plugin.getMenuItems().addWorldItem(inventory, 4, buildWorld, displayName, new ArrayList<>());
@@ -267,7 +263,7 @@ public class EditMenu extends Menu {
                             inventory,
                             30,
                             XMaterial.IRON_PICKAXE,
-                            buildWorld.getData().buildersEnabled().get(),
+                            buildWorld.getData().isBuildersEnabled(),
                             "worldeditor_builders_item",
                             "worldeditor_builders_lore");
         } else {
@@ -283,7 +279,7 @@ public class EditMenu extends Menu {
     private void addVisibilityItem(Player player, Inventory inventory) {
         int slot = 32;
         String displayName = messages.getString("worldeditor_visibility_item", player);
-        boolean isPrivate = buildWorld.getData().privateWorld().get();
+        boolean isPrivate = buildWorld.getData().isPrivateWorld();
 
         if (!playerManager.canCreateWorld(player, Visibility.matchVisibility(isPrivate))) {
             inventory.setItem(
@@ -304,7 +300,7 @@ public class EditMenu extends Menu {
 
     private void addDifficultyItem(Player player, Inventory inventory) {
         XMaterial material =
-                switch (buildWorld.getData().difficulty().get()) {
+                switch (buildWorld.getData().getDifficulty()) {
                     case EASY -> XMaterial.GOLDEN_HELMET;
                     case NORMAL -> XMaterial.IRON_HELMET;
                     case HARD -> XMaterial.DIAMOND_HELMET;
@@ -323,7 +319,7 @@ public class EditMenu extends Menu {
     }
 
     private String getDifficultyName(BuildWorld buildWorld, Player player) {
-        return switch (buildWorld.getData().difficulty().get()) {
+        return switch (buildWorld.getData().getDifficulty()) {
             case PEACEFUL -> messages.getString("difficulty_peaceful", player);
             case EASY -> messages.getString("difficulty_easy", player);
             case NORMAL -> messages.getString("difficulty_normal", player);
@@ -345,7 +341,7 @@ public class EditMenu extends Menu {
         Toggle toggle = TOGGLES.get(event.getSlot());
         if (toggle != null) {
             if (requirePermission(player, toggle.permission())) {
-                Type<Boolean> data = toggle.data().apply(worldData);
+                Property<Boolean> data = toggle.data().apply(worldData);
                 data.set(!data.get());
                 reopen(player);
             }
@@ -376,7 +372,7 @@ public class EditMenu extends Menu {
                     new BuilderMenu(plugin, buildWorld, player).open(player);
                     return;
                 }
-                worldData.buildersEnabled().set(!worldData.buildersEnabled().get());
+                worldData.setBuildersEnabled(!worldData.isBuildersEnabled());
             }
             case 32 -> {
                 if (itemStack.getType() == XMaterial.BARRIER.get()) {
@@ -384,7 +380,7 @@ public class EditMenu extends Menu {
                     return;
                 }
                 if (requirePermission(player, "buildsystem.edit.visibility")) {
-                    worldData.privateWorld().set(!worldData.privateWorld().get());
+                    worldData.setPrivateWorld(!worldData.isPrivateWorld());
                 }
             }
             case 38 -> {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -94,7 +94,7 @@ public class StatusMenu extends Menu {
         itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemStack.setItemMeta(itemMeta);
 
-        if (buildWorld.getData().status().get() == status) {
+        if (buildWorld.getData().getStatus() == status) {
             itemStack.addUnsafeEnchantment(XEnchantment.UNBREAKING.get(), 1);
         }
 
@@ -125,7 +125,7 @@ public class StatusMenu extends Menu {
         }
 
         player.closeInventory();
-        buildWorld.getData().status().set(status);
+        buildWorld.getData().setStatus(status);
         plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
         XSound.ENTITY_CHICKEN_EGG.play(player);

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansionTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansionTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.eintosti.buildsystem.api.data.Type;
 import de.eintosti.buildsystem.api.player.settings.NavigatorType;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.api.world.BuildWorld;
@@ -119,11 +118,8 @@ class PlaceholderApiExpansionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void world_permission_returnsValue() {
-        Type<String> attr = mock(Type.class);
-        when(worldData.permission()).thenReturn(attr);
-        when(attr.get()).thenReturn("buildsystem.world.test");
+        when(worldData.getPermission()).thenReturn("buildsystem.world.test");
         assertEquals("buildsystem.world.test", expansion.onPlaceholderRequest(player, "permission"));
     }
 

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
 import de.eintosti.buildsystem.api.world.builder.Builders;
@@ -60,10 +60,8 @@ class WorldProtectionPolicyTest {
         when(permissions.canBypassBuildRestriction(player)).thenReturn(false);
         when(player.hasPermission("buildsystem.bypass.archive")).thenReturn(false);
         when(player.hasPermission("buildsystem.bypass.builders")).thenReturn(false);
-        Type<BuildWorldStatus> status = mockType(BuildWorldStatus.NOT_STARTED);
-        when(data.status()).thenReturn(status);
-        Type<Boolean> buildersEnabled = mockType(false);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.NOT_STARTED);
+        when(data.isBuildersEnabled()).thenReturn(false);
         when(builders.isCreator(player)).thenReturn(false);
         when(builders.isBuilder(player)).thenReturn(false);
     }
@@ -71,10 +69,8 @@ class WorldProtectionPolicyTest {
     @Test
     void bypass_shortCircuitsEverything() {
         when(permissions.canBypassBuildRestriction(player)).thenReturn(true);
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkArchive(player, world));
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -84,16 +80,14 @@ class WorldProtectionPolicyTest {
     @Test
     void archiveBypassPermission_shortCircuitsArchiveCheck() {
         when(player.hasPermission("buildsystem.bypass.archive")).thenReturn(true);
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
 
         assertEquals(Denial.NONE, policy.checkArchive(player, world));
     }
 
     @Test
     void archivedWorld_noBypass_returnsArchived() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
 
         assertEquals(Denial.ARCHIVED, policy.checkArchive(player, world));
     }
@@ -105,16 +99,14 @@ class WorldProtectionPolicyTest {
 
     @Test
     void buildersEnabled_nonBuilder_notCreator_returnsNotABuilder() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NOT_A_BUILDER, policy.checkBuilders(player, world));
     }
 
     @Test
     void buildersEnabled_isCreator_returnsNone() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
         when(builders.isCreator(player)).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -122,8 +114,7 @@ class WorldProtectionPolicyTest {
 
     @Test
     void buildersEnabled_isBuilder_returnsNone() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
         when(builders.isBuilder(player)).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -137,30 +128,27 @@ class WorldProtectionPolicyTest {
     @Test
     void buildersPermission_shortCircuitsBuildersCheck() {
         when(player.hasPermission("buildsystem.bypass.builders")).thenReturn(true);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
     }
 
     @Test
     void settingDisabled_returnsSettingDisabled() {
-        Type<Boolean> setting = mockType(false);
+        Property<Boolean> setting = mockProperty(false);
         assertEquals(Denial.SETTING_DISABLED, policy.checkSetting(player, world, setting));
     }
 
     @Test
     void settingEnabled_returnsNone() {
-        Type<Boolean> setting = mockType(true);
+        Property<Boolean> setting = mockProperty(true);
         assertEquals(Denial.NONE, policy.checkSetting(player, world, setting));
     }
 
     @Test
     void mayModify_archive_winsOverBuilders() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         // Archive denial takes precedence over builder denial
         assertEquals(Denial.ARCHIVED, policy.mayModify(player, world));
@@ -168,18 +156,16 @@ class WorldProtectionPolicyTest {
 
     @Test
     void mayModify_withSetting_settingDisabled_winsOverBuilders() {
-        Type<Boolean> setting = mockType(false);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        Property<Boolean> setting = mockProperty(false);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.SETTING_DISABLED, policy.mayModify(player, world, setting));
     }
 
     @Test
     void mayModify_withSetting_archiveWinsOverSetting() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> setting = mockType(false);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        Property<Boolean> setting = mockProperty(false);
 
         assertEquals(Denial.ARCHIVED, policy.mayModify(player, world, setting));
     }
@@ -190,8 +176,8 @@ class WorldProtectionPolicyTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Type<T> mockType(T value) {
-        Type<T> t = mock(Type.class);
+    private static <T> Property<T> mockProperty(T value) {
+        Property<T> t = mock(Property.class);
         when(t.get()).thenReturn(value);
         return t;
     }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
+import de.eintosti.buildsystem.world.data.WorldDataImpl.WorldDataBuilder;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+@NullMarked
+class WorldDataAccessorTest {
+
+    private WorldDataImpl newWorldData() {
+        return new WorldDataBuilder("test-world").build();
+    }
+
+    @Test
+    void flatSetter_isReflectedByFlatGetterAndProperty() {
+        WorldDataImpl data = newWorldData();
+
+        data.setStatus(BuildWorldStatus.FINISHED);
+
+        assertEquals(BuildWorldStatus.FINISHED, data.getStatus());
+        assertEquals(BuildWorldStatus.FINISHED, data.status().get());
+    }
+
+    @Test
+    void propertySetter_isReflectedByFlatGetter() {
+        WorldDataImpl data = newWorldData();
+
+        data.status().set(BuildWorldStatus.ARCHIVE);
+
+        assertEquals(BuildWorldStatus.ARCHIVE, data.getStatus());
+        assertEquals(BuildWorldStatus.ARCHIVE, data.status().get());
+    }
+
+    @Test
+    void booleanFlatSetter_isReflectedByPropertyAndFlatGetter() {
+        WorldDataImpl data = newWorldData();
+
+        data.setPhysics(false);
+
+        assertEquals(false, data.isPhysics());
+        assertEquals(false, data.physics().get());
+    }
+}


### PR DESCRIPTION
## What (breaking, API)

Cleans up the public world-data API surface — the highest-value break to make before stabilizing.

- **`Type<T>` → `Property<T>`** (renamed). "Type" collided with `BuildWorldType`/the general notion of a type; the thing is a settable world *property*.
- **Persistence no longer leaks into the public API.** `getConfigFormat()` is removed from the public interface and lives on a new core-only `PersistentProperty<T>` (implemented by `ConfigurableProperty`, née `ConfigurableType`). `WorldData.getAllData()` is dropped from the public interface (the YAML storage reaches the serialization map via the impl).
- **Flat convenience accessors** added to `WorldData` for the common case — `getStatus()/setStatus()`, `getPermission()/setPermission()`, `isPhysics()/setPhysics()`, etc. — instead of the verbose `getData().status().get()/.set()` chain. The property objects remain for advanced capability use (`Bypassable`/`Overridable`).

## Why now

`@since TODO` API isn't released yet, and these are all source-breaking changes — they have to happen before 4.0 stabilizes. Removing the persistence hooks decouples future storage backends from the published API.

## Verification

- `grep getConfigFormat buildsystem-api/src` → empty; `grep '\bType<' buildsystem-api/src buildsystem-core/src/main` → empty; `WorldData` has no `getAllData()`.
- New `WorldDataAccessorTest` proves the flat accessors and property objects stay in sync.
- `./gradlew clean build` (incl. javadoc) + `spotlessCheck` pass.

## Merge ordering

Branches off plain master (`90b8bc50`); does **not** include the open 4.0 feature PRs. Because it renames `Type`→`Property` across `WorldData`, it will conflict with #450/#452 (which add `WorldData` members). Recommended: merge the feature PRs first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)