### PR TITLE
build: jar output location, run-paper test server, minimize() keep-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ Build requires **Java 25**.
 
 ### Then you will find...
 
-* the **BuildSystem** plugin jar `BuildSystem-<identifier>` in **buildsystem-core/build/libs**
+* the **BuildSystem** plugin jar `BuildSystem-<version>` in **build/libs** (the repo root)
 
 ### Other commands
 
+* `./gradlew runServer` will download a Paper server and start it with the freshly-built plugin for
+  local testing.
 * `gradlew idea` will generate an [IntelliJ IDEA](https://www.jetbrains.com/idea/) module for each
   folder.
 * `gradlew eclipse` will generate an [Eclipse](https://www.eclipse.org/downloads/) project for each

--- a/README.md
+++ b/README.md
@@ -153,10 +153,8 @@ Build requires **Java 25**.
 
 * `./gradlew runServer` will download a Paper server and start it with the freshly-built plugin for
   local testing.
-* `gradlew idea` will generate an [IntelliJ IDEA](https://www.jetbrains.com/idea/) module for each
+* `./gradlew idea` will generate an [IntelliJ IDEA](https://www.jetbrains.com/idea/) module for each
   folder.
-* `gradlew eclipse` will generate an [Eclipse](https://www.eclipse.org/downloads/) project for each
-  folder. _(Possibly broken!)_
 
 ### PR Policy
 

--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("java-library")
     id("com.gradleup.shadow") version "9.4.2"
     id("de.eldoria.plugin-yml.bukkit") version "0.9.0"
+    id("xyz.jpenilla.run-paper") version "2.3.1"
 }
 
 project.description = "Core"
@@ -75,8 +76,14 @@ tasks.named("assemble") {
 }
 
 tasks.named<ShadowJar>("shadowJar") {
-    minimize()
+    minimize {
+        exclude(dependency("software.amazon.awssdk:.*:.*"))
+        exclude(dependency("org.apache.sshd:.*:.*"))
+        exclude(dependency("org.bouncycastle:.*:.*"))
+        exclude(dependency("org.bstats:.*:.*"))
+    }
     archiveFileName.set("${rootProject.name}-${project.version}.jar")
+    destinationDirectory.set(rootProject.layout.buildDirectory.dir("libs"))
 
     val shadePath = "de.eintosti.buildsystem.external"
     relocate("com.cryptomorin.xseries", "$shadePath.xseries")
@@ -95,6 +102,14 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.slf4j", "$shadePath.slf4j")
     relocate("software.amazon.awssdk", "$shadePath.awssdk")
     relocate("software.amazon.eventstream", "$shadePath.awssdk.eventstream")
+}
+
+tasks.runServer {
+    minecraftVersion("26.1.2")
+}
+
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("unshaded")
 }
 
 tasks.processResources {


### PR DESCRIPTION
Build/DX improvements.

## The final jar is easier to find
- The shaded plugin jar (`BuildSystem-<version>.jar`) now builds to **`build/libs`** at the repo root, instead of being buried in `buildsystem-core/build/libs`. README updated to match.
- The plain (unshaded) jar gets an `unshaded` classifier so it doesn't sit confusingly next to the real artifact.

## One-command test server
- Adds [`run-paper`](https://github.com/jpenilla/run-task): `./gradlew runServer` downloads a Paper server and boots it with the freshly-built plugin. This is the kind of local smoke test that would have caught the Paper-26.1 `GameRule` `IncompatibleClassChangeError` before release.

## Hardened `minimize()`
- `minimize()` prunes classes that look unused — risky for reflection-/service-loaded shaded deps. Added excludes so the **AWS SDK, SSHD-SFTP, BouncyCastle, and bStats** are kept whole, preventing latent `ClassNotFoundException`/`NoClassDefFoundError` on the backup (S3/SFTP) code paths.

`./gradlew clean build` passes; jar confirmed at `build/libs/BuildSystem-<version>.jar`.

> Note: `runServer`'s `minecraftVersion("26.1.2")` matches this project's target; it resolves the server only when the task is actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)