### PR TITLE
refactor(api)!: return Optional<World> from BuildWorld.getWorld()

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
@@ -28,6 +28,7 @@ import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.api.world.lifecycle.WorldLoader;
 import de.eintosti.buildsystem.api.world.lifecycle.WorldTeleporter;
 import de.eintosti.buildsystem.api.world.lifecycle.WorldUnloader;
+import java.util.Optional;
 import java.util.UUID;
 import org.bukkit.Difficulty;
 import org.bukkit.Material;
@@ -47,9 +48,10 @@ public interface BuildWorld extends Displayable {
     /**
      * Gets the Bukkit {@link World} associated with this {@link BuildWorld}.
      *
-     * @return The Bukkit world, or {@code null} if not loaded
+     * @return An {@link Optional} containing the Bukkit world, or {@link Optional#empty()} if not loaded
+     * @since TODO
      */
-    @Nullable World getWorld();
+    Optional<World> getWorld();
 
     /**
      * Gets the unique identifier of this world.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SaveTemplateSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SaveTemplateSubCommand.java
@@ -75,10 +75,7 @@ public class SaveTemplateSubCommand extends AbstractSubCommand {
             return;
         }
 
-        World world = buildWorld.getWorld();
-        if (world != null) {
-            world.save();
-        }
+        buildWorld.getWorld().ifPresent(World::save);
         messages.sendMessage(
                 player,
                 "worlds_savetemplate_started",

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -166,10 +166,10 @@ public final class BuildWorldImpl implements BuildWorld {
     /**
      * Gets the Bukkit {@link World} associated with this {@link BuildWorld}.
      *
-     * @return The Bukkit world, or {@code null} if not loaded
+     * @return An {@link Optional} containing the Bukkit world, or {@link Optional#empty()} if not loaded
      */
-    public @Nullable World getWorld() {
-        return Bukkit.getWorld(name);
+    public Optional<World> getWorld() {
+        return Optional.ofNullable(Bukkit.getWorld(name));
     }
 
     @Override
@@ -311,11 +311,7 @@ public final class BuildWorldImpl implements BuildWorld {
 
     @Override
     public String getWorldTime() {
-        World bukkitWorld = getWorld();
-        if (bukkitWorld == null) {
-            return "?";
-        }
-        return String.valueOf(bukkitWorld.getTime());
+        return getWorld().map(World::getTime).map(String::valueOf).orElse("?");
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
@@ -68,10 +68,7 @@ public class BackupProfileImpl implements BackupProfile {
 
     @Override
     public CompletableFuture<Backup> createBackup() {
-        World world = this.buildWorld.getWorld();
-        if (world != null) {
-            world.save();
-        }
+        this.buildWorld.getWorld().ifPresent(World::save);
 
         CompletableFuture<Backup> resultFuture = new CompletableFuture<>();
         this.listBackups()
@@ -121,11 +118,12 @@ public class BackupProfileImpl implements BackupProfile {
     @Override
     public CompletableFuture<Void> restoreBackup(Backup backup, Player player) {
         String worldName = this.buildWorld.getName();
-        World world = this.buildWorld.getWorld();
-        if (world == null) {
+        Optional<World> optionalWorld = this.buildWorld.getWorld();
+        if (optionalWorld.isEmpty()) {
             plugin.getMessages().sendMessage(player, "worlds_backup_unknown_world");
             return CompletableFuture.completedFuture(null);
         }
+        World world = optionalWorld.get();
 
         List<@Nullable Player> removedPlayers =
                 plugin.getWorldService().removePlayersFromWorld(worldName, "worlds_backup_restoration_in_progress");

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
@@ -24,6 +24,7 @@ import de.eintosti.buildsystem.api.world.lifecycle.WorldUnloader;
 import de.eintosti.buildsystem.world.BuildWorldImpl;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -92,7 +93,7 @@ public class WorldUnloaderImpl implements WorldUnloader {
             return;
         }
 
-        buildWorld.setLoaded(buildWorld.getWorld() != null);
+        buildWorld.setLoaded(buildWorld.getWorld().isPresent());
         startUnloadTask();
     }
 
@@ -120,10 +121,11 @@ public class WorldUnloaderImpl implements WorldUnloader {
 
     @Override
     public void unload() {
-        World bukkitWorld = buildWorld.getWorld();
-        if (bukkitWorld == null) {
+        Optional<World> optionalWorld = buildWorld.getWorld();
+        if (optionalWorld.isEmpty()) {
             return;
         }
+        World bukkitWorld = optionalWorld.get();
 
         if (!bukkitWorld.getPlayers().isEmpty()) {
             resetUnloadTask();
@@ -155,10 +157,11 @@ public class WorldUnloaderImpl implements WorldUnloader {
         this.buildWorld.setLoaded(false);
         this.unloadTask = null;
 
-        World bukkitWorld = this.buildWorld.getWorld();
-        if (bukkitWorld == null) {
+        Optional<World> optionalWorld = this.buildWorld.getWorld();
+        if (optionalWorld.isEmpty()) {
             return;
         }
+        World bukkitWorld = optionalWorld.get();
 
         if (save) {
             Arrays.stream(bukkitWorld.getLoadedChunks()).forEach(Chunk::unload);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -257,7 +257,7 @@ public class EditMenu extends Menu {
     }
 
     private TimeOfDay getWorldTime() {
-        int worldTime = (int) buildWorld.getWorld().getTime();
+        int worldTime = (int) buildWorld.getWorld().orElseThrow().getTime();
         int noonTime =
                 plugin.getConfigService().current().world().defaults().time().noon();
         return TimeOfDay.fromTicks(worldTime, noonTime);
@@ -401,7 +401,7 @@ public class EditMenu extends Menu {
             case 39 -> {
                 if (requirePermission(player, "buildsystem.edit.difficulty")) {
                     Difficulty newDifficulty = buildWorld.cycleDifficulty();
-                    buildWorld.getWorld().setDifficulty(newDifficulty);
+                    buildWorld.getWorld().orElseThrow().setDifficulty(newDifficulty);
                 }
             }
             case 40 -> {
@@ -463,7 +463,7 @@ public class EditMenu extends Menu {
                                 .time()
                                 .sunrise();
                 };
-        buildWorld.getWorld().setTime(time);
+        buildWorld.getWorld().orElseThrow().setTime(time);
         new EditMenu(plugin, buildWorld, player).open(player);
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/GameRulesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/GameRulesMenu.java
@@ -29,6 +29,7 @@ import de.eintosti.buildsystem.menu.SkullTextures;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -58,18 +59,18 @@ public class GameRulesMenu extends PaginatedMenu {
 
     @Override
     protected int totalItems() {
-        World world = buildWorld.getWorld();
-        return world != null ? world.getGameRules().length : 0;
+        return buildWorld.getWorld().map(world -> world.getGameRules().length).orElse(0);
     }
 
     @Override
     protected void populate(Player player) {
-        World world = buildWorld.getWorld();
-        if (world == null) {
+        Optional<World> optionalWorld = buildWorld.getWorld();
+        if (optionalWorld.isEmpty()) {
             player.closeInventory();
             plugin.getLogger().severe("World '" + buildWorld.getName() + "' does not exist.");
             return;
         }
+        World world = optionalWorld.get();
 
         for (int i = 0; i < 45; i++) {
             if (!isValidSlot(i)) {
@@ -171,7 +172,7 @@ public class GameRulesMenu extends PaginatedMenu {
             case FILLED_MAP:
             case MAP:
                 XSound.ENTITY_CHICKEN_EGG.play(player);
-                modifyGameRule(event, buildWorld.getWorld());
+                modifyGameRule(event, buildWorld.getWorld().orElse(null));
                 populate(player);
                 return;
 


### PR DESCRIPTION
## What (breaking, API)

`BuildWorld.getWorld()` now returns `Optional<World>` instead of `@Nullable World`. A world is unloaded ⇒ empty Optional. This forces callers to handle the "may be unloaded" case the type system previously let them ignore.

## Migration

Every `BuildWorld.getWorld()` call site migrated faithfully (behavior preserved). Bukkit's own `getWorld()` on `Player`/`Location`/`Block` is a different method and was left untouched.

- guarded `world != null` paths → `isPresent()` / `ifPresent(...)` / `map(...).orElse(...)`
- early-return null guards → `isEmpty()` / `get()`

## Latent bugs surfaced

Three `EditMenu` actions dereferenced the nullable world directly — they would have NPE'd on an unloaded world. They're now `orElseThrow()`, preserving the original (implicit) "world is loaded here" assumption while failing loudly:

- `EditMenu` time display (`getWorldTime()`), difficulty cycle, and `changeTime`.

## Notes

- 7 files, +30/−33. `getWorld()` keeps explicit `@since TODO` (its contract changed).
- `./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)