### PR TITLE
refactor: split WorldServiceImpl, Messages, and slim down BuildSystemPlugin (non-breaking)

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemMetrics.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemMetrics.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem;
+
+import de.eintosti.buildsystem.api.player.settings.NavigatorType;
+import de.eintosti.buildsystem.config.ConfigService;
+import de.eintosti.buildsystem.player.PlayerServiceImpl;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.SimplePie;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+final class BuildSystemMetrics {
+
+    private final BuildSystemPlugin plugin;
+
+    BuildSystemMetrics(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    void register() {
+        ConfigService config = plugin.getConfigService();
+        PlayerServiceImpl players = plugin.getPlayerService();
+
+        Metrics metrics = new Metrics(plugin, BuildSystemPlugin.METRICS_ID);
+        metrics.addCustomChart(new SimplePie(
+                "archive_vanish",
+                () -> String.valueOf(config.current().settings().archive().vanish())));
+        metrics.addCustomChart(new SimplePie(
+                "block_world_edit",
+                () -> String.valueOf(config.current().settings().builder().blockWorldEditNonBuilder())));
+        metrics.addCustomChart(new SimplePie(
+                "join_quit_messages",
+                () -> String.valueOf(config.current().settings().joinQuitMessages())));
+        metrics.addCustomChart(new SimplePie(
+                "lock_weather", () -> String.valueOf(config.current().world().lockWeather())));
+        metrics.addCustomChart(new SimplePie(
+                "scoreboard", () -> String.valueOf(config.current().settings().scoreboard())));
+        metrics.addCustomChart(new SimplePie(
+                "update_checker",
+                () -> String.valueOf(config.current().settings().updateChecker())));
+        metrics.addCustomChart(new SimplePie(
+                "unload_worlds",
+                () -> String.valueOf(config.current().world().unload().enabled())));
+        metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
+            Map<NavigatorType, Long> countsByType = players.getPlayerStorage().getBuildPlayers().stream()
+                    .collect(Collectors.groupingBy(
+                            buildPlayer -> buildPlayer.getSettings().getNavigatorType(), Collectors.counting()));
+            int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
+            int newCount = countsByType.getOrDefault(NavigatorType.NEW, 0L).intValue();
+            return Map.of("Old", oldCount, "New", newCount);
+        }));
+        metrics.addCustomChart(new SimplePie(
+                "folder_override_permissions",
+                () -> String.valueOf(config.current().folder().overridePermissions())));
+        metrics.addCustomChart(new SimplePie(
+                "folder_override_projects",
+                () -> String.valueOf(config.current().folder().overrideProjects())));
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -62,20 +62,7 @@ public class BuildSystemPlugin extends JavaPlugin {
     public static final int METRICS_ID = 7427;
     public static final String ADMIN_PERMISSION = "buildsystem.admin";
 
-    private ConfigService configService;
-    private Messages messages;
-
-    private NavigatorService navigatorService;
-    private CustomBlockManager customBlockManager;
-    private PlayerServiceImpl playerService;
-    private PlayerLookupService playerLookupService;
-    private NoClipService noClipService;
-    private SettingsService settingsService;
-    private SpawnService spawnService;
-    private WorldServiceImpl worldService;
-    private BackupService backupService;
-    private CustomizableIcons customizableIcons;
-    private MenuItems menuItems;
+    private final Services services = new Services(this);
 
     private UpdateChecker updateChecker;
 
@@ -87,20 +74,20 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     @Override
     public void onLoad() {
-        this.configService = new ConfigService(this);
+        services.loadCore();
         new ConfigMigrationManager(this).migrate();
         this.getConfig().options().copyDefaults(true);
         this.saveConfig();
-        this.configService.load();
+        services.config().load();
 
-        this.messages = new Messages(this, configService);
-        this.messages.load();
+        services.loadMessages();
+        services.messages().load();
         createTemplateFolder();
     }
 
     @Override
     public void onEnable() {
-        initClasses();
+        services.initClasses();
 
         new CommandRegistrar(this).registerAll();
         new ListenerRegistrar(this).registerAll();
@@ -113,10 +100,10 @@ public class BuildSystemPlugin extends JavaPlugin {
         getServer().getServicesManager().register(BuildSystem.class, api, this, ServicePriority.Normal);
 
         Bukkit.getOnlinePlayers().forEach(pl -> {
-            BuildPlayer buildPlayer = playerService.getPlayerStorage().createBuildPlayer(pl);
+            BuildPlayer buildPlayer = services.player().getPlayerStorage().createBuildPlayer(pl);
             Settings settings = buildPlayer.getSettings();
-            noClipService.startNoClip(pl, settings);
-            settingsService.displayScoreboard(pl);
+            services.noClip().startNoClip(pl, settings);
+            services.settings().displayScoreboard(pl);
         });
 
         registerStats();
@@ -133,17 +120,17 @@ public class BuildSystemPlugin extends JavaPlugin {
     public void onDisable() {
         Bukkit.getOnlinePlayers().forEach(pl -> {
             BuildPlayerImpl buildPlayer =
-                    BuildPlayerImpl.of(playerService.getPlayerStorage().getBuildPlayer(pl));
+                    BuildPlayerImpl.of(services.player().getPlayerStorage().getBuildPlayer(pl));
             buildPlayer.getCachedValues().resetCachedValues(pl);
             buildPlayer.setLogoutLocation(new LogoutLocation(pl.getWorld().getName(), pl.getLocation()));
 
-            settingsService.hideScoreboard(pl);
-            noClipService.stopNoClip(pl.getUniqueId());
-            navigatorService.closeNewNavigator(pl);
+            services.settings().hideScoreboard(pl);
+            services.noClip().stopNoClip(pl.getUniqueId());
+            services.navigator().closeNewNavigator(pl);
         });
 
-        this.backupService.close();
-        worldService.cancelAllUnloadTasks();
+        services.backup().close();
+        services.world().cancelAllUnloadTasks();
 
         reloadConfigData(false);
         saveConfig();
@@ -165,48 +152,34 @@ public class BuildSystemPlugin extends JavaPlugin {
                         .formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
     }
 
-    private void initClasses() {
-        this.customizableIcons = new CustomizableIcons(this);
-
-        this.customBlockManager = new CustomBlockManager(this);
-        this.playerLookupService = new PlayerLookupService(this);
-        (this.playerService = new PlayerServiceImpl(this)).init();
-        this.navigatorService = new NavigatorService(this);
-        this.noClipService = new NoClipService(this);
-        (this.worldService = new WorldServiceImpl(this)).init();
-        this.backupService = new BackupService(this);
-        this.settingsService = new SettingsService(this);
-        this.spawnService = new SpawnService(this);
-        this.menuItems = new MenuItems(this, configService, messages, settingsService);
-    }
-
     private void registerStats() {
         Metrics metrics = new Metrics(this, METRICS_ID);
         metrics.addCustomChart(new SimplePie(
                 "archive_vanish",
                 () -> String.valueOf(
-                        configService.current().settings().archive().vanish())));
+                        services.config().current().settings().archive().vanish())));
         metrics.addCustomChart(new SimplePie(
                 "block_world_edit",
                 () -> String.valueOf(
-                        configService.current().settings().builder().blockWorldEditNonBuilder())));
+                        services.config().current().settings().builder().blockWorldEditNonBuilder())));
         metrics.addCustomChart(new SimplePie(
                 "join_quit_messages",
-                () -> String.valueOf(configService.current().settings().joinQuitMessages())));
+                () -> String.valueOf(services.config().current().settings().joinQuitMessages())));
         metrics.addCustomChart(new SimplePie(
                 "lock_weather",
-                () -> String.valueOf(configService.current().world().lockWeather())));
+                () -> String.valueOf(services.config().current().world().lockWeather())));
         metrics.addCustomChart(new SimplePie(
                 "scoreboard",
-                () -> String.valueOf(configService.current().settings().scoreboard())));
+                () -> String.valueOf(services.config().current().settings().scoreboard())));
         metrics.addCustomChart(new SimplePie(
                 "update_checker",
-                () -> String.valueOf(configService.current().settings().updateChecker())));
+                () -> String.valueOf(services.config().current().settings().updateChecker())));
         metrics.addCustomChart(new SimplePie(
                 "unload_worlds",
-                () -> String.valueOf(configService.current().world().unload().enabled())));
+                () -> String.valueOf(
+                        services.config().current().world().unload().enabled())));
         metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
