### PR TITLE
refactor(api)!: rename Type to Property, split persistence out, add DRY flat accessors

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Capability.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Capability.java
@@ -18,7 +18,7 @@
 package de.eintosti.buildsystem.api.data;
 
 /**
- * A marker interface for a "capability" or "attachment" that can be added to a {@link Type}.
+ * A marker interface for a "capability" or "attachment" that can be added to a {@link Property}.
  *
  * @since 3.0.1
  */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Overridable.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Overridable.java
@@ -23,7 +23,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A {@link Capability} that marks a {@link Type} as being overridable by an external source.
+ * A {@link Capability} that marks a {@link Property} as being overridable by an external source.
  *
  * @param <T> The type of the value being overridden
  * @param isEnabled A supplier that returns {@code true} if the override is active

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Property.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/data/Property.java
@@ -21,21 +21,21 @@ import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A generic interface representing a configurable data type.
+ * A generic interface representing a mutable data property.
  *
  * @param <T> The type of the value held by this data point
  */
 @NullMarked
-public interface Type<T> {
+public interface Property<T> {
 
     /**
-     * An immutable implementation of the {@link Type} interface using a Java Record. This class holds a final,
+     * An immutable implementation of the {@link Property} interface using a Java Record. This class holds a final,
      * read-only value.
      *
      * @param <T> The type of the value held
      * @param value The immutable value
      */
-    record ImmutableType<T>(T value) implements Type<T> {
+    record Immutable<T>(T value) implements Property<T> {
 
         /**
          * Gets the immutable value.
@@ -48,32 +48,22 @@ public interface Type<T> {
         }
 
         /**
-         * Throws {@link UnsupportedOperationException} as this type is immutable.
+         * Throws {@link UnsupportedOperationException} as this property is immutable.
          *
          * @param value The value to set (which is ignored)
-         * @throws UnsupportedOperationException Always, as this type cannot be modified
+         * @throws UnsupportedOperationException Always, as this property cannot be modified
          */
         @Contract("_ -> fail")
         @Override
         public void set(T value) {
-            throw new UnsupportedOperationException("This Type is immutable and cannot be modified.");
-        }
-
-        /**
-         * Gets the immutable value formatted for storage.
-         *
-         * @return The immutable value
-         */
-        @Override
-        public Object getConfigFormat() {
-            return value;
+            throw new UnsupportedOperationException("This Property is immutable and cannot be modified.");
         }
     }
 
     /**
-     * An immutable {@link Type} representing the boolean value {@code true}.
+     * An immutable {@link Property} representing the boolean value {@code true}.
      */
-    Type<Boolean> TRUE = new ImmutableType<>(true);
+    Property<Boolean> TRUE = new Immutable<>(true);
 
     /**
      * Gets the current value of this data point.
@@ -88,12 +78,4 @@ public interface Type<T> {
      * @param value The new value to set
      */
     void set(T value);
-
-    /**
-     * Gets the value of this data point formatted for storage in a configuration file. This might involve converting
-     * complex objects into simpler types (e.g., enums to strings).
-     *
-     * @return The value formatted for a config file
-     */
-    Object getConfigFormat();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
@@ -17,7 +17,7 @@
  */
 package de.eintosti.buildsystem.api.world.access;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -74,10 +74,10 @@ public interface WorldPermissions {
      * </ul>
      *
      * @param player The player attempting to modify the world
-     * @param check The specific data type representing the modification to be checked
+     * @param check The specific data property representing the modification to be checked
      * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
      */
-    boolean canModify(Player player, Type<Boolean> check);
+    boolean canModify(Player player, Property<Boolean> check);
 
     /**
      * Checks if the given {@link Player} is permitted to execute a specific command within the context of the current

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
@@ -18,10 +18,9 @@
 package de.eintosti.buildsystem.api.world.data;
 
 import com.cryptomorin.xseries.XMaterial;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.Backup;
-import java.util.Map;
 import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.jspecify.annotations.NullMarked;
@@ -37,13 +36,33 @@ import org.jspecify.annotations.Nullable;
 public interface WorldData {
 
     /**
-     * Retrieves a {@link Type} object representing the custom spawn location of the {@link BuildWorld}. The value is
+     * Retrieves a {@link Property} object representing the custom spawn location of the {@link BuildWorld}. The value is
      * stored as a string in the format {@code x;y;z;yaw;pitch}.
      *
-     * @return A {@link Type} containing the custom spawn string
+     * @return A {@link Property} containing the custom spawn string
      * @see #getCustomSpawnLocation()
      */
-    Type<String> customSpawn();
+    Property<String> customSpawn();
+
+    /**
+     * Gets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
+     *
+     * @return The custom spawn string
+     * @since TODO
+     */
+    default String getCustomSpawn() {
+        return customSpawn().get();
+    }
+
+    /**
+     * Sets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
+     *
+     * @param customSpawn The custom spawn string
+     * @since TODO
+     */
+    default void setCustomSpawn(String customSpawn) {
+        customSpawn().set(customSpawn);
+    }
 
     /**
      * Gets the {@link BuildWorld}'s custom spawn as a {@link Location} object.
@@ -53,150 +72,502 @@ public interface WorldData {
     @Nullable Location getCustomSpawnLocation();
 
     /**
-     * Retrieves a {@link Type} object representing the permission required to enter the {@link BuildWorld}. Returns "-"
-     * if no specific permission is required.
+     * Retrieves a {@link Property} object representing the permission required to enter the {@link BuildWorld}. Returns
+     * "-" if no specific permission is required.
      *
-     * @return A {@link Type} containing the permission string
+     * @return A {@link Property} containing the permission string
      */
-    Type<String> permission();
+    Property<String> permission();
 
     /**
-     * Retrieves a {@link Type} object representing the project description of the {@link BuildWorld}. This typically
-     * provides a brief overview or purpose of the world.
+     * Gets the permission required to enter the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing the project description string
-     */
-    Type<String> project();
-
-    /**
-     * Retrieves a {@link Type} object representing the {@link Difficulty} of the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing the world's difficulty setting
-     */
-    Type<Difficulty> difficulty();
-
-    /**
-     * Retrieves a {@link Type} object representing the {@link XMaterial} used to display the {@link BuildWorld} in the
-     * navigator menus.
-     *
-     * @return A {@link Type} containing the material used for display
-     */
-    Type<XMaterial> material();
-
-    /**
-     * Retrieves a {@link Type} object representing the current {@link BuildWorldStatus} of the world. This indicates
-     * the building progression or state of the world.
-     *
-     * @return A {@link Type} containing the current build status
-     */
-    Type<BuildWorldStatus> status();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether block breaking is allowed in the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if allowed, otherwise {@code false}
-     */
-    Type<Boolean> blockBreaking();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether block interactions (e.g., opening doors, chests) are enabled
-     * in the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Type<Boolean> blockInteractions();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether block placement is allowed in the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if allowed, otherwise {@code false}
-     */
-    Type<Boolean> blockPlacement();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether the "builders feature" is enabled in the {@link BuildWorld}.
-     * When enabled, only designated builders can modify the world.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Type<Boolean> buildersEnabled();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether explosions are enabled in the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Type<Boolean> explosions();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether entities in the {@link BuildWorld} have artificial
-     * intelligence.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Type<Boolean> mobAi();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether physics (e.g., gravity, fluid flow) is applied to blocks in
-     * the {@link BuildWorld}.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Type<Boolean> physics();
-
-    /**
-     * Retrieves a {@link Type} object indicating whether this world is pinned to the top of the navigator, ahead of
-     * unpinned worlds regardless of the active sort order.
-     *
-     * @return A {@link Type} containing a boolean: {@code true} if pinned, otherwise {@code false}
+     * @return The permission string
      * @since TODO
      */
-    Type<Boolean> pinned();
+    default String getPermission() {
+        return permission().get();
+    }
 
     /**
-     * Retrieves a {@link Type} object indicating whether the {@link BuildWorld} is set to private visibility. A private
-     * world is typically only accessible to its creator and designated builders.
+     * Sets the permission required to enter the {@link BuildWorld}.
      *
-     * @return A {@link Type} containing a boolean: {@code true} if private, otherwise {@code false}
+     * @param permission The permission string
+     * @since TODO
      */
-    Type<Boolean> privateWorld();
+    default void setPermission(String permission) {
+        permission().set(permission);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the project description of the {@link BuildWorld}. This typically
+     * provides a brief overview or purpose of the world.
+     *
+     * @return A {@link Property} containing the project description string
+     */
+    Property<String> project();
+
+    /**
+     * Gets the project description of the {@link BuildWorld}.
+     *
+     * @return The project description string
+     * @since TODO
+     */
+    default String getProject() {
+        return project().get();
+    }
+
+    /**
+     * Sets the project description of the {@link BuildWorld}.
+     *
+     * @param project The project description string
+     * @since TODO
+     */
+    default void setProject(String project) {
+        project().set(project);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing the world's difficulty setting
+     */
+    Property<Difficulty> difficulty();
+
+    /**
+     * Gets the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @return The world's difficulty setting
+     * @since TODO
+     */
+    default Difficulty getDifficulty() {
+        return difficulty().get();
+    }
+
+    /**
+     * Sets the {@link Difficulty} of the {@link BuildWorld}.
+     *
+     * @param difficulty The world's difficulty setting
+     * @since TODO
+     */
+    default void setDifficulty(Difficulty difficulty) {
+        difficulty().set(difficulty);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the {@link XMaterial} used to display the {@link BuildWorld} in
+     * the navigator menus.
+     *
+     * @return A {@link Property} containing the material used for display
+     */
+    Property<XMaterial> material();
+
+    /**
+     * Gets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
+     *
+     * @return The material used for display
+     * @since TODO
+     */
+    default XMaterial getMaterial() {
+        return material().get();
+    }
+
+    /**
+     * Sets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
+     *
+     * @param material The material used for display
+     * @since TODO
+     */
+    default void setMaterial(XMaterial material) {
+        material().set(material);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the current {@link BuildWorldStatus} of the world. This indicates
+     * the building progression or state of the world.
+     *
+     * @return A {@link Property} containing the current build status
+     */
+    Property<BuildWorldStatus> status();
+
+    /**
+     * Gets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
+     *
+     * @return The current build status
+     * @since TODO
+     */
+    default BuildWorldStatus getStatus() {
+        return status().get();
+    }
+
+    /**
+     * Sets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
+     *
+     * @param status The current build status
+     * @since TODO
+     */
+    default void setStatus(BuildWorldStatus status) {
+        status().set(status);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether block breaking is allowed in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
+     */
+    Property<Boolean> blockBreaking();
+
+    /**
+     * Gets whether block breaking is allowed in the {@link BuildWorld}.
+     *
+     * @return {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isBlockBreaking() {
+        return blockBreaking().get();
+    }
+
+    /**
+     * Sets whether block breaking is allowed in the {@link BuildWorld}.
+     *
+     * @param blockBreaking {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    default void setBlockBreaking(boolean blockBreaking) {
+        blockBreaking().set(blockBreaking);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether block interactions (e.g., opening doors, chests) are
+     * enabled in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> blockInteractions();
+
+    /**
+     * Gets whether block interactions are enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isBlockInteractions() {
+        return blockInteractions().get();
+    }
+
+    /**
+     * Sets whether block interactions are enabled in the {@link BuildWorld}.
+     *
+     * @param blockInteractions {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default void setBlockInteractions(boolean blockInteractions) {
+        blockInteractions().set(blockInteractions);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
+     */
+    Property<Boolean> blockPlacement();
+
+    /**
+     * Gets whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @return {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isBlockPlacement() {
+        return blockPlacement().get();
+    }
+
+    /**
+     * Sets whether block placement is allowed in the {@link BuildWorld}.
+     *
+     * @param blockPlacement {@code true} if allowed, otherwise {@code false}
+     * @since TODO
+     */
+    default void setBlockPlacement(boolean blockPlacement) {
+        blockPlacement().set(blockPlacement);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether the "builders feature" is enabled in the
+     * {@link BuildWorld}. When enabled, only designated builders can modify the world.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> buildersEnabled();
+
+    /**
+     * Gets whether the "builders feature" is enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isBuildersEnabled() {
+        return buildersEnabled().get();
+    }
+
+    /**
+     * Sets whether the "builders feature" is enabled in the {@link BuildWorld}.
+     *
+     * @param buildersEnabled {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default void setBuildersEnabled(boolean buildersEnabled) {
+        buildersEnabled().set(buildersEnabled);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> explosions();
+
+    /**
+     * Gets whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isExplosions() {
+        return explosions().get();
+    }
+
+    /**
+     * Sets whether explosions are enabled in the {@link BuildWorld}.
+     *
+     * @param explosions {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default void setExplosions(boolean explosions) {
+        explosions().set(explosions);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether entities in the {@link BuildWorld} have artificial
+     * intelligence.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> mobAi();
+
+    /**
+     * Gets whether entities in the {@link BuildWorld} have artificial intelligence.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isMobAi() {
+        return mobAi().get();
+    }
+
+    /**
+     * Sets whether entities in the {@link BuildWorld} have artificial intelligence.
+     *
+     * @param mobAi {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default void setMobAi(boolean mobAi) {
+        mobAi().set(mobAi);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether physics (e.g., gravity, fluid flow) is applied to blocks in
+     * the {@link BuildWorld}.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
+     */
+    Property<Boolean> physics();
+
+    /**
+     * Gets whether physics is applied to blocks in the {@link BuildWorld}.
+     *
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isPhysics() {
+        return physics().get();
+    }
+
+    /**
+     * Sets whether physics is applied to blocks in the {@link BuildWorld}.
+     *
+     * @param physics {@code true} if enabled, otherwise {@code false}
+     * @since TODO
+     */
+    default void setPhysics(boolean physics) {
+        physics().set(physics);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether this world is pinned to the top of the navigator, ahead of
+     * unpinned worlds regardless of the active sort order.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if pinned, otherwise {@code false}
+     * @since TODO
+     */
+    Property<Boolean> pinned();
+
+    /**
+     * Gets whether this world is pinned to the top of the navigator.
+     *
+     * @return {@code true} if pinned, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isPinned() {
+        return pinned().get();
+    }
+
+    /**
+     * Sets whether this world is pinned to the top of the navigator.
+     *
+     * @param pinned {@code true} if pinned, otherwise {@code false}
+     * @since TODO
+     */
+    default void setPinned(boolean pinned) {
+        pinned().set(pinned);
+    }
+
+    /**
+     * Retrieves a {@link Property} object indicating whether the {@link BuildWorld} is set to private visibility. A
+     * private world is typically only accessible to its creator and designated builders.
+     *
+     * @return A {@link Property} containing a boolean: {@code true} if private, otherwise {@code false}
+     */
+    Property<Boolean> privateWorld();
+
+    /**
+     * Gets whether the {@link BuildWorld} is set to private visibility.
+     *
+     * @return {@code true} if private, otherwise {@code false}
+     * @since TODO
+     */
+    default boolean isPrivateWorld() {
+        return privateWorld().get();
+    }
+
+    /**
+     * Sets whether the {@link BuildWorld} is set to private visibility.
+     *
+     * @param privateWorld {@code true} if private, otherwise {@code false}
+     * @since TODO
+     */
+    default void setPrivateWorld(boolean privateWorld) {
+        privateWorld().set(privateWorld);
+    }
 
     /**
      * Gets the number of seconds that have passed since that last {@link Backup} of the {@link BuildWorld} was created.
      *
      * @return The number of seconds since the last backup
      */
-    Type<Integer> timeSinceBackup();
+    Property<Integer> timeSinceBackup();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
+     *
+     * @return The number of seconds since the last backup
+     * @since TODO
+     */
+    default int getTimeSinceBackup() {
+        return timeSinceBackup().get();
+    }
+
+    /**
+     * Sets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
+     *
+     * @param timeSinceBackup The number of seconds since the last backup
+     * @since TODO
+     */
+    default void setTimeSinceBackup(int timeSinceBackup) {
+        timeSinceBackup().set(timeSinceBackup);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was edited.
      *
-     * @return A {@link Type} containing the last edited timestamp
+     * @return A {@link Property} containing the last edited timestamp
      */
-    Type<Long> lastEdited();
+    Property<Long> lastEdited();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
+     *
+     * @return The last edited timestamp
+     * @since TODO
+     */
+    default long getLastEdited() {
+        return lastEdited().get();
+    }
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
+     *
+     * @param lastEdited The last edited timestamp
+     * @since TODO
+     */
+    default void setLastEdited(long lastEdited) {
+        lastEdited().set(lastEdited);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was loaded.
      *
-     * @return A {@link Type} containing the last loaded timestamp
+     * @return A {@link Property} containing the last loaded timestamp
      */
-    Type<Long> lastLoaded();
+    Property<Long> lastLoaded();
 
     /**
-     * Retrieves a {@link Type} object representing the timestamp (in milliseconds since epoch) of the last time the
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
+     *
+     * @return The last loaded timestamp
+     * @since TODO
+     */
+    default long getLastLoaded() {
+        return lastLoaded().get();
+    }
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
+     *
+     * @param lastLoaded The last loaded timestamp
+     * @since TODO
+     */
+    default void setLastLoaded(long lastLoaded) {
+        lastLoaded().set(lastLoaded);
+    }
+
+    /**
+     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
      * {@link BuildWorld} was unloaded.
      *
-     * @return A {@link Type} containing the last unloaded timestamp
+     * @return A {@link Property} containing the last unloaded timestamp
      */
-    Type<Long> lastUnloaded();
+    Property<Long> lastUnloaded();
 
     /**
-     * Gets a map of all configurable data points for the {@link BuildWorld}.
+     * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
      *
-     * @return An unmodifiable map where keys are data point names and values are their corresponding {@link Type}
-     *     objects
+     * @return The last unloaded timestamp
+     * @since TODO
      */
-    Map<String, Type<?>> getAllData();
+    default long getLastUnloaded() {
+        return lastUnloaded().get();
+    }
+
+    /**
+     * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
+     *
+     * @param lastUnloaded The last unloaded timestamp
+     * @since TODO
+     */
+    default void setLastUnloaded(long lastUnloaded) {
+        lastUnloaded().set(lastUnloaded);
+    }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
@@ -57,7 +57,7 @@ public class PhysicsCommand extends CommandBase {
                 if (args[0].equalsIgnoreCase("all") && !worldStorage.worldExists("all")) {
                     worldStorage
                             .getBuildWorlds()
-                            .forEach(world -> world.getData().physics().set(true));
+                            .forEach(world -> world.getData().setPhysics(true));
                     messages.sendMessage(player, "physics_activated_all");
                 } else {
                     togglePhysics(player, Bukkit.getWorld(args[0]));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/RemoveSpawnSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/RemoveSpawnSubCommand.java
@@ -47,7 +47,7 @@ public class RemoveSpawnSubCommand extends AbstractSubCommand {
             return;
         }
 
-        buildWorld.getData().customSpawn().set("");
+        buildWorld.getData().setCustomSpawn("");
         messages.sendMessage(
                 player, "worlds_removespawn_world_spawn_removed", Map.entry("%world%", buildWorld.getName()));
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetItemSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetItemSubCommand.java
@@ -50,7 +50,7 @@ public class SetItemSubCommand extends AbstractSubCommand {
             return;
         }
 
-        buildWorld.getData().material().set(XMaterial.matchXMaterial(itemStack));
+        buildWorld.getData().setMaterial(XMaterial.matchXMaterial(itemStack));
         messages.sendMessage(player, "worlds_setitem_set", Map.entry("%world%", buildWorld.getName()));
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetPermissionSubCommand.java
@@ -65,7 +65,7 @@ public class SetPermissionSubCommand extends AbstractSubCommand {
                 return;
             }
 
-            buildWorld.getData().permission().set(permission);
+            buildWorld.getData().setPermission(permission);
             plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
             XSound.ENTITY_PLAYER_LEVELUP.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetProjectSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetProjectSubCommand.java
@@ -49,7 +49,7 @@ public class SetProjectSubCommand extends AbstractSubCommand {
 
     public void getProjectInput(Player player, BuildWorld buildWorld, boolean closeInventory) {
         new PlayerChatInput(plugin, player, "enter_world_project", input -> {
-            buildWorld.getData().project().set(input.trim());
+            buildWorld.getData().setProject(input.trim());
             plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
             XSound.ENTITY_PLAYER_LEVELUP.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
@@ -39,7 +39,7 @@ final class WorldsCompletions {
             Player player, WorldStorage worldStorage, @Nullable String commandPermission, String input) {
         List<String> result = new ArrayList<>();
         for (BuildWorld world : worldStorage.getBuildWorlds()) {
-            String worldPerm = world.getData().permission().get();
+            String worldPerm = world.getData().getPermission();
             if ((player.hasPermission(worldPerm) || worldPerm.equalsIgnoreCase("-"))
                     && world.getPermissions().canPerformCommand(player, commandPermission)) {
                 addIfStartsWith(input, world.getName(), result);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansion.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansion.java
@@ -142,28 +142,27 @@ public class PlaceholderApiExpansion extends PlaceholderExpansion {
         Builders builders = buildWorld.getBuilders();
         WorldData worldData = buildWorld.getData();
         return switch (identifier.toLowerCase(Locale.ROOT)) {
-            case "blockbreaking" -> String.valueOf(worldData.blockBreaking().get());
-            case "blockplacement" -> String.valueOf(worldData.blockPlacement().get());
+            case "blockbreaking" -> String.valueOf(worldData.isBlockBreaking());
+            case "blockplacement" -> String.valueOf(worldData.isBlockPlacement());
             case "builders" -> builders.asPlaceholder(player);
-            case "buildersenabled" -> String.valueOf(worldData.buildersEnabled().get());
+            case "buildersenabled" -> String.valueOf(worldData.isBuildersEnabled());
             case "creation" -> messages.formatDate(buildWorld.getCreation());
             case "creator" -> builders.hasCreator() ? builders.getCreator().getName() : "-";
             case "creatorid" ->
                 builders.hasCreator() ? String.valueOf(builders.getCreator().getUniqueId()) : "-";
-            case "explosions" -> String.valueOf(worldData.explosions().get());
-            case "lastedited" -> messages.formatDate(worldData.lastEdited().get());
-            case "lastloaded" -> messages.formatDate(worldData.lastLoaded().get());
-            case "lastunloaded" -> messages.formatDate(worldData.lastUnloaded().get());
+            case "explosions" -> String.valueOf(worldData.isExplosions());
+            case "lastedited" -> messages.formatDate(worldData.getLastEdited());
+            case "lastloaded" -> messages.formatDate(worldData.getLastLoaded());
+            case "lastunloaded" -> messages.formatDate(worldData.getLastUnloaded());
             case "loaded" -> String.valueOf(buildWorld.isLoaded());
-            case "material" -> worldData.material().get().name();
-            case "mobai" -> String.valueOf(worldData.mobAi().get());
-            case "permission" -> worldData.permission().get();
-            case "private" -> String.valueOf(worldData.privateWorld().get());
-            case "project" -> worldData.project().get();
-            case "physics" -> String.valueOf(worldData.physics().get());
-            case "spawn" -> worldData.customSpawn().get();
-            case "status" ->
-                messages.getString(Messages.getMessageKey(worldData.status().get()), player);
+            case "material" -> worldData.getMaterial().name();
+            case "mobai" -> String.valueOf(worldData.isMobAi());
+            case "permission" -> worldData.getPermission();
+            case "private" -> String.valueOf(worldData.isPrivateWorld());
+            case "project" -> worldData.getProject();
+            case "physics" -> String.valueOf(worldData.isPhysics());
+            case "spawn" -> worldData.getCustomSpawn();
+            case "status" -> messages.getString(Messages.getMessageKey(worldData.getStatus()), player);
             case "time" -> buildWorld.getWorldTime();
             case "type" -> messages.getString(Messages.getMessageKey(buildWorld.getType()), player);
             case "world" -> buildWorld.getName();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/worldedit/EditSessionListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/worldedit/EditSessionListener.java
@@ -67,7 +67,7 @@ public class EditSessionListener implements Listener {
         }
 
         if (buildWorld.getPermissions().hasAdminPermission(player)) {
-            buildWorld.getData().lastEdited().set(System.currentTimeMillis());
+            buildWorld.getData().setLastEdited(System.currentTimeMillis());
             return;
         }
 
@@ -81,6 +81,6 @@ public class EditSessionListener implements Listener {
             return;
         }
 
-        buildWorld.getData().lastEdited().set(System.currentTimeMillis());
+        buildWorld.getData().setLastEdited(System.currentTimeMillis());
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
@@ -211,7 +211,7 @@ public class NavigatorListener implements Listener {
      */
     private void disableArchivedWorlds(Player player, Cancellable cancellable) {
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld());
-        if (buildWorld == null || buildWorld.getData().status().get() != BuildWorldStatus.ARCHIVE) {
+        if (buildWorld == null || buildWorld.getData().getStatus() != BuildWorldStatus.ARCHIVE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
@@ -74,7 +74,7 @@ public class PlayerChangedWorldListener implements Listener {
 
         BuildWorld newWorld = worldStorage.getBuildWorld(worldName);
         if (newWorld != null
-                && !newWorld.getData().physics().get()
+                && !newWorld.getData().isPhysics()
                 && player.hasPermission("buildsystem.physics.message")) {
             plugin.getMessages()
                     .sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", newWorld.getName()));
@@ -112,7 +112,7 @@ public class PlayerChangedWorldListener implements Listener {
     private void setGoldBlock(@Nullable BuildWorld buildWorld) {
         if (buildWorld == null
                 || buildWorld.getType() != BuildWorldType.VOID
-                || buildWorld.getData().status().get() != BuildWorldStatus.NOT_STARTED) {
+                || buildWorld.getData().getStatus() != BuildWorldStatus.NOT_STARTED) {
             return;
         }
 
@@ -136,7 +136,7 @@ public class PlayerChangedWorldListener implements Listener {
                 .getCachedValues();
         cachedValues.resetArchiveStateIfPresent(player);
 
-        if (buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             cachedValues.saveArchiveState(player);
 
             removeArmorContent(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
@@ -50,7 +50,7 @@ public class BlockPhysicsListener implements Listener {
 
     private boolean physicsAllowed(World world) {
         BuildWorld buildWorld = worldStorage.getBuildWorld(world);
-        return buildWorld == null || buildWorld.getData().physics().get();
+        return buildWorld == null || buildWorld.getData().isPhysics();
     }
 
     @EventHandler

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/EntitySpawnListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/EntitySpawnListener.java
@@ -44,7 +44,7 @@ public class EntitySpawnListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(bukkitWorld.getName());
-        if (buildWorld == null || buildWorld.getData().mobAi().get()) {
+        if (buildWorld == null || buildWorld.getData().isMobAi()) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/FoodLevelChangeListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/FoodLevelChangeListener.java
@@ -43,7 +43,7 @@ public class FoodLevelChangeListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld());
-        if (buildWorld != null && buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (buildWorld != null && buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             event.setCancelled(true);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
@@ -19,7 +19,7 @@ package de.eintosti.buildsystem.listener.world;
 
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.event.world.BuildWorldManipulationEvent;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -97,7 +97,7 @@ public class WorldManipulateListener implements Listener {
 
         dispatcher.tryDispatchManipulationEvent(player, event);
 
-        if (!buildWorld.getData().physics().get() && event.getClickedBlock() != null) {
+        if (!buildWorld.getData().isPhysics() && event.getClickedBlock() != null) {
             if (event.getAction() == Action.PHYSICAL && event.getClickedBlock().getType() == XMaterial.FARMLAND.get()) {
                 event.setCancelled(true);
             }
@@ -115,18 +115,18 @@ public class WorldManipulateListener implements Listener {
         WorldData worldData = buildWorld.getData();
         Cancellable parentEvent = event.getParentEvent();
 
-        Type<Boolean> setting = worldSettingFor(parentEvent, worldData);
+        Property<Boolean> setting = worldSettingFor(parentEvent, worldData);
         if (!buildWorld.getPermissions().canModify(player, setting)) {
             parentEvent.setCancelled(true);
             denyPlayerInteraction(event);
             return;
         }
 
-        worldData.lastEdited().set(System.currentTimeMillis());
+        worldData.setLastEdited(System.currentTimeMillis());
         updateStatus(worldData, player);
     }
 
-    private Type<Boolean> worldSettingFor(Cancellable event, WorldData data) {
+    private Property<Boolean> worldSettingFor(Cancellable event, WorldData data) {
         return switch (event) {
             case BlockBreakEvent ignored -> data.blockBreaking();
             case BlockPlaceEvent ignored -> data.blockPlacement();
@@ -142,8 +142,8 @@ public class WorldManipulateListener implements Listener {
     }
 
     private void updateStatus(WorldData worldData, Player player) {
-        if (worldData.status().get() == BuildWorldStatus.NOT_STARTED) {
-            worldData.status().set(BuildWorldStatus.IN_PROGRESS);
+        if (worldData.getStatus() == BuildWorldStatus.NOT_STARTED) {
+            worldData.setStatus(BuildWorldStatus.IN_PROGRESS);
             plugin.getSettingsService().forceUpdateSidebar(player);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -110,7 +110,7 @@ public final class MenuItems {
      */
     public void addWorldItem(
             Inventory inventory, int slot, BuildWorld buildWorld, String displayName, List<String> lore) {
-        XMaterial material = buildWorld.getData().material().get();
+        XMaterial material = buildWorld.getData().getMaterial();
         if (material != XMaterial.PLAYER_HEAD) {
             inventory.setItem(slot, InventoryUtils.createItem(material, displayName, lore));
             return;
@@ -122,7 +122,7 @@ public final class MenuItems {
 
         XSkull.createItem()
                 .profile(
-                        buildWorld.getData().privateWorld().get()
+                        buildWorld.getData().isPrivateWorld()
                                 ? buildWorld.asProfilable()
                                 : Profileable.username(buildWorld.getName()))
                 .fallback(buildWorld.asProfilable())

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockManager.java
@@ -75,15 +75,15 @@ public class CustomBlockManager implements Listener {
         }
 
         boolean hadToDisablePhysics = false;
-        if (isBuildWorld && !buildWorld.getData().physics().get()) {
+        if (isBuildWorld && !buildWorld.getData().isPhysics()) {
             hadToDisablePhysics = true;
-            buildWorld.getData().physics().set(true);
+            buildWorld.getData().setPhysics(true);
         }
 
         setBlock(event, customBlock);
 
         if (isBuildWorld && hadToDisablePhysics) {
-            buildWorld.getData().physics().set(false);
+            buildWorld.getData().setPhysics(false);
         }
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
@@ -17,7 +17,7 @@
  */
 package de.eintosti.buildsystem.protection;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -40,7 +40,7 @@ public final class WorldProtectionPolicy {
             return Denial.NONE;
         }
 
-        if (world.getData().status().get() == BuildWorldStatus.ARCHIVE) {
+        if (world.getData().getStatus() == BuildWorldStatus.ARCHIVE) {
             return Denial.ARCHIVED;
         }
 
@@ -58,14 +58,14 @@ public final class WorldProtectionPolicy {
             return Denial.NONE;
         }
 
-        if (world.getData().buildersEnabled().get() && !builders.isBuilder(player)) {
+        if (world.getData().isBuildersEnabled() && !builders.isBuilder(player)) {
             return Denial.NOT_A_BUILDER;
         }
 
         return Denial.NONE;
     }
 
-    public Denial checkSetting(Player player, BuildWorld world, Type<Boolean> setting) {
+    public Denial checkSetting(Player player, BuildWorld world, Property<Boolean> setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }
@@ -90,7 +90,7 @@ public final class WorldProtectionPolicy {
         return checkBuilders(player, world);
     }
 
-    public Denial mayModify(Player player, BuildWorld world, Type<Boolean> setting) {
+    public Denial mayModify(Player player, BuildWorld world, Property<Boolean> setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/WorldStorageImpl.java
@@ -130,8 +130,7 @@ public abstract class WorldStorageImpl implements WorldStorage {
     @Unmodifiable
     public List<BuildWorld> getBuildWorldsCreatedByPlayer(Player player, Visibility visibility) {
         return getBuildWorldsCreatedByPlayer(player).stream()
-                .filter(buildWorld ->
-                        isCorrectVisibility(buildWorld.getData().privateWorld().get(), visibility))
+                .filter(buildWorld -> isCorrectVisibility(buildWorld.getData().isPrivateWorld(), visibility))
                 .toList();
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
@@ -24,7 +24,6 @@ import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
-import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
 import de.eintosti.buildsystem.world.BuildWorldImpl;
 import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
@@ -95,7 +94,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
             world.put("creator", builders.getCreator().toString());
         }
         world.put("type", buildWorld.getType().name());
-        world.put("data", serializeWorldData(buildWorld.getData()));
+        world.put("data", serializeWorldData((WorldDataImpl) buildWorld.getData()));
         world.put("date", buildWorld.getCreation());
         world.put("builders", serializeBuilders(builders.getAllBuilders()));
         if (buildWorld.getCustomGenerator() != null) {
@@ -105,7 +104,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
         return world;
     }
 
-    private Map<String, Object> serializeWorldData(WorldData worldData) {
+    private Map<String, Object> serializeWorldData(WorldDataImpl worldData) {
         return worldData.getAllData().entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey, entry -> entry.getValue().getConfigFormat()));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -171,7 +171,7 @@ public class WorldServiceImpl implements WorldService {
             return LoadResult.FAILED;
         }
 
-        buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
+        buildWorld.getData().setLastLoaded(System.currentTimeMillis());
         plugin.getLogger().info("✔ World loaded: " + worldName);
         return LoadResult.LOADED;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
@@ -10,11 +10,12 @@ package de.eintosti.buildsystem.world.backup;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.BackupProfile;
 import de.eintosti.buildsystem.api.world.backup.BackupStorage;
+import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.config.PluginConfig;
 import de.eintosti.buildsystem.world.backup.storage.LocalBackupStorage;
 import de.eintosti.buildsystem.world.backup.storage.S3BackupStorage;
@@ -153,7 +154,7 @@ public class BackupService {
         if (autoBackup.onlyActiveWorlds()) {
             for (Player pl : Bukkit.getOnlinePlayers()) {
                 BuildWorld buildWorld = worldStorage.getBuildWorld(pl.getWorld().getName());
-                if (buildWorld != null && buildWorld.getPermissions().canModify(pl, Type.TRUE)) {
+                if (buildWorld != null && buildWorld.getPermissions().canModify(pl, Property.TRUE)) {
                     worlds.add(buildWorld);
                 }
             }
@@ -162,12 +163,12 @@ public class BackupService {
         }
 
         worlds.forEach(buildWorld -> {
-            Type<Integer> timeSinceBackup = buildWorld.getData().timeSinceBackup();
-            timeSinceBackup.set((int) (timeSinceBackup.get() + UPDATE_PERIOD));
+            WorldData worldData = buildWorld.getData();
+            worldData.setTimeSinceBackup((int) (worldData.getTimeSinceBackup() + UPDATE_PERIOD));
 
-            if (timeSinceBackup.get() > autoBackup.interval()) {
+            if (worldData.getTimeSinceBackup() > autoBackup.interval()) {
                 getProfile(buildWorld).createBackup();
-                timeSinceBackup.set(0);
+                worldData.setTimeSinceBackup(0);
             }
         });
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
@@ -97,7 +97,7 @@ abstract class AbstractWorldCreator {
             folder.addWorld(bw);
         }
 
-        bw.getData().lastLoaded().set(System.currentTimeMillis());
+        bw.getData().setLastLoaded(System.currentTimeMillis());
         worldStorage.addBuildWorld(bw);
         Bukkit.getServer().getPluginManager().callEvent(new BuildWorldPostCreateEvent(bw, isImport()));
         return bw;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -20,11 +20,12 @@ package de.eintosti.buildsystem.world.data;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.data.Bypassable;
 import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.display.Folder;
-import de.eintosti.buildsystem.world.data.type.ConfigurableType;
+import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
+import de.eintosti.buildsystem.world.data.type.PersistentProperty;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -40,41 +41,41 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class WorldDataImpl implements WorldData {
 
-    private final Map<String, Type<?>> data = new HashMap<>();
+    private final Map<String, PersistentProperty<?>> data = new HashMap<>();
     private String worldName;
 
     private @Nullable Supplier<@Nullable Folder> folderResolver;
 
-    private final Type<String> customSpawn;
-    private final Type<String> permission;
-    private final Type<String> project;
+    private final Property<String> customSpawn;
+    private final Property<String> permission;
+    private final Property<String> project;
 
-    private final Type<Difficulty> difficulty;
-    private final Type<XMaterial> material;
-    private final Type<BuildWorldStatus> status;
+    private final Property<Difficulty> difficulty;
+    private final Property<XMaterial> material;
+    private final Property<BuildWorldStatus> status;
 
-    private final Type<Boolean> blockBreaking;
-    private final Type<Boolean> blockInteractions;
-    private final Type<Boolean> blockPlacement;
-    private final Type<Boolean> buildersEnabled;
-    private final Type<Boolean> explosions;
-    private final Type<Boolean> mobAi;
-    private final Type<Boolean> physics;
-    private final Type<Boolean> pinned;
-    private final Type<Boolean> privateWorld;
+    private final Property<Boolean> blockBreaking;
+    private final Property<Boolean> blockInteractions;
+    private final Property<Boolean> blockPlacement;
+    private final Property<Boolean> buildersEnabled;
+    private final Property<Boolean> explosions;
+    private final Property<Boolean> mobAi;
+    private final Property<Boolean> physics;
+    private final Property<Boolean> pinned;
+    private final Property<Boolean> privateWorld;
 
-    private final Type<Integer> timeSinceBackup;
-    private final Type<Long> lastEdited;
-    private final Type<Long> lastLoaded;
-    private final Type<Long> lastUnloaded;
+    private final Property<Integer> timeSinceBackup;
+    private final Property<Long> lastEdited;
+    private final Property<Long> lastLoaded;
+    private final Property<Long> lastUnloaded;
 
     private WorldDataImpl(WorldDataBuilder builder) {
         this.worldName = builder.worldName;
 
-        this.customSpawn = register("spawn", new ConfigurableType<>(builder.customSpawn));
+        this.customSpawn = register("spawn", new ConfigurableProperty<>(builder.customSpawn));
         this.permission = register(
                 "permission",
-                new ConfigurableType<>(builder.permission)
+                new ConfigurableProperty<>(builder.permission)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.permission"))
                         .withCapability(Overridable.class, new Overridable<>(builder.permissionOverrideEnabled, () -> {
                             Folder folder = getAssignedFolder();
@@ -82,45 +83,45 @@ public class WorldDataImpl implements WorldData {
                         })));
         this.project = register(
                 "project",
-                new ConfigurableType<>(builder.project)
+                new ConfigurableProperty<>(builder.project)
                         .withCapability(Overridable.class, new Overridable<>(builder.projectOverrideEnabled, () -> {
                             Folder folder = getAssignedFolder();
                             return (folder != null) ? folder.getProject() : null;
                         })));
 
         this.difficulty = register(
-                "difficulty", new ConfigurableType<>(builder.difficulty).withConfigFormatter(Difficulty::name));
+                "difficulty", new ConfigurableProperty<>(builder.difficulty).withConfigFormatter(Difficulty::name));
         this.material =
-                register("material", new ConfigurableType<>(builder.material).withConfigFormatter(XMaterial::name));
+                register("material", new ConfigurableProperty<>(builder.material).withConfigFormatter(XMaterial::name));
         this.status = register(
                 "status",
-                new ConfigurableType<>(builder.status)
+                new ConfigurableProperty<>(builder.status)
                         .withConfigFormatter(BuildWorldStatus::name)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.archive")));
 
         this.blockBreaking = register(
                 "block-breaking",
-                new ConfigurableType<>(builder.blockBreaking)
+                new ConfigurableProperty<>(builder.blockBreaking)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
         this.blockInteractions = register(
                 "block-interactions",
-                new ConfigurableType<>(builder.blockInteractions)
+                new ConfigurableProperty<>(builder.blockInteractions)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
         this.blockPlacement = register(
                 "block-placement",
-                new ConfigurableType<>(builder.blockPlacement)
+                new ConfigurableProperty<>(builder.blockPlacement)
                         .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings")));
-        this.buildersEnabled = register("builders-enabled", new ConfigurableType<>(builder.buildersEnabled));
-        this.explosions = register("explosions", new ConfigurableType<>(builder.explosions));
-        this.mobAi = register("mob-ai", new ConfigurableType<>(builder.mobAi));
-        this.physics = register("physics", new ConfigurableType<>(builder.physics));
-        this.pinned = register("pinned", new ConfigurableType<>(builder.pinned));
-        this.privateWorld = register("private", new ConfigurableType<>(builder.privateWorld));
+        this.buildersEnabled = register("builders-enabled", new ConfigurableProperty<>(builder.buildersEnabled));
+        this.explosions = register("explosions", new ConfigurableProperty<>(builder.explosions));
+        this.mobAi = register("mob-ai", new ConfigurableProperty<>(builder.mobAi));
+        this.physics = register("physics", new ConfigurableProperty<>(builder.physics));
+        this.pinned = register("pinned", new ConfigurableProperty<>(builder.pinned));
+        this.privateWorld = register("private", new ConfigurableProperty<>(builder.privateWorld));
 
-        this.timeSinceBackup = register("time-since-backup", new ConfigurableType<>(builder.timeSinceBackup));
-        this.lastEdited = register("last-edited", new ConfigurableType<>(builder.lastEdited));
-        this.lastLoaded = register("last-loaded", new ConfigurableType<>(builder.lastLoaded));
-        this.lastUnloaded = register("last-unloaded", new ConfigurableType<>(builder.lastUnloaded));
+        this.timeSinceBackup = register("time-since-backup", new ConfigurableProperty<>(builder.timeSinceBackup));
+        this.lastEdited = register("last-edited", new ConfigurableProperty<>(builder.lastEdited));
+        this.lastLoaded = register("last-loaded", new ConfigurableProperty<>(builder.lastLoaded));
+        this.lastUnloaded = register("last-unloaded", new ConfigurableProperty<>(builder.lastUnloaded));
     }
 
     public void setFolderResolver(Supplier<@Nullable Folder> resolver) {
@@ -129,7 +130,7 @@ public class WorldDataImpl implements WorldData {
 
     @SuppressWarnings("unchecked")
     public void setStatusChangeListener(BiConsumer<BuildWorldStatus, BuildWorldStatus> listener) {
-        ((ConfigurableType<BuildWorldStatus>) this.status).setChangeListener(listener);
+        ((ConfigurableProperty<BuildWorldStatus>) this.status).setChangeListener(listener);
     }
 
     private @Nullable Folder getAssignedFolder() {
@@ -137,13 +138,13 @@ public class WorldDataImpl implements WorldData {
         return resolver != null ? resolver.get() : null;
     }
 
-    private <T> ConfigurableType<T> register(String key, ConfigurableType<T> type) {
-        this.data.put(key, type);
-        return type;
+    private <T> ConfigurableProperty<T> register(String key, ConfigurableProperty<T> property) {
+        this.data.put(key, property);
+        return property;
     }
 
     @Override
-    public Type<String> customSpawn() {
+    public Property<String> customSpawn() {
         return customSpawn;
     }
 
@@ -165,92 +166,92 @@ public class WorldDataImpl implements WorldData {
     }
 
     @Override
-    public Type<String> permission() {
+    public Property<String> permission() {
         return permission;
     }
 
     @Override
-    public Type<String> project() {
+    public Property<String> project() {
         return project;
     }
 
     @Override
-    public Type<Difficulty> difficulty() {
+    public Property<Difficulty> difficulty() {
         return difficulty;
     }
 
     @Override
-    public Type<XMaterial> material() {
+    public Property<XMaterial> material() {
         return material;
     }
 
     @Override
-    public Type<BuildWorldStatus> status() {
+    public Property<BuildWorldStatus> status() {
         return status;
     }
 
     @Override
-    public Type<Boolean> blockBreaking() {
+    public Property<Boolean> blockBreaking() {
         return blockBreaking;
     }
 
     @Override
-    public Type<Boolean> blockInteractions() {
+    public Property<Boolean> blockInteractions() {
         return blockInteractions;
     }
 
     @Override
-    public Type<Boolean> blockPlacement() {
+    public Property<Boolean> blockPlacement() {
         return blockPlacement;
     }
 
     @Override
-    public Type<Boolean> buildersEnabled() {
+    public Property<Boolean> buildersEnabled() {
         return buildersEnabled;
     }
 
     @Override
-    public Type<Boolean> explosions() {
+    public Property<Boolean> explosions() {
         return explosions;
     }
 
     @Override
-    public Type<Boolean> mobAi() {
+    public Property<Boolean> mobAi() {
         return mobAi;
     }
 
     @Override
-    public Type<Boolean> physics() {
+    public Property<Boolean> physics() {
         return physics;
     }
 
     @Override
-    public Type<Boolean> pinned() {
+    public Property<Boolean> pinned() {
         return pinned;
     }
 
     @Override
-    public Type<Boolean> privateWorld() {
+    public Property<Boolean> privateWorld() {
         return privateWorld;
     }
 
     @Override
-    public Type<Integer> timeSinceBackup() {
+    public Property<Integer> timeSinceBackup() {
         return timeSinceBackup;
     }
 
     @Override
-    public Type<Long> lastEdited() {
+    public Property<Long> lastEdited() {
         return lastEdited;
     }
 
     @Override
-    public Type<Long> lastLoaded() {
+    public Property<Long> lastLoaded() {
         return lastLoaded;
     }
 
     @Override
-    public Type<Long> lastUnloaded() {
+    public Property<Long> lastUnloaded() {
         return lastUnloaded;
     }
 
@@ -258,8 +259,7 @@ public class WorldDataImpl implements WorldData {
         this.worldName = worldName;
     }
 
-    @Override
-    public Map<String, Type<?>> getAllData() {
+    public Map<String, PersistentProperty<?>> getAllData() {
         return data;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
@@ -19,7 +19,7 @@ package de.eintosti.buildsystem.world.data.type;
 
 import de.eintosti.buildsystem.api.data.Capability;
 import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,12 +30,12 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A single, concrete implementation of {@link Type} that uses a composition-based {@link Capability} model.
+ * A single, concrete implementation of {@link Property} that uses a composition-based {@link Capability} model.
  *
  * @param <T> The type of the value held.
  */
 @NullMarked
-public class ConfigurableType<T> implements Type<T> {
+public class ConfigurableProperty<T> implements PersistentProperty<T> {
 
     private T value;
     private Function<T, Object> configFormatter = (value) -> (Object) value;
@@ -44,37 +44,38 @@ public class ConfigurableType<T> implements Type<T> {
     private final Map<Class<? extends Capability>, Capability> capabilities = new HashMap<>();
 
     /**
-     * Creates a simple type.
+     * Creates a simple property.
      */
-    public ConfigurableType(T defaultValue) {
+    public ConfigurableProperty(T defaultValue) {
         this.value = defaultValue;
     }
 
     /**
-     * Sets a custom config formatter for this type.
+     * Sets a custom config formatter for this property.
      *
      * @param configFormatter A function that formats the value for config storage
      * @return This object, for fluent chaining
      */
-    public ConfigurableType<T> withConfigFormatter(Function<T, Object> configFormatter) {
+    public ConfigurableProperty<T> withConfigFormatter(Function<T, Object> configFormatter) {
         this.configFormatter = configFormatter;
         return this;
     }
 
     /**
-     * Attaches a new capability to this type.
+     * Attaches a new capability to this property.
      *
      * @param capabilityType The class of the capability
      * @param capabilityInstance The instance of the capability
      * @return This object, for fluent chaining
      */
-    public <C extends Capability> ConfigurableType<T> withCapability(Class<C> capabilityType, C capabilityInstance) {
+    public <C extends Capability> ConfigurableProperty<T> withCapability(
+            Class<C> capabilityType, C capabilityInstance) {
         this.capabilities.put(capabilityType, capabilityInstance);
         return this;
     }
 
     /**
-     * Checks if this type has a specific capability.
+     * Checks if this property has a specific capability.
      *
      * @param capability The class of the capability
      * @return {@code true} if the capability is present, {@code false} otherwise
@@ -94,7 +95,7 @@ public class ConfigurableType<T> implements Type<T> {
     }
 
     /**
-     * Gets the effective value for this type, taking into account any active {@link Overridable} capability.
+     * Gets the effective value for this property, taking into account any active {@link Overridable} capability.
      *
      * @return The current value
      */
@@ -109,7 +110,7 @@ public class ConfigurableType<T> implements Type<T> {
     }
 
     /**
-     * Registers a listener that is notified whenever {@link #set(Object)} changes this type's base value.
+     * Registers a listener that is notified whenever {@link #set(Object)} changes this property's base value.
      *
      * @param changeListener A consumer receiving {@code (oldValue, newValue)}, or {@code null} to deregister
      */
@@ -118,7 +119,7 @@ public class ConfigurableType<T> implements Type<T> {
     }
 
     /**
-     * Sets the base value for this type.
+     * Sets the base value for this property.
      *
      * <p>Note: This sets the underlying value. If an {@link Overridable} capability is active, {@link #get()} will
      * still return the overridden value.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
@@ -15,15 +15,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
+import de.eintosti.buildsystem.api.data.Property;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A {@link Capability} that marks a {@link Property} as being bypassable with a specific permission.
+ * A {@link Property} that can be serialized to a configuration file.
  *
- * @param permission The permission node required to bypass this type
- * @since 3.0.1
+ * @param <T> The type of the value held
  */
 @NullMarked
-public record Bypassable(String permission) implements Capability {}
+public interface PersistentProperty<T> extends Property<T> {
+
+    /**
+     * Gets the value of this data point formatted for storage in a configuration file. This might involve converting
+     * complex objects into simpler types (e.g., enums to strings).
+     *
+     * @return The value formatted for a config file
+     */
+    Object getConfigFormat();
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/DisplayOrdering.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/DisplayOrdering.java
@@ -50,7 +50,6 @@ public final class DisplayOrdering {
     }
 
     private static boolean isPinned(Displayable displayable) {
-        return displayable instanceof BuildWorld world
-                && world.getData().pinned().get();
+        return displayable instanceof BuildWorld world && world.getData().isPinned();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoaderImpl.java
@@ -84,7 +84,7 @@ public class WorldLoaderImpl implements WorldLoader {
             return;
         }
 
-        this.buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
+        this.buildWorld.getData().setLastLoaded(System.currentTimeMillis());
         this.buildWorld.setLoaded(true);
 
         Bukkit.getServer().getPluginManager().callEvent(new BuildWorldPostLoadEvent(this.buildWorld));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
@@ -19,13 +19,13 @@ package de.eintosti.buildsystem.world.lifecycle;
 
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.data.Bypassable;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
-import de.eintosti.buildsystem.world.data.type.ConfigurableType;
+import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -63,7 +63,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
             return true;
         }
 
-        String permission = buildWorld.getData().permission().get();
+        String permission = buildWorld.getData().getPermission();
         if (permission.equals("-")) {
             return true;
         }
@@ -72,7 +72,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
     }
 
     @Override
-    public boolean canModify(Player player, Type<Boolean> check) {
+    public boolean canModify(Player player, Property<Boolean> check) {
         if (buildWorld == null) {
             return true;
         }
@@ -81,7 +81,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
             return true;
         }
 
-        if (buildWorld.getData().status().get() == BuildWorldStatus.ARCHIVE
+        if (buildWorld.getData().getStatus() == BuildWorldStatus.ARCHIVE
                 && !player.hasPermission("buildsystem.bypass.archive")) {
             return false;
         }
@@ -98,22 +98,22 @@ public class WorldPermissionsImpl implements WorldPermissions {
         return builders.isCreator(player)
                 || builders.isBuilder(player)
                 || player.hasPermission("buildsystem.bypass.builders")
-                || !buildWorld.getData().buildersEnabled().get();
+                || !buildWorld.getData().isBuildersEnabled();
     }
 
     /**
      * Checks if the player has the bypass permission for the given check.
      *
      * @param player The player to check
-     * @param check The specific data type representing the modification to be checked
+     * @param check The specific data property representing the modification to be checked
      * @return {@code true} if the player can bypass the modification, otherwise {@code false}
      */
-    private boolean canBypassModification(Player player, Type<Boolean> check) {
-        if (!(check instanceof ConfigurableType<Boolean> configurableType)) {
+    private boolean canBypassModification(Player player, Property<Boolean> check) {
+        if (!(check instanceof ConfigurableProperty<Boolean> configurableProperty)) {
             return false;
         }
 
-        return configurableType
+        return configurableProperty
                 .getCapability(Bypassable.class)
                 .map(bypassable -> player.hasPermission(bypassable.permission()))
                 .orElse(false);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
@@ -151,7 +151,7 @@ public class WorldUnloaderImpl implements WorldUnloader {
             return;
         }
 
-        this.buildWorld.getData().lastUnloaded().set(System.currentTimeMillis());
+        this.buildWorld.getData().setLastUnloaded(System.currentTimeMillis());
         this.buildWorld.setLoaded(false);
         this.unloadTask = null;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
@@ -130,7 +130,7 @@ public class BackupsMenu extends Menu {
                 .backup()
                 .autoBackup()
                 .interval();
-        int timeSinceBackup = buildWorld.getData().timeSinceBackup().get();
+        int timeSinceBackup = buildWorld.getData().getTimeSinceBackup();
 
         int secondsRemaining = Math.max(0, timeUntilBackup - timeSinceBackup);
         return "%02d:%02d".formatted(secondsRemaining / 60, secondsRemaining % 60);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -24,7 +24,7 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.google.common.collect.Sets;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
@@ -135,7 +135,7 @@ public class EditMenu extends Menu {
             String permission,
             String itemKey,
             String loreKey,
-            Function<WorldData, Type<Boolean>> data) {}
+            Function<WorldData, Property<Boolean>> data) {}
 
     private final BuildSystemPlugin plugin;
     private final PlayerServiceImpl playerManager;
@@ -206,9 +206,7 @@ public class EditMenu extends Menu {
                         messages.getStringList(
                                 "worldeditor_project_lore",
                                 player,
-                                Map.entry(
-                                        "%project%",
-                                        buildWorld.getData().project().get()))));
+                                Map.entry("%project%", buildWorld.getData().getProject()))));
         inv.setItem(
                 42,
                 InventoryUtils.createItem(
@@ -217,15 +215,13 @@ public class EditMenu extends Menu {
                         messages.getStringList(
                                 "worldeditor_permission_lore",
                                 player,
-                                Map.entry(
-                                        "%permission%",
-                                        buildWorld.getData().permission().get()))));
+                                Map.entry("%permission%", buildWorld.getData().getPermission()))));
     }
 
     private void addBuildWorldInfoItem(Player player, Inventory inventory) {
         String worldName = buildWorld.getName();
         String displayName = messages.getString("worldeditor_world_item", player, Map.entry("%world%", worldName));
-        XMaterial material = buildWorld.getData().material().get();
+        XMaterial material = buildWorld.getData().getMaterial();
 
         if (material == XMaterial.PLAYER_HEAD) {
             plugin.getMenuItems().addWorldItem(inventory, 4, buildWorld, displayName, new ArrayList<>());
@@ -275,7 +271,7 @@ public class EditMenu extends Menu {
                             inventory,
                             30,
                             XMaterial.IRON_PICKAXE,
-                            buildWorld.getData().buildersEnabled().get(),
+                            buildWorld.getData().isBuildersEnabled(),
                             "worldeditor_builders_item",
                             "worldeditor_builders_lore");
         } else {
@@ -291,7 +287,7 @@ public class EditMenu extends Menu {
     private void addVisibilityItem(Player player, Inventory inventory) {
         int slot = 32;
         String displayName = messages.getString("worldeditor_visibility_item", player);
-        boolean isPrivate = buildWorld.getData().privateWorld().get();
+        boolean isPrivate = buildWorld.getData().isPrivateWorld();
 
         if (!playerManager.canCreateWorld(player, Visibility.matchVisibility(isPrivate))) {
             inventory.setItem(
@@ -312,7 +308,7 @@ public class EditMenu extends Menu {
 
     private void addDifficultyItem(Player player, Inventory inventory) {
         XMaterial material =
-                switch (buildWorld.getData().difficulty().get()) {
+                switch (buildWorld.getData().getDifficulty()) {
                     case EASY -> XMaterial.GOLDEN_HELMET;
                     case NORMAL -> XMaterial.IRON_HELMET;
                     case HARD -> XMaterial.DIAMOND_HELMET;
@@ -331,7 +327,7 @@ public class EditMenu extends Menu {
     }
 
     private String getDifficultyName(BuildWorld buildWorld, Player player) {
-        return switch (buildWorld.getData().difficulty().get()) {
+        return switch (buildWorld.getData().getDifficulty()) {
             case PEACEFUL -> messages.getString("difficulty_peaceful", player);
             case EASY -> messages.getString("difficulty_easy", player);
             case NORMAL -> messages.getString("difficulty_normal", player);
@@ -353,7 +349,7 @@ public class EditMenu extends Menu {
         Toggle toggle = TOGGLES.get(event.getSlot());
         if (toggle != null) {
             if (requirePermission(player, toggle.permission())) {
-                Type<Boolean> data = toggle.data().apply(worldData);
+                Property<Boolean> data = toggle.data().apply(worldData);
                 data.set(!data.get());
                 reopen(player);
             }
@@ -384,7 +380,7 @@ public class EditMenu extends Menu {
                     new BuilderMenu(plugin, buildWorld, player).open(player);
                     return;
                 }
-                worldData.buildersEnabled().set(!worldData.buildersEnabled().get());
+                worldData.setBuildersEnabled(!worldData.isBuildersEnabled());
             }
             case 32 -> {
                 if (itemStack.getType() == XMaterial.BARRIER.get()) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -94,7 +94,7 @@ public class StatusMenu extends Menu {
         itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemStack.setItemMeta(itemMeta);
 
-        if (buildWorld.getData().status().get() == status) {
+        if (buildWorld.getData().getStatus() == status) {
             itemStack.addUnsafeEnchantment(XEnchantment.UNBREAKING.get(), 1);
         }
 
@@ -125,7 +125,7 @@ public class StatusMenu extends Menu {
         }
 
         player.closeInventory();
-        buildWorld.getData().status().set(status);
+        buildWorld.getData().setStatus(status);
         plugin.getSettingsService().forceUpdateSidebar(buildWorld);
 
         XSound.ENTITY_CHICKEN_EGG.play(player);

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansionTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/integration/placeholderapi/PlaceholderApiExpansionTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.eintosti.buildsystem.api.data.Type;
 import de.eintosti.buildsystem.api.player.settings.NavigatorType;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.api.world.BuildWorld;
@@ -119,11 +118,8 @@ class PlaceholderApiExpansionTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void world_permission_returnsValue() {
-        Type<String> attr = mock(Type.class);
-        when(worldData.permission()).thenReturn(attr);
-        when(attr.get()).thenReturn("buildsystem.world.test");
+        when(worldData.getPermission()).thenReturn("buildsystem.world.test");
         assertEquals("buildsystem.world.test", expansion.onPlaceholderRequest(player, "permission"));
     }
 

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.eintosti.buildsystem.api.data.Type;
+import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
 import de.eintosti.buildsystem.api.world.builder.Builders;
@@ -60,10 +60,8 @@ class WorldProtectionPolicyTest {
         when(permissions.canBypassBuildRestriction(player)).thenReturn(false);
         when(player.hasPermission("buildsystem.bypass.archive")).thenReturn(false);
         when(player.hasPermission("buildsystem.bypass.builders")).thenReturn(false);
-        Type<BuildWorldStatus> status = mockType(BuildWorldStatus.NOT_STARTED);
-        when(data.status()).thenReturn(status);
-        Type<Boolean> buildersEnabled = mockType(false);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.NOT_STARTED);
+        when(data.isBuildersEnabled()).thenReturn(false);
         when(builders.isCreator(player)).thenReturn(false);
         when(builders.isBuilder(player)).thenReturn(false);
     }
@@ -71,10 +69,8 @@ class WorldProtectionPolicyTest {
     @Test
     void bypass_shortCircuitsEverything() {
         when(permissions.canBypassBuildRestriction(player)).thenReturn(true);
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkArchive(player, world));
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -84,16 +80,14 @@ class WorldProtectionPolicyTest {
     @Test
     void archiveBypassPermission_shortCircuitsArchiveCheck() {
         when(player.hasPermission("buildsystem.bypass.archive")).thenReturn(true);
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
 
         assertEquals(Denial.NONE, policy.checkArchive(player, world));
     }
 
     @Test
     void archivedWorld_noBypass_returnsArchived() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
 
         assertEquals(Denial.ARCHIVED, policy.checkArchive(player, world));
     }
@@ -105,16 +99,14 @@ class WorldProtectionPolicyTest {
 
     @Test
     void buildersEnabled_nonBuilder_notCreator_returnsNotABuilder() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NOT_A_BUILDER, policy.checkBuilders(player, world));
     }
 
     @Test
     void buildersEnabled_isCreator_returnsNone() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
         when(builders.isCreator(player)).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -122,8 +114,7 @@ class WorldProtectionPolicyTest {
 
     @Test
     void buildersEnabled_isBuilder_returnsNone() {
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
         when(builders.isBuilder(player)).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
@@ -137,30 +128,27 @@ class WorldProtectionPolicyTest {
     @Test
     void buildersPermission_shortCircuitsBuildersCheck() {
         when(player.hasPermission("buildsystem.bypass.builders")).thenReturn(true);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.NONE, policy.checkBuilders(player, world));
     }
 
     @Test
     void settingDisabled_returnsSettingDisabled() {
-        Type<Boolean> setting = mockType(false);
+        Property<Boolean> setting = mockProperty(false);
         assertEquals(Denial.SETTING_DISABLED, policy.checkSetting(player, world, setting));
     }
 
     @Test
     void settingEnabled_returnsNone() {
-        Type<Boolean> setting = mockType(true);
+        Property<Boolean> setting = mockProperty(true);
         assertEquals(Denial.NONE, policy.checkSetting(player, world, setting));
     }
 
     @Test
     void mayModify_archive_winsOverBuilders() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         // Archive denial takes precedence over builder denial
         assertEquals(Denial.ARCHIVED, policy.mayModify(player, world));
@@ -168,18 +156,16 @@ class WorldProtectionPolicyTest {
 
     @Test
     void mayModify_withSetting_settingDisabled_winsOverBuilders() {
-        Type<Boolean> setting = mockType(false);
-        Type<Boolean> buildersEnabled = mockType(true);
-        when(data.buildersEnabled()).thenReturn(buildersEnabled);
+        Property<Boolean> setting = mockProperty(false);
+        when(data.isBuildersEnabled()).thenReturn(true);
 
         assertEquals(Denial.SETTING_DISABLED, policy.mayModify(player, world, setting));
     }
 
     @Test
     void mayModify_withSetting_archiveWinsOverSetting() {
-        Type<BuildWorldStatus> archived = mockType(BuildWorldStatus.ARCHIVE);
-        when(data.status()).thenReturn(archived);
-        Type<Boolean> setting = mockType(false);
+        when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
+        Property<Boolean> setting = mockProperty(false);
 
         assertEquals(Denial.ARCHIVED, policy.mayModify(player, world, setting));
     }
@@ -190,9 +176,9 @@ class WorldProtectionPolicyTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> Type<T> mockType(T value) {
-        Type<T> t = mock(Type.class);
-        when(t.get()).thenReturn(value);
-        return t;
+    private static <T> Property<T> mockProperty(T value) {
+        Property<T> property = mock(Property.class);
+        when(property.get()).thenReturn(value);
+        return property;
     }
 }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/ConfigurablePropertyChangeListenerTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/ConfigurablePropertyChangeListenerTest.java
@@ -19,26 +19,26 @@ package de.eintosti.buildsystem.world.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import de.eintosti.buildsystem.world.data.type.ConfigurableType;
+import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
 @NullMarked
-class ConfigurableTypeChangeListenerTest {
+class ConfigurablePropertyChangeListenerTest {
 
     @Test
     void set_changesValue_notifiesListener() {
-        ConfigurableType<String> type = new ConfigurableType<>("old");
+        ConfigurableProperty<String> property = new ConfigurableProperty<>("old");
         AtomicInteger invocations = new AtomicInteger();
         String[] observed = new String[2];
-        type.setChangeListener((oldValue, newValue) -> {
+        property.setChangeListener((oldValue, newValue) -> {
             invocations.incrementAndGet();
             observed[0] = oldValue;
             observed[1] = newValue;
         });
 
-        type.set("new");
+        property.set("new");
 
         assertEquals(1, invocations.get());
         assertEquals("old", observed[0]);
@@ -47,32 +47,32 @@ class ConfigurableTypeChangeListenerTest {
 
     @Test
     void set_sameValue_doesNotNotifyListener() {
-        ConfigurableType<String> type = new ConfigurableType<>("same");
+        ConfigurableProperty<String> property = new ConfigurableProperty<>("same");
         AtomicInteger invocations = new AtomicInteger();
-        type.setChangeListener((oldValue, newValue) -> invocations.incrementAndGet());
+        property.setChangeListener((oldValue, newValue) -> invocations.incrementAndGet());
 
-        type.set("same");
+        property.set("same");
 
         assertEquals(0, invocations.get());
     }
 
     @Test
     void set_withoutListener_doesNotThrow() {
-        ConfigurableType<String> type = new ConfigurableType<>("old");
-        type.set("new");
-        assertEquals("new", type.get());
+        ConfigurableProperty<String> property = new ConfigurableProperty<>("old");
+        property.set("new");
+        assertEquals("new", property.get());
     }
 
     @Test
     void setChangeListener_null_deregistersListener() {
-        ConfigurableType<String> type = new ConfigurableType<>("old");
+        ConfigurableProperty<String> property = new ConfigurableProperty<>("old");
         AtomicInteger invocations = new AtomicInteger();
-        type.setChangeListener((oldValue, newValue) -> invocations.incrementAndGet());
-        type.setChangeListener(null);
+        property.setChangeListener((oldValue, newValue) -> invocations.incrementAndGet());
+        property.setChangeListener(null);
 
-        type.set("new");
+        property.set("new");
 
         assertEquals(0, invocations.get());
-        assertEquals("new", type.get());
+        assertEquals("new", property.get());
     }
 }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+@NullMarked
+class WorldDataAccessorTest {
+
+    private static WorldDataImpl worldData() {
+        return new WorldDataImpl.WorldDataBuilder("test").build();
+    }
+
+    @Test
+    void flatSetter_updatesUnderlyingProperty() {
+        WorldDataImpl data = worldData();
+
+        data.setStatus(BuildWorldStatus.FINISHED);
+
+        assertEquals(BuildWorldStatus.FINISHED, data.getStatus());
+        assertEquals(BuildWorldStatus.FINISHED, data.status().get());
+    }
+
+    @Test
+    void propertySetter_reflectsInFlatGetter() {
+        WorldDataImpl data = worldData();
+
+        data.status().set(BuildWorldStatus.ARCHIVE);
+
+        assertEquals(BuildWorldStatus.ARCHIVE, data.getStatus());
+        assertEquals(BuildWorldStatus.ARCHIVE, data.status().get());
+    }
+
+    @Test
+    void booleanFlatAccessor_staysInSyncWithProperty() {
+        WorldDataImpl data = worldData();
+
+        data.setPhysics(false);
+        assertEquals(false, data.isPhysics());
+        assertEquals(false, data.physics().get());
+
+        data.physics().set(true);
+        assertEquals(true, data.isPhysics());
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/DisplayOrderingTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/DisplayOrderingTest.java
@@ -20,7 +20,6 @@ package de.eintosti.buildsystem.world.display;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import de.eintosti.buildsystem.api.data.Type;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.display.Displayable;
@@ -35,15 +34,12 @@ import org.junit.jupiter.api.Test;
 @NullMarked
 class DisplayOrderingTest {
 
-    @SuppressWarnings("unchecked")
     private static BuildWorld world(String name, boolean pinned) {
         BuildWorld world = mock(BuildWorld.class);
         WorldData data = mock(WorldData.class);
-        Type<Boolean> pinnedType = mock(Type.class);
         when(world.getName()).thenReturn(name);
         when(world.getData()).thenReturn(data);
-        when(data.pinned()).thenReturn(pinnedType);
-        when(pinnedType.get()).thenReturn(pinned);
+        when(data.isPinned()).thenReturn(pinned);
         return world;
     }
 


### PR DESCRIPTION
Supersedes #456 (which couldn't be reopened after its branch was recreated). Re-implemented fresh on current master with a **DRY** design.

## What (breaking, API)

- **`Type<T>` → `Property<T>`** (`api.data`). The name collided with `BuildWorldType`; the thing is a settable world *property*.
- **Persistence removed from the public surface.** `getConfigFormat()` is gone from the public interface (moved to a core-only `PersistentProperty<T>`, implemented by `ConfigurableProperty`), and `WorldData.getAllData()` is dropped from the public interface (YAML storage reaches it via the impl). Storage format is no longer part of the published API.
- **Ergonomic flat accessors** — `getStatus()/setStatus()`, `isPhysics()/setPhysics()`, etc. for all 20 properties.

## DRY design (the point of the redo)

The flat accessors are **`default` methods on the `WorldData` interface**, each delegating to its property accessor:

```java
Property<BuildWorldStatus> status();
default BuildWorldStatus getStatus() { return status().get(); }
default void setStatus(BuildWorldStatus status) { status().set(status); }
```

`WorldDataImpl` implements **zero** flat accessors — they live once, as interface defaults. (The earlier version duplicated all 38 in the impl.) The `Property` objects remain for capability access (`Bypassable`/`Overridable`).

## Verification

- `grep getConfigFormat buildsystem-api/src` → empty; `grep '\bType<' buildsystem-api/src buildsystem-core/src/main` → empty.
- 38 flat defaults on `WorldData`, all `@since TODO`; **0** flat-accessor impls in `WorldDataImpl`.
- Core call sites migrated to flat accessors (capability sites keep the property object).
- New `WorldDataAccessorTest` proves flat accessor ⇄ property object stay in sync.
- `./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)