-            Map<NavigatorType, Long> countsByType = playerService.getPlayerStorage().getBuildPlayers().stream()
+            Map<NavigatorType, Long> countsByType = services.player().getPlayerStorage().getBuildPlayers().stream()
                     .collect(Collectors.groupingBy(
                             buildPlayer -> buildPlayer.getSettings().getNavigatorType(), Collectors.counting()));
             int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
@@ -215,10 +188,10 @@ public class BuildSystemPlugin extends JavaPlugin {
         }));
         metrics.addCustomChart(new SimplePie(
                 "folder_override_permissions",
-                () -> String.valueOf(configService.current().folder().overridePermissions())));
+                () -> String.valueOf(services.config().current().folder().overridePermissions())));
         metrics.addCustomChart(new SimplePie(
                 "folder_override_projects",
-                () -> String.valueOf(configService.current().folder().overrideProjects())));
+                () -> String.valueOf(services.config().current().folder().overrideProjects())));
     }
 
     public UpdateChecker getUpdateChecker() {
@@ -227,7 +200,7 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     private void performUpdateCheck() {
         this.updateChecker = new UpdateChecker(this, SPIGOT_ID);
-        if (!configService.current().settings().updateChecker()) {
+        if (!services.config().current().settings().updateChecker()) {
             return;
         }
 
@@ -261,9 +234,9 @@ public class BuildSystemPlugin extends JavaPlugin {
     }
 
     private CompletableFuture<Void> saveBuildConfig() {
-        CompletableFuture<Void> worldSave = worldService.save();
-        CompletableFuture<Void> playerSave = playerService.save();
-        CompletableFuture<Void> spawnSave = spawnService.save();
+        CompletableFuture<Void> worldSave = services.world().save();
+        CompletableFuture<Void> playerSave = services.player().save();
+        CompletableFuture<Void> spawnSave = services.spawn().save();
         return CompletableFuture.allOf(worldSave, playerSave, spawnSave);
     }
 
@@ -278,15 +251,15 @@ public class BuildSystemPlugin extends JavaPlugin {
         }
 
         reloadConfig();
-        configService.load();
+        services.config().load();
         if (isEnabled()) {
-            backupService.reload();
+            services.backup().reload();
         }
 
         if (init) {
-            worldService.remanageAllUnloadTasks();
+            services.world().remanageAllUnloadTasks();
 
-            if (configService.current().settings().scoreboard()) {
+            if (services.config().current().settings().scoreboard()) {
                 getSettingsService().displayScoreboard();
             } else {
                 getSettingsService().hideScoreboards();
@@ -295,54 +268,54 @@ public class BuildSystemPlugin extends JavaPlugin {
     }
 
     public NavigatorService getNavigatorService() {
-        return navigatorService;
+        return services.navigator();
     }
 
     public CustomBlockManager getCustomBlockManager() {
-        return customBlockManager;
+        return services.customBlockManager();
     }
 
     public PlayerServiceImpl getPlayerService() {
-        return playerService;
+        return services.player();
     }
 
     public PlayerLookupService getPlayerLookupService() {
-        return playerLookupService;
+        return services.playerLookup();
     }
 
     public NoClipService getNoClipService() {
-        return noClipService;
+        return services.noClip();
     }
 
     public SettingsService getSettingsService() {
-        return settingsService;
+        return services.settings();
     }
 
     public SpawnService getSpawnService() {
-        return spawnService;
+        return services.spawn();
     }
 
     public WorldServiceImpl getWorldService() {
-        return worldService;
+        return services.world();
     }
 
     public BackupService getBackupService() {
-        return backupService;
+        return services.backup();
     }
 
     public ConfigService getConfigService() {
-        return configService;
+        return services.config();
     }
 
     public Messages getMessages() {
-        return messages;
+        return services.messages();
     }
 
     public CustomizableIcons getCustomizableIcons() {
-        return customizableIcons;
+        return services.customizableIcons();
     }
 
     public MenuItems getMenuItems() {
-        return menuItems;
+        return services.menuItems();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -19,7 +19,6 @@ package de.eintosti.buildsystem;
 
 import de.eintosti.buildsystem.api.BuildSystem;
 import de.eintosti.buildsystem.api.player.BuildPlayer;
-import de.eintosti.buildsystem.api.player.settings.NavigatorType;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.command.CommandRegistrar;
 import de.eintosti.buildsystem.config.ConfigService;
@@ -42,13 +41,8 @@ import de.eintosti.buildsystem.world.backup.BackupService;
 import de.eintosti.buildsystem.world.display.CustomizableIcons;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
 import java.io.File;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
-import org.bstats.bukkit.Metrics;
-import org.bstats.charts.AdvancedPie;
-import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -106,7 +100,7 @@ public class BuildSystemPlugin extends JavaPlugin {
             services.settings().displayScoreboard(pl);
         });
 
-        registerStats();
+        new BuildSystemMetrics(this).register();
 
         this.configSaveTask = Bukkit.getScheduler()
                 .runTaskTimerAsynchronously(this, this::saveBuildConfig, 6000L, 6000L); // Every 5 minutes
@@ -150,48 +144,6 @@ public class BuildSystemPlugin extends JavaPlugin {
         Bukkit.getConsoleSender()
                 .sendMessage("%sBuildSystem » Plugin %sdisabled%s!"
                         .formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
-    }
-
-    private void registerStats() {
-        Metrics metrics = new Metrics(this, METRICS_ID);
-        metrics.addCustomChart(new SimplePie(
-                "archive_vanish",
-                () -> String.valueOf(
-                        services.config().current().settings().archive().vanish())));
-        metrics.addCustomChart(new SimplePie(
-                "block_world_edit",
-                () -> String.valueOf(
-                        services.config().current().settings().builder().blockWorldEditNonBuilder())));
-        metrics.addCustomChart(new SimplePie(
-                "join_quit_messages",
-                () -> String.valueOf(services.config().current().settings().joinQuitMessages())));
-        metrics.addCustomChart(new SimplePie(
-                "lock_weather",
-                () -> String.valueOf(services.config().current().world().lockWeather())));
-        metrics.addCustomChart(new SimplePie(
-                "scoreboard",
-                () -> String.valueOf(services.config().current().settings().scoreboard())));
-        metrics.addCustomChart(new SimplePie(
-                "update_checker",
-                () -> String.valueOf(services.config().current().settings().updateChecker())));
-        metrics.addCustomChart(new SimplePie(
-                "unload_worlds",
-                () -> String.valueOf(
-                        services.config().current().world().unload().enabled())));
-        metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
-            Map<NavigatorType, Long> countsByType = services.player().getPlayerStorage().getBuildPlayers().stream()
-                    .collect(Collectors.groupingBy(
-                            buildPlayer -> buildPlayer.getSettings().getNavigatorType(), Collectors.counting()));
-            int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
-            int newCount = countsByType.getOrDefault(NavigatorType.NEW, 0L).intValue();
-            return Map.of("Old", oldCount, "New", newCount);
-        }));
-        metrics.addCustomChart(new SimplePie(
-                "folder_override_permissions",
-                () -> String.valueOf(services.config().current().folder().overridePermissions())));
-        metrics.addCustomChart(new SimplePie(
-                "folder_override_projects",
-                () -> String.valueOf(services.config().current().folder().overrideProjects())));
     }
 
     public UpdateChecker getUpdateChecker() {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/Services.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/Services.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem;
+
+import de.eintosti.buildsystem.config.ConfigService;
+import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.navigator.NavigatorService;
+import de.eintosti.buildsystem.player.PlayerLookupService;
+import de.eintosti.buildsystem.player.PlayerServiceImpl;
+import de.eintosti.buildsystem.player.customblock.CustomBlockManager;
+import de.eintosti.buildsystem.player.noclip.NoClipService;
+import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import de.eintosti.buildsystem.world.backup.BackupService;
+import de.eintosti.buildsystem.world.display.CustomizableIcons;
+import de.eintosti.buildsystem.world.spawn.SpawnService;
+
+/**
+ * Internal holder for the plugin's services. Centralizes the service fields and their construction order so that
+ * {@link BuildSystemPlugin} can delegate its getters here instead of carrying the wiring inline.
+ *
+ * <p>The construction order is load-bearing: {@link #initClasses()} mirrors the order services depend on each other.
+ */
+final class Services {
+
+    private final BuildSystemPlugin plugin;
+
+    // Built during onLoad, before the onEnable-phase services.
+    private ConfigService configService;
+    private Messages messages;
+
+    // Built during onEnable, in dependency order (see initClasses()).
+    private CustomizableIcons customizableIcons;
+    private CustomBlockManager customBlockManager;
+    private PlayerLookupService playerLookupService;
+    private PlayerServiceImpl playerService;
+    private NavigatorService navigatorService;
+    private NoClipService noClipService;
+    private WorldServiceImpl worldService;
+    private BackupService backupService;
+    private SettingsService settingsService;
+    private SpawnService spawnService;
+    private MenuItems menuItems;
+
+    Services(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Builds the config service and messages. Invoked from {@code onLoad}, before {@link #initClasses()}.
+     */
+    void loadCore() {
+        this.configService = new ConfigService(plugin);
+    }
+
+    void loadMessages() {
+        this.messages = new Messages(plugin, configService);
+    }
+
+    /**
+     * Constructs the onEnable-phase services in their required order. The sequence is load-bearing.
+     */
+    void initClasses() {
+        this.customizableIcons = new CustomizableIcons(plugin);
+
+        this.customBlockManager = new CustomBlockManager(plugin);
+        this.playerLookupService = new PlayerLookupService(plugin);
+        (this.playerService = new PlayerServiceImpl(plugin)).init();
+        this.navigatorService = new NavigatorService(plugin);
+        this.noClipService = new NoClipService(plugin);
+        (this.worldService = new WorldServiceImpl(plugin)).init();
+        this.backupService = new BackupService(plugin);
+        this.settingsService = new SettingsService(plugin);
+        this.spawnService = new SpawnService(plugin);
+        this.menuItems = new MenuItems(plugin, configService, messages, settingsService);
+    }
+
+    ConfigService config() {
+        return configService;
+    }
+
+    Messages messages() {
+        return messages;
+    }
+
+    CustomizableIcons customizableIcons() {
+        return customizableIcons;
+    }
+
+    CustomBlockManager customBlockManager() {
+        return customBlockManager;
+    }
+
+    PlayerLookupService playerLookup() {
+        return playerLookupService;
+    }
+
+    PlayerServiceImpl player() {
+        return playerService;
+    }
+
+    NavigatorService navigator() {
+        return navigatorService;
+    }
+
+    NoClipService noClip() {
+        return noClipService;
+    }
+
+    WorldServiceImpl world() {
+        return worldService;
+    }
+
+    BackupService backup() {
+        return backupService;
+    }
+
+    SettingsService settings() {
+        return settingsService;
+    }
+
+    SpawnService spawn() {
+        return spawnService;
+    }
+
+    MenuItems menuItems() {
+        return menuItems;
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/MessageStore.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/MessageStore.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.i18n;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Loads, merges and looks up messages from {@code messages.yml}. Owns the raw message map and the bundled-default
+ * merge/copy-back; rendering and sending are handled by {@link Messages}.
+ */
+@NullMarked
+final class MessageStore {
+
+    private final BuildSystemPlugin plugin;
+    private volatile Map<String, String> messages = Map.of();
+
+    MessageStore(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    void load() {
+        // 1. If user file doesn't exist, save the bundled default
+        File file = new File(plugin.getDataFolder(), "messages.yml");
+        if (!file.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+
+        // 2. Load user file and bundled defaults
+        YamlConfiguration userConfig = YamlConfiguration.loadConfiguration(file);
+        InputStream defaultStream = plugin.getResource("messages.yml");
+        if (defaultStream != null) {
+            YamlConfiguration defaults =
+                    YamlConfiguration.loadConfiguration(new InputStreamReader(defaultStream, StandardCharsets.UTF_8));
+            // 3. Copy missing keys from bundled defaults to user file
+            boolean changed = false;
+            for (String key : defaults.getKeys(false)) {
+                if (!userConfig.contains(key)) {
+                    userConfig.set(key, defaults.get(key));
+                    changed = true;
+                }
+            }
+            if (changed) {
+                try {
+                    userConfig.save(file);
+                } catch (IOException e) {
+                    plugin.getLogger().log(Level.SEVERE, "Could not save messages.yml", e);
+                }
+            }
+        }
+
+        // 4. Build messages map
+        Map<String, String> map = new HashMap<>();
+        ConfigurationSection section = userConfig.getConfigurationSection("");
+        if (section != null) {
+            section.getKeys(false).forEach(key -> {
+                if (!userConfig.contains(key)) {
+                    Bukkit.getConsoleSender()
+                            .sendMessage(ChatColor.RED + "[BuildSystem] Could not find message with key: " + key);
+                    return;
+                }
+                if (userConfig.isList(key)) {
+                    map.put(key, String.join("\n", userConfig.getStringList(key)));
+                } else {
+                    map.put(
+                            key,
+                            Objects.requireNonNull(
+                                    userConfig.getString(key), "Message key '%s' is null".formatted(key)));
+                }
+            });
+        }
+        this.messages = Map.copyOf(map);
+    }
+
+    void reload() {
+        load();
+    }
+
+    String getPrefix() {
+        return messages.getOrDefault("prefix", "");
+    }
+
+    private void checkIfKeyPresent(String key) {
+        if (!messages.containsKey(key)) {
+            plugin.getLogger().warning("Could not find message with key: " + key);
+        }
+    }
+
+    /**
+     * Returns the raw message for the given key with the {@code %prefix%} token substituted, warning when the key is
+     * missing. The returned text has not yet had placeholders, the external resolver, or colors applied.
+     *
+     * @param key The message key
+     * @return The raw, prefix-substituted message, or an empty string when the key is missing
+     */
+    String getRaw(String key) {
+        checkIfKeyPresent(key);
+        return messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+    }
+
+    /**
+     * Returns the raw message for the given key with the {@code %prefix%} token substituted, without emitting a
+     * missing-key warning. The returned text has not yet had placeholders, the external resolver, or colors applied.
+     *
+     * @param key The message key
+     * @return The raw, prefix-substituted message, or an empty string when the key is missing
+     */
+    String getRawUnchecked(String key) {
+        return messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/Messages.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/Messages.java
@@ -22,20 +22,12 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.util.color.ColorAPI;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Function;
-import java.util.logging.Level;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
@@ -44,14 +36,13 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class Messages {
 
-    private final BuildSystemPlugin plugin;
     private final ConfigService configService;
-    private volatile Map<String, String> messages = Map.of();
+    private final MessageStore store;
     private volatile @Nullable TextResolver placeholderResolver;
 
     public Messages(BuildSystemPlugin plugin, ConfigService configService) {
-        this.plugin = plugin;
         this.configService = configService;
+        this.store = new MessageStore(plugin);
     }
 
     /**
@@ -65,70 +56,11 @@ public final class Messages {
     }
 
     public void load() {
-        // 1. If user file doesn't exist, save the bundled default
-        File file = new File(plugin.getDataFolder(), "messages.yml");
-        if (!file.exists()) {
-            plugin.saveResource("messages.yml", false);
-        }
-
-        // 2. Load user file and bundled defaults
-        YamlConfiguration userConfig = YamlConfiguration.loadConfiguration(file);
-        java.io.InputStream defaultStream = plugin.getResource("messages.yml");
-        if (defaultStream != null) {
-            YamlConfiguration defaults =
-                    YamlConfiguration.loadConfiguration(new InputStreamReader(defaultStream, StandardCharsets.UTF_8));
-            // 3. Copy missing keys from bundled defaults to user file
-            boolean changed = false;
-            for (String key : defaults.getKeys(false)) {
-                if (!userConfig.contains(key)) {
-                    userConfig.set(key, defaults.get(key));
-                    changed = true;
-                }
-            }
-            if (changed) {
-                try {
-                    userConfig.save(file);
-                } catch (IOException e) {
-                    plugin.getLogger().log(Level.SEVERE, "Could not save messages.yml", e);
-                }
-            }
-        }
-
-        // 4. Build messages map
-        Map<String, String> map = new HashMap<>();
-        ConfigurationSection section = userConfig.getConfigurationSection("");
-        if (section != null) {
-            section.getKeys(false).forEach(key -> {
-                if (!userConfig.contains(key)) {
-                    Bukkit.getConsoleSender()
-                            .sendMessage(ChatColor.RED + "[BuildSystem] Could not find message with key: " + key);
-                    return;
-                }
-                if (userConfig.isList(key)) {
-                    map.put(key, String.join("\n", userConfig.getStringList(key)));
-                } else {
-                    map.put(
-                            key,
-                            Objects.requireNonNull(
-                                    userConfig.getString(key), "Message key '%s' is null".formatted(key)));
-                }
-            });
-        }
-        this.messages = Map.copyOf(map);
+        store.load();
     }
 
     public void reload() {
-        load();
-    }
-
-    private String getPrefix() {
-        return messages.getOrDefault("prefix", "");
-    }
-
-    private void checkIfKeyPresent(String key) {
-        if (!messages.containsKey(key)) {
-            plugin.getLogger().warning("Could not find message with key: " + key);
-        }
+        store.reload();
     }
 
     public void sendPermissionError(CommandSender sender) {
@@ -145,8 +77,7 @@ public final class Messages {
 
     @SafeVarargs
     public final String getString(String key, CommandSender sender, Entry<String, Object>... placeholders) {
-        checkIfKeyPresent(key);
-        String message = messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+        String message = store.getRaw(key);
         String result = Placeholders.apply(message, placeholders);
         Player player = sender instanceof Player p ? p : null;
         return ColorAPI.process(applyResolver(this.placeholderResolver, player, result));
@@ -177,7 +108,7 @@ public final class Messages {
     @Unmodifiable
     public List<String> getStringList(
             String key, @Nullable Player player, Function<String, Entry<String, Object>[]> placeholders) {
-        String message = messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+        String message = store.getRawUnchecked(key);
         TextResolver resolver = this.placeholderResolver;
         return Arrays.stream(message.split("\n"))
                 .map(line -> Placeholders.apply(line, placeholders.apply(line)))

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.world;
 
-import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.event.world.BuildWorldDeleteEvent;
 import de.eintosti.buildsystem.api.event.world.BuildWorldPostDeleteEvent;
@@ -35,17 +34,17 @@ import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
 import de.eintosti.buildsystem.api.world.creation.generator.Generator;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.display.Folder;
-import de.eintosti.buildsystem.menu.PlayerChatInput;
 import de.eintosti.buildsystem.storage.FolderStorageImpl;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
 import de.eintosti.buildsystem.storage.yaml.YamlFolderStorage;
 import de.eintosti.buildsystem.storage.yaml.YamlWorldStorage;
 import de.eintosti.buildsystem.util.FileUtils;
-import de.eintosti.buildsystem.util.StringCleaner;
-import de.eintosti.buildsystem.world.creation.BukkitWorldFactory;
 import de.eintosti.buildsystem.world.creation.WorldBuilderImpl;
+import de.eintosti.buildsystem.world.creation.WorldCreationPrompts;
+import de.eintosti.buildsystem.world.creation.WorldImportCoordinator;
 import de.eintosti.buildsystem.world.creation.WorldImporterImpl;
 import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
+import de.eintosti.buildsystem.world.lifecycle.WorldLoadBootstrap;
 import de.eintosti.buildsystem.world.lifecycle.WorldRenamer;
 import de.eintosti.buildsystem.world.lifecycle.WorldUnloaderImpl;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
@@ -54,15 +53,11 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -71,127 +66,23 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class WorldServiceImpl implements WorldService {
 
-    private final AtomicBoolean importingAllWorlds = new AtomicBoolean(false);
-
     private final BuildSystemPlugin plugin;
     private final FolderStorageImpl folderStorage;
     private final WorldStorageImpl worldStorage;
+    private final WorldImportCoordinator importCoordinator;
+    private final WorldCreationPrompts creationPrompts;
 
     public WorldServiceImpl(BuildSystemPlugin plugin) {
         this.plugin = plugin;
         this.worldStorage = new YamlWorldStorage(plugin);
         this.folderStorage = new YamlFolderStorage(plugin, this.worldStorage);
+        this.importCoordinator = new WorldImportCoordinator(plugin, this, this.worldStorage);
+        this.creationPrompts = new WorldCreationPrompts(plugin, this);
     }
 
     public void init() {
         this.folderStorage.loadFolders();
-        loadWorlds();
-    }
-
-    private void loadWorlds() {
-        this.worldStorage
-                .load()
-                .thenAccept(worlds -> Bukkit.getScheduler().runTask(plugin, () -> {
-                    worlds.forEach(worldStorage::addBuildWorld);
-                    assignWorldsToFolders();
-
-                    boolean loadAllWorlds = !plugin.getConfigService()
-                            .current()
-                            .world()
-                            .unload()
-                            .enabled();
-                    if (loadAllWorlds) {
-                        plugin.getLogger().info("*** All worlds will be loaded now ***");
-                    }
-
-                    List<BuildWorld> notLoaded = new ArrayList<>();
-                    worldStorage.getBuildWorlds().forEach(buildWorld -> {
-                        if (preLoadWorld(buildWorld, loadAllWorlds) == LoadResult.FAILED) {
-                            notLoaded.add(buildWorld);
-                        }
-                    });
-                    notLoaded.forEach(worldStorage::removeBuildWorld);
-
-                    plugin.getLogger().info("Loaded " + worlds.size() + " worlds from storage");
-                }))
-                .exceptionally(throwable -> {
-                    plugin.getLogger().log(Level.SEVERE, "Failed to load worlds from storage", throwable);
-                    return null;
-                });
-    }
-
-    /**
-     * Assigns all {@link BuildWorld}s to their respective {@link Folder}s, dropping references to worlds that no longer
-     * exist.
-     *
-     * <p>Must be called after all folders and worlds have been loaded.
-     */
-    private void assignWorldsToFolders() {
-        folderStorage.getFolders().forEach(folder -> {
-            List<UUID> invalidWorlds = new ArrayList<>();
-            folder.getWorldUUIDs().stream()
-                    .map(worldUUID -> {
-                        BuildWorld buildWorld = worldStorage.getBuildWorld(worldUUID);
-                        if (buildWorld == null) {
-                            invalidWorlds.add(worldUUID);
-                            plugin.getLogger()
-                                    .warning("World with UUID " + worldUUID + " does not exist. Removing from folder: "
-                                            + folder.getName());
-                        }
-                        return buildWorld;
-                    })
-                    .filter(Objects::nonNull)
-                    .forEach(buildWorld -> buildWorld.setFolder(folder));
-            invalidWorlds.forEach(folder::removeWorld);
-        });
-    }
-
-    /**
-     * Attempts to load the Bukkit world backing the given {@link BuildWorld} at startup.
-     *
-     * @param buildWorld The world to load
-     * @param alwaysLoad Whether the world should always be loaded, regardless of being blacklisted
-     * @return The result of the load attempt
-     */
-    private LoadResult preLoadWorld(BuildWorld buildWorld, boolean alwaysLoad) {
-        String worldName = buildWorld.getName();
-        boolean shouldPreLoad = alwaysLoad
-                || plugin.getConfigService()
-                        .current()
-                        .world()
-                        .unload()
-                        .blacklistedWorlds()
-                        .contains(worldName);
-        if (!shouldPreLoad) {
-            return LoadResult.NOT_LOADED;
-        }
-
-        World world = new BukkitWorldFactory(plugin, buildWorld).generate(BukkitWorldFactory.VersionCheck.REQUIRED);
-        if (world == null) {
-            return LoadResult.FAILED;
-        }
-
-        buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
-        plugin.getLogger().info("✔ World loaded: " + worldName);
-        return LoadResult.LOADED;
-    }
-
-    private enum LoadResult {
-
-        /**
-         * The {@link BuildWorld} was successfully loaded.
-         */
-        LOADED,
-
-        /**
-         * The {@link BuildWorld} was attempted to be loaded, but failed.
-         */
-        FAILED,
-
-        /**
-         * Not attempted: unloading is enabled and the world is not blacklisted, so it may stay unloaded.
-         */
-        NOT_LOADED
+        new WorldLoadBootstrap(plugin, worldStorage, folderStorage).loadWorlds();
     }
 
     @Override
@@ -222,63 +113,7 @@ public class WorldServiceImpl implements WorldService {
             @Nullable String template,
             boolean privateWorld,
             @Nullable Folder folder) {
-        player.closeInventory();
-        PlayerChatInput.requestSanitizedName(
-                plugin,
-                player,
-                "enter_world_name",
-                "worlds_world_creation_invalid_characters",
-                "worlds_world_creation_name_bank",
-                worldName -> {
-                    if (worldType == BuildWorldType.CUSTOM) {
-                        startCustomGeneratorInput(player, worldName, template, privateWorld, folder);
-                    } else {
-                        buildAndTeleport(
-                                player,
-                                newWorld(worldName)
-                                        .type(worldType)
-                                        .template(template)
-                                        .privateWorld(privateWorld)
-                                        .folder(folder));
-                    }
-                });
-    }
-
-    private void startCustomGeneratorInput(
-            Player player, String worldName, @Nullable String template, boolean privateWorld, @Nullable Folder folder) {
-        new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
-            boolean restrictTemplateAccess =
-                    plugin.getConfigService().current().settings().restrictTemplateAccess();
-            if (restrictTemplateAccess && !player.hasPermission("buildsystem.create.generator." + input.trim())) {
-                plugin.getMessages().sendPermissionError(player);
-                XSound.ENTITY_ITEM_BREAK.play(player);
-                return;
-            }
-
-            CustomGenerator customGenerator = CustomGeneratorImpl.of(input, worldName);
-            if (customGenerator == null) {
-                plugin.getMessages().sendMessage(player, "worlds_import_unknown_generator");
-                XSound.ENTITY_ITEM_BREAK.play(player);
-                return;
-            }
-
-            buildAndTeleport(
-                    player,
-                    newWorld(worldName)
-                            .type(BuildWorldType.CUSTOM)
-                            .template(template)
-                            .privateWorld(privateWorld)
-                            .customGenerator(customGenerator)
-                            .folder(folder));
-        });
-    }
-
-    private void buildAndTeleport(Player player, WorldBuilder worldBuilder) {
-        BuildWorld world =
-                worldBuilder.creator(Builder.of(player)).notify(player).build();
-        if (world != null) {
-            world.getTeleporter().teleport(player);
-        }
+        creationPrompts.startWorldNameInput(player, worldType, template, privateWorld, folder);
     }
 
     public boolean importWorld(
@@ -325,134 +160,16 @@ public class WorldServiceImpl implements WorldService {
     }
 
     public void importWorlds(Player player, String[] worldList, Generator generator, @Nullable Builder creator) {
-        int delay = plugin.getConfigService().current().world().importAllDelay();
-        plugin.getMessages()
-                .sendMessage(
-                        player, "worlds_importall_started", Map.entry("%amount%", String.valueOf(worldList.length)));
-        plugin.getMessages().sendMessage(player, "worlds_importall_delay", Map.entry("%delay%", String.valueOf(delay)));
-
-        importingAllWorlds.set(true);
-        BulkImportListener listener = new BulkImportListener() {
-            @Override
-            public void skippedExisting(String worldName) {
-                plugin.getMessages()
-                        .sendMessage(
-                                player, "worlds_importall_world_already_imported", Map.entry("%world%", worldName));
-            }
-
-            @Override
-            public void invalidName(String worldName, String invalidChar) {
-                plugin.getMessages()
-                        .sendMessage(
-                                player,
-                                "worlds_importall_invalid_character",
-                                Map.entry("%world%", worldName),
-                                Map.entry("%char%", invalidChar));
-            }
-
-            @Override
-            public void imported(String worldName) {
-                plugin.getMessages()
-                        .sendMessage(player, "worlds_importall_world_imported", Map.entry("%world%", worldName));
-            }
-        };
-        importStaggered(
-                        worldList,
-                        listener,
-                        worldName -> importWorld(
-                                player, worldName, creator, BuildWorldType.IMPORTED, generator, "void", false))
-                .thenRun(() -> plugin.getMessages().sendMessage(player, "worlds_importall_finished"));
+        importCoordinator.importWorlds(player, worldList, generator, creator);
     }
 
     public boolean isImportingAllWorlds() {
-        return importingAllWorlds.get();
+        return importCoordinator.isImportingAllWorlds();
     }
 
     @Override
     public CompletableFuture<Integer> importWorlds() {
-        if (!importingAllWorlds.compareAndSet(false, true)) {
-            return CompletableFuture.failedFuture(new IllegalStateException("A bulk import is already in progress"));
-        }
-
-        String[] directories = scanImportableDirectories();
-        if (directories.length == 0) {
-            importingAllWorlds.set(false);
-            return CompletableFuture.completedFuture(0);
-        }
-
-        return importStaggered(
-                directories,
-                new BulkImportListener() {},
-                worldName -> importWorld(worldName).build() != null);
-    }
-
-    /**
-     * Per-world progress callbacks for a staggered bulk import.
-     */
-    private interface BulkImportListener {
-
-        default void skippedExisting(String worldName) {}
-
-        default void invalidName(String worldName, String invalidChar) {}
-
-        default void imported(String worldName) {}
-    }
-
-    /**
-     * Imports the given worlds one per configured delay interval, skipping names that are already imported or contain
-     * invalid characters. Clears {@link #importingAllWorlds} and completes with the import count once all names have
-     * been processed.
-     */
-    private CompletableFuture<Integer> importStaggered(
-            String[] worldNames, BulkImportListener listener, Predicate<String> importer) {
-        int delay = plugin.getConfigService().current().world().importAllDelay();
-        String invalidCharacters = plugin.getConfigService().current().world().invalidCharacters();
-
-        CompletableFuture<Integer> result = new CompletableFuture<>();
-        AtomicInteger index = new AtomicInteger(0);
-        AtomicInteger imported = new AtomicInteger(0);
-
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                int i = index.getAndIncrement();
-                if (i >= worldNames.length) {
-                    this.cancel();
-                    importingAllWorlds.set(false);
-                    result.complete(imported.get());
-                    return;
-                }
-
-                String worldName = worldNames[i];
-                if (worldStorage.worldExists(worldName)) {
-                    listener.skippedExisting(worldName);
-                    return;
-                }
-
-                String invalidChar = StringCleaner.firstInvalidChar(worldName, invalidCharacters);
-                if (invalidChar != null) {
-                    listener.invalidName(worldName, invalidChar);
-                    return;
-                }
-
-                if (importer.test(worldName)) {
-                    imported.incrementAndGet();
-                    listener.imported(worldName);
-                }
-            }
-        }.runTaskTimer(plugin, 0, 20L * delay);
-
-        return result;
-    }
-
-    private String[] scanImportableDirectories() {
-        String[] directories = Bukkit.getWorldContainer().list((dir, name) -> {
-            File worldFolder = new File(dir, name);
-            return worldFolder.isDirectory()
-                    && new File(worldFolder, "level.dat").exists()
-                    && !worldStorage.worldExists(name);
-        });
-        return directories != null ? directories : new String[0];
+        return importCoordinator.importWorlds();
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.creation;
+
+import com.cryptomorin.xseries.XSound;
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.builder.Builder;
+import de.eintosti.buildsystem.api.world.creation.WorldBuilder;
+import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
+import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.menu.PlayerChatInput;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
+import org.bukkit.entity.Player;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Drives the chat-input world creation flow: prompting the player for a world name, optionally a custom generator, and
+ * then building and teleporting them into the new world.
+ */
+@NullMarked
+public class WorldCreationPrompts {
+
+    private final BuildSystemPlugin plugin;
+    private final WorldServiceImpl worldService;
+
+    public WorldCreationPrompts(BuildSystemPlugin plugin, WorldServiceImpl worldService) {
+        this.plugin = plugin;
+        this.worldService = worldService;
+    }
+
+    public void startWorldNameInput(
+            Player player,
+            BuildWorldType worldType,
+            @Nullable String template,
+            boolean privateWorld,
+            @Nullable Folder folder) {
+        player.closeInventory();
+        PlayerChatInput.requestSanitizedName(
+                plugin,
+                player,
+                "enter_world_name",
+                "worlds_world_creation_invalid_characters",
+                "worlds_world_creation_name_bank",
+                worldName -> {
+                    if (worldType == BuildWorldType.CUSTOM) {
+                        startCustomGeneratorInput(player, worldName, template, privateWorld, folder);
+                    } else {
+                        buildAndTeleport(
+                                player,
+                                worldService
+                                        .newWorld(worldName)
+                                        .type(worldType)
+                                        .template(template)
+                                        .privateWorld(privateWorld)
+                                        .folder(folder));
+                    }
+                });
+    }
+
+    private void startCustomGeneratorInput(
+            Player player, String worldName, @Nullable String template, boolean privateWorld, @Nullable Folder folder) {
+        new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
+            boolean restrictTemplateAccess =
+                    plugin.getConfigService().current().settings().restrictTemplateAccess();
+            if (restrictTemplateAccess && !player.hasPermission("buildsystem.create.generator." + input.trim())) {
+                plugin.getMessages().sendPermissionError(player);
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                return;
+            }
+
+            CustomGenerator customGenerator = CustomGeneratorImpl.of(input, worldName);
+            if (customGenerator == null) {
+                plugin.getMessages().sendMessage(player, "worlds_import_unknown_generator");
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                return;
+            }
+
+            buildAndTeleport(
+                    player,
+                    worldService
+                            .newWorld(worldName)
+                            .type(BuildWorldType.CUSTOM)
+                            .template(template)
+                            .privateWorld(privateWorld)
+                            .customGenerator(customGenerator)
+                            .folder(folder));
+        });
+    }
+
+    private void buildAndTeleport(Player player, WorldBuilder worldBuilder) {
+        BuildWorld world =
+                worldBuilder.creator(Builder.of(player)).notify(player).build();
+        if (world != null) {
+            world.getTeleporter().teleport(player);
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImportCoordinator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImportCoordinator.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.creation;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.builder.Builder;
+import de.eintosti.buildsystem.api.world.creation.generator.Generator;
+import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.StringCleaner;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Coordinates staggered bulk imports of worlds, importing one world per configured delay interval while tracking
+ * whether an import is currently in progress.
+ */
+@NullMarked
+public class WorldImportCoordinator {
+
+    private final AtomicBoolean importingAllWorlds = new AtomicBoolean(false);
+
+    private final BuildSystemPlugin plugin;
+    private final WorldServiceImpl worldService;
+    private final WorldStorageImpl worldStorage;
+
+    public WorldImportCoordinator(
+            BuildSystemPlugin plugin, WorldServiceImpl worldService, WorldStorageImpl worldStorage) {
+        this.plugin = plugin;
+        this.worldService = worldService;
+        this.worldStorage = worldStorage;
+    }
+
+    public void importWorlds(Player player, String[] worldList, Generator generator, @Nullable Builder creator) {
+        int delay = plugin.getConfigService().current().world().importAllDelay();
+        plugin.getMessages()
+                .sendMessage(
+                        player, "worlds_importall_started", Map.entry("%amount%", String.valueOf(worldList.length)));
+        plugin.getMessages().sendMessage(player, "worlds_importall_delay", Map.entry("%delay%", String.valueOf(delay)));
+
+        importingAllWorlds.set(true);
+        BulkImportListener listener = new BulkImportListener() {
+            @Override
+            public void skippedExisting(String worldName) {
+                plugin.getMessages()
+                        .sendMessage(
+                                player, "worlds_importall_world_already_imported", Map.entry("%world%", worldName));
+            }
+
+            @Override
+            public void invalidName(String worldName, String invalidChar) {
+                plugin.getMessages()
+                        .sendMessage(
+                                player,
+                                "worlds_importall_invalid_character",
+                                Map.entry("%world%", worldName),
+                                Map.entry("%char%", invalidChar));
+            }
+
+            @Override
+            public void imported(String worldName) {
+                plugin.getMessages()
+                        .sendMessage(player, "worlds_importall_world_imported", Map.entry("%world%", worldName));
+            }
+        };
+        importStaggered(
+                        worldList,
+                        listener,
+                        worldName -> worldService.importWorld(
+                                player, worldName, creator, BuildWorldType.IMPORTED, generator, "void", false))
+                .thenRun(() -> plugin.getMessages().sendMessage(player, "worlds_importall_finished"));
+    }
+
+    public boolean isImportingAllWorlds() {
+        return importingAllWorlds.get();
+    }
+
+    public CompletableFuture<Integer> importWorlds() {
+        if (!importingAllWorlds.compareAndSet(false, true)) {
+            return CompletableFuture.failedFuture(new IllegalStateException("A bulk import is already in progress"));
+        }
+
+        String[] directories = scanImportableDirectories();
+        if (directories.length == 0) {
+            importingAllWorlds.set(false);
+            return CompletableFuture.completedFuture(0);
+        }
+
+        return importStaggered(
+                directories,
+                new BulkImportListener() {},
+                worldName -> worldService.importWorld(worldName).build() != null);
+    }
+
+    /**
+     * Per-world progress callbacks for a staggered bulk import.
+     */
+    private interface BulkImportListener {
+
+        default void skippedExisting(String worldName) {}
+
+        default void invalidName(String worldName, String invalidChar) {}
+
+        default void imported(String worldName) {}
+    }
+
+    /**
+     * Imports the given worlds one per configured delay interval, skipping names that are already imported or contain
+     * invalid characters. Clears {@link #importingAllWorlds} and completes with the import count once all names have
+     * been processed.
+     */
+    private CompletableFuture<Integer> importStaggered(
+            String[] worldNames, BulkImportListener listener, Predicate<String> importer) {
+        int delay = plugin.getConfigService().current().world().importAllDelay();
+        String invalidCharacters = plugin.getConfigService().current().world().invalidCharacters();
+
+        CompletableFuture<Integer> result = new CompletableFuture<>();
+        AtomicInteger index = new AtomicInteger(0);
+        AtomicInteger imported = new AtomicInteger(0);
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                int i = index.getAndIncrement();
+                if (i >= worldNames.length) {
+                    this.cancel();
+                    importingAllWorlds.set(false);
+                    result.complete(imported.get());
+                    return;
+                }
+
+                String worldName = worldNames[i];
+                if (worldStorage.worldExists(worldName)) {
+                    listener.skippedExisting(worldName);
+                    return;
+                }
+
+                String invalidChar = StringCleaner.firstInvalidChar(worldName, invalidCharacters);
+                if (invalidChar != null) {
+                    listener.invalidName(worldName, invalidChar);
+                    return;
+                }
+
+                if (importer.test(worldName)) {
+                    imported.incrementAndGet();
+                    listener.imported(worldName);
+                }
+            }
+        }.runTaskTimer(plugin, 0, 20L * delay);
+
+        return result;
+    }
+
+    private String[] scanImportableDirectories() {
+        String[] directories = Bukkit.getWorldContainer().list((dir, name) -> {
+            File worldFolder = new File(dir, name);
+            return worldFolder.isDirectory()
+                    && new File(worldFolder, "level.dat").exists()
+                    && !worldStorage.worldExists(name);
+        });
+        return directories != null ? directories : new String[0];
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoadBootstrap.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoadBootstrap.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.lifecycle;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.storage.FolderStorageImpl;
+import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.world.creation.BukkitWorldFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Loads persisted {@link BuildWorld}s at startup: reads them from storage, assigns them to their folders, and
+ * pre-loads the backing Bukkit worlds that should be loaded immediately.
+ */
+@NullMarked
+public class WorldLoadBootstrap {
+
+    private final BuildSystemPlugin plugin;
+    private final WorldStorageImpl worldStorage;
+    private final FolderStorageImpl folderStorage;
+
+    public WorldLoadBootstrap(
+            BuildSystemPlugin plugin, WorldStorageImpl worldStorage, FolderStorageImpl folderStorage) {
+        this.plugin = plugin;
+        this.worldStorage = worldStorage;
+        this.folderStorage = folderStorage;
+    }
+
+    public void loadWorlds() {
+        this.worldStorage
+                .load()
+                .thenAccept(worlds -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    worlds.forEach(worldStorage::addBuildWorld);
+                    assignWorldsToFolders();
+
+                    boolean loadAllWorlds = !plugin.getConfigService()
+                            .current()
+                            .world()
+                            .unload()
+                            .enabled();
+                    if (loadAllWorlds) {
+                        plugin.getLogger().info("*** All worlds will be loaded now ***");
+                    }
+
+                    List<BuildWorld> notLoaded = new ArrayList<>();
+                    worldStorage.getBuildWorlds().forEach(buildWorld -> {
+                        if (preLoadWorld(buildWorld, loadAllWorlds) == LoadResult.FAILED) {
+                            notLoaded.add(buildWorld);
+                        }
+                    });
+                    notLoaded.forEach(worldStorage::removeBuildWorld);
+
+                    plugin.getLogger().info("Loaded " + worlds.size() + " worlds from storage");
+                }))
+                .exceptionally(throwable -> {
+                    plugin.getLogger().log(Level.SEVERE, "Failed to load worlds from storage", throwable);
+                    return null;
+                });
+    }
+
+    /**
+     * Assigns all {@link BuildWorld}s to their respective {@link Folder}s, dropping references to worlds that no longer
+     * exist.
+     *
+     * <p>Must be called after all folders and worlds have been loaded.
+     */
+    private void assignWorldsToFolders() {
+        folderStorage.getFolders().forEach(folder -> {
+            List<UUID> invalidWorlds = new ArrayList<>();
+            folder.getWorldUUIDs().stream()
+                    .map(worldUUID -> {
+                        BuildWorld buildWorld = worldStorage.getBuildWorld(worldUUID);
+                        if (buildWorld == null) {
+                            invalidWorlds.add(worldUUID);
+                            plugin.getLogger()
+                                    .warning("World with UUID " + worldUUID + " does not exist. Removing from folder: "
+                                            + folder.getName());
+                        }
+                        return buildWorld;
+                    })
+                    .filter(Objects::nonNull)
+                    .forEach(buildWorld -> buildWorld.setFolder(folder));
+            invalidWorlds.forEach(folder::removeWorld);
+        });
+    }
+
+    /**
+     * Attempts to load the Bukkit world backing the given {@link BuildWorld} at startup.
+     *
+     * @param buildWorld The world to load
+     * @param alwaysLoad Whether the world should always be loaded, regardless of being blacklisted
+     * @return The result of the load attempt
+     */
+    private LoadResult preLoadWorld(BuildWorld buildWorld, boolean alwaysLoad) {
+        String worldName = buildWorld.getName();
+        boolean shouldPreLoad = alwaysLoad
+                || plugin.getConfigService()
+                        .current()
+                        .world()
+                        .unload()
+                        .blacklistedWorlds()
+                        .contains(worldName);
+        if (!shouldPreLoad) {
+            return LoadResult.NOT_LOADED;
+        }
+
+        World world = new BukkitWorldFactory(plugin, buildWorld).generate(BukkitWorldFactory.VersionCheck.REQUIRED);
+        if (world == null) {
+            return LoadResult.FAILED;
+        }
+
+        buildWorld.getData().lastLoaded().set(System.currentTimeMillis());
+        plugin.getLogger().info("✔ World loaded: " + worldName);
+        return LoadResult.LOADED;
+    }
+
+    private enum LoadResult {
+
+        /**
+         * The {@link BuildWorld} was successfully loaded.
+         */
+        LOADED,
+
+        /**
+         * The {@link BuildWorld} was attempted to be loaded, but failed.
+         */
+        FAILED,
+
+        /**
+         * Not attempted: unloading is enabled and the world is not blacklisted, so it may stay unloaded.
+         */
+        NOT_LOADED
+    }
+}


### PR DESCRIPTION
Four behavior-preserving structural refactors. No public API or behavior changes — diffs are almost entirely code moves; all existing tests stay green.

## 1. Split `WorldServiceImpl` (was 598 lines)
Extracted three focused collaborators; the service keeps its public methods and delegates:
- `WorldImportCoordinator` — bulk import (staggered scheduling, `importWorlds()`, scan/listener).
- `WorldCreationPrompts` — the chat-input creation flow (preserves the #323 generator permission gating verbatim).
- `WorldLoadBootstrap` — startup world loading/folder assignment.

## 2. Split `Messages` (was 220 lines)
- `MessageStore` — file load/merge, missing-key copy-back, key lookup, prefix.
- `Messages` — the renderer (placeholders, resolver, color, send). Every public signature unchanged; `applyResolver` stays as-is for its test.

## 3. Slim `BuildSystemPlugin` (348 → 273 lines)
- Service fields/construction moved into an internal `Services` holder (17 fields → 4); the `getXxx()` getters delegate one-line, so the hundreds of call sites are untouched. Construction order preserved exactly.
- bStats chart setup (~40 lines) extracted into `BuildSystemMetrics`.

## Notes
- Adapted to current master (the merged #449–#451 already moved init into `onEnable` and added event firing / generator gating — all preserved).
- No public signatures changed; `WorldService` API interface untouched.
- `./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)