### PR TITLE
refactor: split WorldServiceImpl/Messages, internal Services holder, extract BuildSystemMetrics

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemMetrics.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemMetrics.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem;
+
+import de.eintosti.buildsystem.api.player.settings.NavigatorType;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.SimplePie;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Registers the plugin's bStats charts.
+ */
+@NullMarked
+final class BuildSystemMetrics {
+
+    private final BuildSystemPlugin plugin;
+
+    BuildSystemMetrics(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    void register() {
+        Metrics metrics = new Metrics(plugin, BuildSystemPlugin.METRICS_ID);
+        metrics.addCustomChart(new SimplePie(
+                "archive_vanish",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().settings().archive().vanish())));
+        metrics.addCustomChart(new SimplePie(
+                "block_world_edit",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().settings().builder().blockWorldEditNonBuilder())));
+        metrics.addCustomChart(new SimplePie(
+                "join_quit_messages",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().settings().joinQuitMessages())));
+        metrics.addCustomChart(new SimplePie(
+                "lock_weather",
+                () -> String.valueOf(plugin.getConfigService().current().world().lockWeather())));
+        metrics.addCustomChart(new SimplePie(
+                "scoreboard",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().settings().scoreboard())));
+        metrics.addCustomChart(new SimplePie(
+                "update_checker",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().settings().updateChecker())));
+        metrics.addCustomChart(new SimplePie(
+                "unload_worlds",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().world().unload().enabled())));
+        metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
+            Map<NavigatorType, Long> countsByType =
+                    plugin.getPlayerService().getPlayerStorage().getBuildPlayers().stream()
+                            .collect(Collectors.groupingBy(
+                                    buildPlayer -> buildPlayer.getSettings().getNavigatorType(),
+                                    Collectors.counting()));
+            int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
+            int newCount = countsByType.getOrDefault(NavigatorType.NEW, 0L).intValue();
+            return Map.of("Old", oldCount, "New", newCount);
+        }));
+        metrics.addCustomChart(new SimplePie(
+                "folder_override_permissions",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().folder().overridePermissions())));
+        metrics.addCustomChart(new SimplePie(
+                "folder_override_projects",
+                () -> String.valueOf(
+                        plugin.getConfigService().current().folder().overrideProjects())));
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -62,20 +62,7 @@ public class BuildSystemPlugin extends JavaPlugin {
     public static final int METRICS_ID = 7427;
     public static final String ADMIN_PERMISSION = "buildsystem.admin";
 
-    private ConfigService configService;
-    private Messages messages;
-
-    private NavigatorService navigatorService;
-    private CustomBlockManager customBlockManager;
-    private PlayerServiceImpl playerService;
-    private PlayerLookupService playerLookupService;
-    private NoClipService noClipService;
-    private SettingsService settingsService;
-    private SpawnService spawnService;
-    private WorldServiceImpl worldService;
-    private BackupService backupService;
-    private CustomizableIcons customizableIcons;
-    private MenuItems menuItems;
+    private Services services;
 
     private UpdateChecker updateChecker;
 
@@ -87,20 +74,21 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     @Override
     public void onLoad() {
-        this.configService = new ConfigService(this);
+        this.services = new Services(this);
+
+        ConfigService configService = this.services.createConfigService();
         new ConfigMigrationManager(this).migrate();
         this.getConfig().options().copyDefaults(true);
         this.saveConfig();
-        this.configService.load();
+        configService.load();
 
-        this.messages = new Messages(this, configService);
-        this.messages.load();
+        this.services.createMessages().load();
         createTemplateFolder();
     }
 
     @Override
     public void onEnable() {
-        initClasses();
+        this.services.initClasses();
 
         new CommandRegistrar(this).registerAll();
         new ListenerRegistrar(this).registerAll();
@@ -112,10 +100,10 @@ public class BuildSystemPlugin extends JavaPlugin {
         getServer().getServicesManager().register(BuildSystem.class, api, this, ServicePriority.Normal);
 
         Bukkit.getOnlinePlayers().forEach(pl -> {
-            BuildPlayer buildPlayer = playerService.getPlayerStorage().createBuildPlayer(pl);
+            BuildPlayer buildPlayer = getPlayerService().getPlayerStorage().createBuildPlayer(pl);
             Settings settings = buildPlayer.getSettings();
-            noClipService.startNoClip(pl, settings);
-            settingsService.displayScoreboard(pl);
+            getNoClipService().startNoClip(pl, settings);
+            getSettingsService().displayScoreboard(pl);
         });
 
         registerStats();
@@ -132,17 +120,17 @@ public class BuildSystemPlugin extends JavaPlugin {
     public void onDisable() {
         Bukkit.getOnlinePlayers().forEach(pl -> {
             BuildPlayerImpl buildPlayer =
-                    BuildPlayerImpl.of(playerService.getPlayerStorage().getBuildPlayer(pl));
+                    BuildPlayerImpl.of(getPlayerService().getPlayerStorage().getBuildPlayer(pl));
             buildPlayer.getCachedValues().resetCachedValues(pl);
             buildPlayer.setLogoutLocation(new LogoutLocation(pl.getWorld().getName(), pl.getLocation()));
 
-            settingsService.hideScoreboard(pl);
-            noClipService.stopNoClip(pl.getUniqueId());
-            navigatorService.closeNewNavigator(pl);
+            getSettingsService().hideScoreboard(pl);
+            getNoClipService().stopNoClip(pl.getUniqueId());
+            getNavigatorService().closeNewNavigator(pl);
         });
 
-        this.backupService.close();
-        worldService.cancelAllUnloadTasks();
+        getBackupService().close();
+        getWorldService().cancelAllUnloadTasks();
 
         reloadConfigData(false);
         saveConfig();
@@ -164,48 +152,34 @@ public class BuildSystemPlugin extends JavaPlugin {
                         .formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
     }
 
-    private void initClasses() {
-        this.customizableIcons = new CustomizableIcons(this);
-
-        this.customBlockManager = new CustomBlockManager(this);
-        this.playerLookupService = new PlayerLookupService(this);
-        (this.playerService = new PlayerServiceImpl(this)).init();
-        this.navigatorService = new NavigatorService(this);
-        this.noClipService = new NoClipService(this);
-        (this.worldService = new WorldServiceImpl(this)).init();
-        this.backupService = new BackupService(this);
-        this.settingsService = new SettingsService(this);
-        this.spawnService = new SpawnService(this);
-        this.menuItems = new MenuItems(this, configService, messages, settingsService);
-    }
-
     private void registerStats() {
         Metrics metrics = new Metrics(this, METRICS_ID);
         metrics.addCustomChart(new SimplePie(
                 "archive_vanish",
                 () -> String.valueOf(
-                        configService.current().settings().archive().vanish())));
+                        getConfigService().current().settings().archive().vanish())));
         metrics.addCustomChart(new SimplePie(
                 "block_world_edit",
                 () -> String.valueOf(
-                        configService.current().settings().builder().blockWorldEditNonBuilder())));
+                        getConfigService().current().settings().builder().blockWorldEditNonBuilder())));
         metrics.addCustomChart(new SimplePie(
                 "join_quit_messages",
-                () -> String.valueOf(configService.current().settings().joinQuitMessages())));
+                () -> String.valueOf(getConfigService().current().settings().joinQuitMessages())));
         metrics.addCustomChart(new SimplePie(
                 "lock_weather",
-                () -> String.valueOf(configService.current().world().lockWeather())));
+                () -> String.valueOf(getConfigService().current().world().lockWeather())));
         metrics.addCustomChart(new SimplePie(
                 "scoreboard",
-                () -> String.valueOf(configService.current().settings().scoreboard())));
+                () -> String.valueOf(getConfigService().current().settings().scoreboard())));
         metrics.addCustomChart(new SimplePie(
                 "update_checker",
-                () -> String.valueOf(configService.current().settings().updateChecker())));
+                () -> String.valueOf(getConfigService().current().settings().updateChecker())));
         metrics.addCustomChart(new SimplePie(
                 "unload_worlds",
-                () -> String.valueOf(configService.current().world().unload().enabled())));
+                () -> String.valueOf(
+                        getConfigService().current().world().unload().enabled())));
         metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
-            Map<NavigatorType, Long> countsByType = playerService.getPlayerStorage().getBuildPlayers().stream()
+            Map<NavigatorType, Long> countsByType = getPlayerService().getPlayerStorage().getBuildPlayers().stream()
                     .collect(Collectors.groupingBy(
                             buildPlayer -> buildPlayer.getSettings().getNavigatorType(), Collectors.counting()));
             int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
@@ -214,10 +188,10 @@ public class BuildSystemPlugin extends JavaPlugin {
         }));
         metrics.addCustomChart(new SimplePie(
                 "folder_override_permissions",
-                () -> String.valueOf(configService.current().folder().overridePermissions())));
+                () -> String.valueOf(getConfigService().current().folder().overridePermissions())));
         metrics.addCustomChart(new SimplePie(
                 "folder_override_projects",
-                () -> String.valueOf(configService.current().folder().overrideProjects())));
+                () -> String.valueOf(getConfigService().current().folder().overrideProjects())));
     }
 
     public UpdateChecker getUpdateChecker() {
@@ -226,7 +200,7 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     private void performUpdateCheck() {
         this.updateChecker = new UpdateChecker(this, SPIGOT_ID);
-        if (!configService.current().settings().updateChecker()) {
+        if (!getConfigService().current().settings().updateChecker()) {
             return;
         }
 
@@ -260,9 +234,9 @@ public class BuildSystemPlugin extends JavaPlugin {
     }
 
     private CompletableFuture<Void> saveBuildConfig() {
-        CompletableFuture<Void> worldSave = worldService.save();
-        CompletableFuture<Void> playerSave = playerService.save();
-        CompletableFuture<Void> spawnSave = spawnService.save();
+        CompletableFuture<Void> worldSave = getWorldService().save();
+        CompletableFuture<Void> playerSave = getPlayerService().save();
+        CompletableFuture<Void> spawnSave = getSpawnService().save();
         return CompletableFuture.allOf(worldSave, playerSave, spawnSave);
     }
 
@@ -277,15 +251,15 @@ public class BuildSystemPlugin extends JavaPlugin {
         }
 
         reloadConfig();
-        configService.load();
+        getConfigService().load();
         if (isEnabled()) {
-            backupService.reload();
+            getBackupService().reload();
         }
 
         if (init) {
-            worldService.remanageAllUnloadTasks();
+            getWorldService().remanageAllUnloadTasks();
 
-            if (configService.current().settings().scoreboard()) {
+            if (getConfigService().current().settings().scoreboard()) {
                 getSettingsService().displayScoreboard();
             } else {
                 getSettingsService().hideScoreboards();
@@ -294,54 +268,54 @@ public class BuildSystemPlugin extends JavaPlugin {
     }
 
     public NavigatorService getNavigatorService() {
-        return navigatorService;
+        return services.navigator();
     }
 
     public CustomBlockManager getCustomBlockManager() {
-        return customBlockManager;
+        return services.customBlockManager();
     }
 
     public PlayerServiceImpl getPlayerService() {
-        return playerService;
+        return services.player();
     }
 
     public PlayerLookupService getPlayerLookupService() {
-        return playerLookupService;
+        return services.playerLookup();
     }
 
     public NoClipService getNoClipService() {
-        return noClipService;
+        return services.noClip();
     }
 
     public SettingsService getSettingsService() {
-        return settingsService;
+        return services.settings();
     }
 
     public SpawnService getSpawnService() {
-        return spawnService;
+        return services.spawn();
     }
 
     public WorldServiceImpl getWorldService() {
-        return worldService;
+        return services.world();
     }
 
     public BackupService getBackupService() {
-        return backupService;
+        return services.backup();
     }
 
     public ConfigService getConfigService() {
-        return configService;
+        return services.config();
     }
 
     public Messages getMessages() {
-        return messages;
+        return services.messages();
     }
 
     public CustomizableIcons getCustomizableIcons() {
-        return customizableIcons;
+        return services.customizableIcons();
     }
 
     public MenuItems getMenuItems() {
-        return menuItems;
+        return services.menuItems();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -19,7 +19,6 @@ package de.eintosti.buildsystem;
 
 import de.eintosti.buildsystem.api.BuildSystem;
 import de.eintosti.buildsystem.api.player.BuildPlayer;
-import de.eintosti.buildsystem.api.player.settings.NavigatorType;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.command.CommandRegistrar;
 import de.eintosti.buildsystem.config.ConfigService;
@@ -42,13 +41,8 @@ import de.eintosti.buildsystem.world.backup.BackupService;
 import de.eintosti.buildsystem.world.display.CustomizableIcons;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
 import java.io.File;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.stream.Collectors;
-import org.bstats.bukkit.Metrics;
-import org.bstats.charts.AdvancedPie;
-import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -106,7 +100,7 @@ public class BuildSystemPlugin extends JavaPlugin {
             getSettingsService().displayScoreboard(pl);
         });
 
-        registerStats();
+        new BuildSystemMetrics(this).register();
 
         this.configSaveTask = Bukkit.getScheduler()
                 .runTaskTimerAsynchronously(this, this::saveBuildConfig, 6000L, 6000L); // Every 5 minutes
@@ -150,48 +144,6 @@ public class BuildSystemPlugin extends JavaPlugin {
         Bukkit.getConsoleSender()
                 .sendMessage("%sBuildSystem » Plugin %sdisabled%s!"
                         .formatted(ChatColor.RESET, ChatColor.RED, ChatColor.RESET));
-    }
-
-    private void registerStats() {
-        Metrics metrics = new Metrics(this, METRICS_ID);
-        metrics.addCustomChart(new SimplePie(
-                "archive_vanish",
-                () -> String.valueOf(
-                        getConfigService().current().settings().archive().vanish())));
-        metrics.addCustomChart(new SimplePie(
-                "block_world_edit",
-                () -> String.valueOf(
-                        getConfigService().current().settings().builder().blockWorldEditNonBuilder())));
-        metrics.addCustomChart(new SimplePie(
-                "join_quit_messages",
-                () -> String.valueOf(getConfigService().current().settings().joinQuitMessages())));
-        metrics.addCustomChart(new SimplePie(
-                "lock_weather",
-                () -> String.valueOf(getConfigService().current().world().lockWeather())));
-        metrics.addCustomChart(new SimplePie(
-                "scoreboard",
-                () -> String.valueOf(getConfigService().current().settings().scoreboard())));
-        metrics.addCustomChart(new SimplePie(
-                "update_checker",
-                () -> String.valueOf(getConfigService().current().settings().updateChecker())));
-        metrics.addCustomChart(new SimplePie(
-                "unload_worlds",
-                () -> String.valueOf(
-                        getConfigService().current().world().unload().enabled())));
-        metrics.addCustomChart(new AdvancedPie("navigator_type", () -> {
-            Map<NavigatorType, Long> countsByType = getPlayerService().getPlayerStorage().getBuildPlayers().stream()
-                    .collect(Collectors.groupingBy(
-                            buildPlayer -> buildPlayer.getSettings().getNavigatorType(), Collectors.counting()));
-            int oldCount = countsByType.getOrDefault(NavigatorType.OLD, 0L).intValue();
-            int newCount = countsByType.getOrDefault(NavigatorType.NEW, 0L).intValue();
-            return Map.of("Old", oldCount, "New", newCount);
-        }));
-        metrics.addCustomChart(new SimplePie(
-                "folder_override_permissions",
-                () -> String.valueOf(getConfigService().current().folder().overridePermissions())));
-        metrics.addCustomChart(new SimplePie(
-                "folder_override_projects",
-                () -> String.valueOf(getConfigService().current().folder().overrideProjects())));
     }
 
     public UpdateChecker getUpdateChecker() {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/Services.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/Services.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem;
+
+import de.eintosti.buildsystem.config.ConfigService;
+import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.navigator.NavigatorService;
+import de.eintosti.buildsystem.player.PlayerLookupService;
+import de.eintosti.buildsystem.player.PlayerServiceImpl;
+import de.eintosti.buildsystem.player.customblock.CustomBlockManager;
+import de.eintosti.buildsystem.player.noclip.NoClipService;
+import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import de.eintosti.buildsystem.world.backup.BackupService;
+import de.eintosti.buildsystem.world.display.CustomizableIcons;
+import de.eintosti.buildsystem.world.spawn.SpawnService;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Internal holder for the plugin's services. Owns the service fields and constructs them in the exact order the plugin
+ * lifecycle requires; {@link BuildSystemPlugin}'s getters delegate to this holder.
+ */
+@NullMarked
+final class Services {
+
+    private final BuildSystemPlugin plugin;
+
+    private ConfigService configService;
+    private Messages messages;
+
+    private NavigatorService navigatorService;
+    private CustomBlockManager customBlockManager;
+    private PlayerServiceImpl playerService;
+    private PlayerLookupService playerLookupService;
+    private NoClipService noClipService;
+    private SettingsService settingsService;
+    private SpawnService spawnService;
+    private WorldServiceImpl worldService;
+    private BackupService backupService;
+    private CustomizableIcons customizableIcons;
+    private MenuItems menuItems;
+
+    Services(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Creates the configuration service. Must be called first, during {@code onLoad}.
+     */
+    ConfigService createConfigService() {
+        this.configService = new ConfigService(plugin);
+        return this.configService;
+    }
+
+    /**
+     * Creates the message service, which depends on the already-created {@link ConfigService}. Called during
+     * {@code onLoad}.
+     */
+    Messages createMessages() {
+        this.messages = new Messages(plugin, configService);
+        return this.messages;
+    }
+
+    /**
+     * Constructs the remaining services in the exact order required by the plugin lifecycle. Called during
+     * {@code onEnable}.
+     */
+    void initClasses() {
+        this.customizableIcons = new CustomizableIcons(plugin);
+
+        this.customBlockManager = new CustomBlockManager(plugin);
+        this.playerLookupService = new PlayerLookupService(plugin);
+        (this.playerService = new PlayerServiceImpl(plugin)).init();
+        this.navigatorService = new NavigatorService(plugin);
+        this.noClipService = new NoClipService(plugin);
+        (this.worldService = new WorldServiceImpl(plugin)).init();
+        this.backupService = new BackupService(plugin);
+        this.settingsService = new SettingsService(plugin);
+        this.spawnService = new SpawnService(plugin);
+        this.menuItems = new MenuItems(plugin, configService, messages, settingsService);
+    }
+
+    ConfigService config() {
+        return configService;
+    }
+
+    Messages messages() {
+        return messages;
+    }
+
+    NavigatorService navigator() {
+        return navigatorService;
+    }
+
+    CustomBlockManager customBlockManager() {
+        return customBlockManager;
+    }
+
+    PlayerServiceImpl player() {
+        return playerService;
+    }
+
+    PlayerLookupService playerLookup() {
+        return playerLookupService;
+    }
+
+    NoClipService noClip() {
+        return noClipService;
+    }
+
+    SettingsService settings() {
+        return settingsService;
+    }
+
+    SpawnService spawn() {
+        return spawnService;
+    }
+
+    WorldServiceImpl world() {
+        return worldService;
+    }
+
+    BackupService backup() {
+        return backupService;
+    }
+
+    CustomizableIcons customizableIcons() {
+        return customizableIcons;
+    }
+
+    MenuItems menuItems() {
+        return menuItems;
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/MessageStore.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/MessageStore.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.i18n;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Loads {@code messages.yml} from disk, merging in any keys missing from the bundled defaults, and provides raw
+ * (unrendered) lookups of the resulting message strings.
+ */
+@NullMarked
+final class MessageStore {
+
+    private final BuildSystemPlugin plugin;
+    private volatile Map<String, String> messages = Map.of();
+
+    MessageStore(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    void load() {
+        // 1. If user file doesn't exist, save the bundled default
+        File file = new File(plugin.getDataFolder(), "messages.yml");
+        if (!file.exists()) {
+            plugin.saveResource("messages.yml", false);
+        }
+
+        // 2. Load user file and bundled defaults
+        YamlConfiguration userConfig = YamlConfiguration.loadConfiguration(file);
+        java.io.InputStream defaultStream = plugin.getResource("messages.yml");
+        if (defaultStream != null) {
+            YamlConfiguration defaults =
+                    YamlConfiguration.loadConfiguration(new InputStreamReader(defaultStream, StandardCharsets.UTF_8));
+            // 3. Copy missing keys from bundled defaults to user file
+            boolean changed = false;
+            for (String key : defaults.getKeys(false)) {
+                if (!userConfig.contains(key)) {
+                    userConfig.set(key, defaults.get(key));
+                    changed = true;
+                }
+            }
+            if (changed) {
+                try {
+                    userConfig.save(file);
+                } catch (IOException e) {
+                    plugin.getLogger().log(Level.SEVERE, "Could not save messages.yml", e);
+                }
+            }
+        }
+
+        // 4. Build messages map
+        Map<String, String> map = new HashMap<>();
+        ConfigurationSection section = userConfig.getConfigurationSection("");
+        if (section != null) {
+            section.getKeys(false).forEach(key -> {
+                if (!userConfig.contains(key)) {
+                    Bukkit.getConsoleSender()
+                            .sendMessage(ChatColor.RED + "[BuildSystem] Could not find message with key: " + key);
+                    return;
+                }
+                if (userConfig.isList(key)) {
+                    map.put(key, String.join("\n", userConfig.getStringList(key)));
+                } else {
+                    map.put(
+                            key,
+                            Objects.requireNonNull(
+                                    userConfig.getString(key), "Message key '%s' is null".formatted(key)));
+                }
+            });
+        }
+        this.messages = Map.copyOf(map);
+    }
+
+    void reload() {
+        load();
+    }
+
+    String getPrefix() {
+        return messages.getOrDefault("prefix", "");
+    }
+
+    void checkIfKeyPresent(String key) {
+        if (!messages.containsKey(key)) {
+            plugin.getLogger().warning("Could not find message with key: " + key);
+        }
+    }
+
+    /**
+     * Returns the raw, unrendered value stored for the given key, or an empty string when the key is absent.
+     *
+     * @param key The message key
+     * @return The raw stored message
+     */
+    String getRaw(String key) {
+        return messages.getOrDefault(key, "");
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/Messages.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/i18n/Messages.java
@@ -22,20 +22,11 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.util.color.ColorAPI;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
-import java.util.logging.Level;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
@@ -44,14 +35,13 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public final class Messages {
 
-    private final BuildSystemPlugin plugin;
     private final ConfigService configService;
-    private volatile Map<String, String> messages = Map.of();
+    private final MessageStore store;
     private volatile @Nullable TextResolver placeholderResolver;
 
     public Messages(BuildSystemPlugin plugin, ConfigService configService) {
-        this.plugin = plugin;
         this.configService = configService;
+        this.store = new MessageStore(plugin);
     }
 
     /**
@@ -65,70 +55,11 @@ public final class Messages {
     }
 
     public void load() {
-        // 1. If user file doesn't exist, save the bundled default
-        File file = new File(plugin.getDataFolder(), "messages.yml");
-        if (!file.exists()) {
-            plugin.saveResource("messages.yml", false);
-        }
-
-        // 2. Load user file and bundled defaults
-        YamlConfiguration userConfig = YamlConfiguration.loadConfiguration(file);
-        java.io.InputStream defaultStream = plugin.getResource("messages.yml");
-        if (defaultStream != null) {
-            YamlConfiguration defaults =
-                    YamlConfiguration.loadConfiguration(new InputStreamReader(defaultStream, StandardCharsets.UTF_8));
-            // 3. Copy missing keys from bundled defaults to user file
-            boolean changed = false;
-            for (String key : defaults.getKeys(false)) {
-                if (!userConfig.contains(key)) {
-                    userConfig.set(key, defaults.get(key));
-                    changed = true;
-                }
-            }
-            if (changed) {
-                try {
-                    userConfig.save(file);
-                } catch (IOException e) {
-                    plugin.getLogger().log(Level.SEVERE, "Could not save messages.yml", e);
-                }
-            }
-        }
-
-        // 4. Build messages map
-        Map<String, String> map = new HashMap<>();
-        ConfigurationSection section = userConfig.getConfigurationSection("");
-        if (section != null) {
-            section.getKeys(false).forEach(key -> {
-                if (!userConfig.contains(key)) {
-                    Bukkit.getConsoleSender()
-                            .sendMessage(ChatColor.RED + "[BuildSystem] Could not find message with key: " + key);
-                    return;
-                }
-                if (userConfig.isList(key)) {
-                    map.put(key, String.join("\n", userConfig.getStringList(key)));
-                } else {
-                    map.put(
-                            key,
-                            Objects.requireNonNull(
-                                    userConfig.getString(key), "Message key '%s' is null".formatted(key)));
-                }
-            });
-        }
-        this.messages = Map.copyOf(map);
+        this.store.load();
     }
 
     public void reload() {
-        load();
-    }
-
-    private String getPrefix() {
-        return messages.getOrDefault("prefix", "");
-    }
-
-    private void checkIfKeyPresent(String key) {
-        if (!messages.containsKey(key)) {
-            plugin.getLogger().warning("Could not find message with key: " + key);
-        }
+        this.store.reload();
     }
 
     public void sendPermissionError(CommandSender sender) {
@@ -145,8 +76,8 @@ public final class Messages {
 
     @SafeVarargs
     public final String getString(String key, CommandSender sender, Entry<String, Object>... placeholders) {
-        checkIfKeyPresent(key);
-        String message = messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+        store.checkIfKeyPresent(key);
+        String message = store.getRaw(key).replace("%prefix%", store.getPrefix());
         String result = Placeholders.apply(message, placeholders);
         Player player = sender instanceof Player p ? p : null;
         return ColorAPI.process(applyResolver(this.placeholderResolver, player, result));
@@ -177,7 +108,7 @@ public final class Messages {
     @Unmodifiable
     public List<String> getStringList(
             String key, @Nullable Player player, Function<String, Entry<String, Object>[]> placeholders) {
-        String message = messages.getOrDefault(key, "").replace("%prefix%", getPrefix());
+        String message = store.getRaw(key).replace("%prefix%", store.getPrefix());
         TextResolver resolver = this.placeholderResolver;
         return Arrays.stream(message.split("\n"))
                 .map(line -> Placeholders.apply(line, placeholders.apply(line)))

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.world;
 
-import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.event.world.BuildWorldDeleteEvent;
 import de.eintosti.buildsystem.api.event.world.BuildWorldPostDeleteEvent;
@@ -35,17 +34,17 @@ import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
 import de.eintosti.buildsystem.api.world.creation.generator.Generator;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.display.Folder;
-import de.eintosti.buildsystem.menu.PlayerChatInput;
 import de.eintosti.buildsystem.storage.FolderStorageImpl;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
 import de.eintosti.buildsystem.storage.yaml.YamlFolderStorage;
 import de.eintosti.buildsystem.storage.yaml.YamlWorldStorage;
 import de.eintosti.buildsystem.util.FileUtils;
-import de.eintosti.buildsystem.util.StringCleaner;
-import de.eintosti.buildsystem.world.creation.BukkitWorldFactory;
 import de.eintosti.buildsystem.world.creation.WorldBuilderImpl;
+import de.eintosti.buildsystem.world.creation.WorldCreationPrompts;
+import de.eintosti.buildsystem.world.creation.WorldImportCoordinator;
 import de.eintosti.buildsystem.world.creation.WorldImporterImpl;
 import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
+import de.eintosti.buildsystem.world.lifecycle.WorldLoadBootstrap;
 import de.eintosti.buildsystem.world.lifecycle.WorldRenamer;
 import de.eintosti.buildsystem.world.lifecycle.WorldUnloaderImpl;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
@@ -54,15 +53,11 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -71,127 +66,26 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public class WorldServiceImpl implements WorldService {
 
-    private final AtomicBoolean importingAllWorlds = new AtomicBoolean(false);
-
     private final BuildSystemPlugin plugin;
     private final FolderStorageImpl folderStorage;
     private final WorldStorageImpl worldStorage;
+
+    private final WorldLoadBootstrap loadBootstrap;
+    private final WorldCreationPrompts creationPrompts;
+    private final WorldImportCoordinator importCoordinator;
 
     public WorldServiceImpl(BuildSystemPlugin plugin) {
         this.plugin = plugin;
         this.worldStorage = new YamlWorldStorage(plugin);
         this.folderStorage = new YamlFolderStorage(plugin, this.worldStorage);
+        this.loadBootstrap = new WorldLoadBootstrap(plugin, this.folderStorage, this.worldStorage);
+        this.creationPrompts = new WorldCreationPrompts(plugin, this);
+        this.importCoordinator = new WorldImportCoordinator(plugin, this, this.worldStorage);
     }
 
     public void init() {
         this.folderStorage.loadFolders();
-        loadWorlds();
-    }
-
-    private void loadWorlds() {
-        this.worldStorage
-                .load()
-                .thenAccept(worlds -> Bukkit.getScheduler().runTask(plugin, () -> {
-                    worlds.forEach(worldStorage::addBuildWorld);
-                    assignWorldsToFolders();
-
-                    boolean loadAllWorlds = !plugin.getConfigService()
-                            .current()
-                            .world()
-                            .unload()
-                            .enabled();
-                    if (loadAllWorlds) {
-                        plugin.getLogger().info("*** All worlds will be loaded now ***");
-                    }
-
-                    List<BuildWorld> notLoaded = new ArrayList<>();
-                    worldStorage.getBuildWorlds().forEach(buildWorld -> {
-                        if (preLoadWorld(buildWorld, loadAllWorlds) == LoadResult.FAILED) {
-                            notLoaded.add(buildWorld);
-                        }
-                    });
-                    notLoaded.forEach(worldStorage::removeBuildWorld);
-
-                    plugin.getLogger().info("Loaded " + worlds.size() + " worlds from storage");
-                }))
-                .exceptionally(throwable -> {
-                    plugin.getLogger().log(Level.SEVERE, "Failed to load worlds from storage", throwable);
-                    return null;
-                });
-    }
-
-    /**
-     * Assigns all {@link BuildWorld}s to their respective {@link Folder}s, dropping references to worlds that no longer
-     * exist.
-     *
-     * <p>Must be called after all folders and worlds have been loaded.
-     */
-    private void assignWorldsToFolders() {
-        folderStorage.getFolders().forEach(folder -> {
-            List<UUID> invalidWorlds = new ArrayList<>();
-            folder.getWorldUUIDs().stream()
-                    .map(worldUUID -> {
-                        BuildWorld buildWorld = worldStorage.getBuildWorld(worldUUID);
-                        if (buildWorld == null) {
-                            invalidWorlds.add(worldUUID);
-                            plugin.getLogger()
-                                    .warning("World with UUID " + worldUUID + " does not exist. Removing from folder: "
-                                            + folder.getName());
-                        }
-                        return buildWorld;
-                    })
-                    .filter(Objects::nonNull)
-                    .forEach(buildWorld -> buildWorld.setFolder(folder));
-            invalidWorlds.forEach(folder::removeWorld);
-        });
-    }
-
-    /**
-     * Attempts to load the Bukkit world backing the given {@link BuildWorld} at startup.
-     *
-     * @param buildWorld The world to load
-     * @param alwaysLoad Whether the world should always be loaded, regardless of being blacklisted
-     * @return The result of the load attempt
-     */
-    private LoadResult preLoadWorld(BuildWorld buildWorld, boolean alwaysLoad) {
-        String worldName = buildWorld.getName();
-        boolean shouldPreLoad = alwaysLoad
-                || plugin.getConfigService()
-                        .current()
-                        .world()
-                        .unload()
-                        .blacklistedWorlds()
-                        .contains(worldName);
-        if (!shouldPreLoad) {
-            return LoadResult.NOT_LOADED;
-        }
-
-        World world = new BukkitWorldFactory(plugin, buildWorld).generate(BukkitWorldFactory.VersionCheck.REQUIRED);
-        if (world == null) {
-            return LoadResult.FAILED;
-        }
-
-        buildWorld.getData().setLastLoaded(System.currentTimeMillis());
-        plugin.getLogger().info("✔ World loaded: " + worldName);
-        return LoadResult.LOADED;
-    }
-
-    private enum LoadResult {
-
-        /**
-         * The {@link BuildWorld} was successfully loaded.
-         */
-        LOADED,
-
-        /**
-         * The {@link BuildWorld} was attempted to be loaded, but failed.
-         */
-        FAILED,
-
-        /**
-         * Not attempted: unloading is enabled and the world is not blacklisted, so it may stay unloaded.
-         */
-        NOT_LOADED
+        this.loadBootstrap.loadWorlds();
     }
 
     @Override
@@ -222,65 +116,7 @@ public class WorldServiceImpl implements WorldService {
             @Nullable String template,
             boolean privateWorld,
             @Nullable Folder folder) {
-        player.closeInventory();
-        PlayerChatInput.requestSanitizedName(
-                plugin,
-                player,
-                "enter_world_name",
-                "worlds_world_creation_invalid_characters",
-                "worlds_world_creation_name_bank",
-                worldName -> {
-                    if (worldType == BuildWorldType.CUSTOM) {
-                        startCustomGeneratorInput(player, worldName, template, privateWorld, folder);
-                    } else {
-                        buildAndTeleport(
-                                player,
-                                newWorld(worldName)
-                                        .type(worldType)
-                                        .template(template)
-                                        .privateWorld(privateWorld)
-                                        .folder(folder));
-                    }
-                });
-    }
-
-    private void startCustomGeneratorInput(
-            Player player, String worldName, @Nullable String template, boolean privateWorld, @Nullable Folder folder) {
-        new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
-            // Generator names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is emulated: a
-            // generator is permitted unless an admin has explicitly denied its specific node.
-            String generatorNode = "buildsystem.create.generator." + input.trim();
-            boolean allowed = !player.isPermissionSet(generatorNode) || player.hasPermission(generatorNode);
-            if (!allowed) {
-                plugin.getMessages().sendPermissionError(player);
-                XSound.ENTITY_ITEM_BREAK.play(player);
-                return;
-            }
-
-            CustomGenerator customGenerator = CustomGeneratorImpl.of(input, worldName);
-            if (customGenerator == null) {
-                plugin.getMessages().sendMessage(player, "worlds_import_unknown_generator");
-                XSound.ENTITY_ITEM_BREAK.play(player);
-                return;
-            }
-
-            buildAndTeleport(
-                    player,
-                    newWorld(worldName)
-                            .type(BuildWorldType.CUSTOM)
-                            .template(template)
-                            .privateWorld(privateWorld)
-                            .customGenerator(customGenerator)
-                            .folder(folder));
-        });
-    }
-
-    private void buildAndTeleport(Player player, WorldBuilder worldBuilder) {
-        BuildWorld world =
-                worldBuilder.creator(Builder.of(player)).notify(player).build();
-        if (world != null) {
-            world.getTeleporter().teleport(player);
-        }
+        this.creationPrompts.startWorldNameInput(player, worldType, template, privateWorld, folder);
     }
 
     public boolean importWorld(
@@ -327,134 +163,16 @@ public class WorldServiceImpl implements WorldService {
     }
 
     public void importWorlds(Player player, String[] worldList, Generator generator, @Nullable Builder creator) {
-        int delay = plugin.getConfigService().current().world().importAllDelay();
-        plugin.getMessages()
-                .sendMessage(
-                        player, "worlds_importall_started", Map.entry("%amount%", String.valueOf(worldList.length)));
-        plugin.getMessages().sendMessage(player, "worlds_importall_delay", Map.entry("%delay%", String.valueOf(delay)));
-
-        importingAllWorlds.set(true);
-        BulkImportListener listener = new BulkImportListener() {
-            @Override
-            public void skippedExisting(String worldName) {
-                plugin.getMessages()
-                        .sendMessage(
-                                player, "worlds_importall_world_already_imported", Map.entry("%world%", worldName));
-            }
-
-            @Override
-            public void invalidName(String worldName, String invalidChar) {
-                plugin.getMessages()
-                        .sendMessage(
-                                player,
-                                "worlds_importall_invalid_character",
-                                Map.entry("%world%", worldName),
-                                Map.entry("%char%", invalidChar));
-            }
-
-            @Override
-            public void imported(String worldName) {
-                plugin.getMessages()
-                        .sendMessage(player, "worlds_importall_world_imported", Map.entry("%world%", worldName));
-            }
-        };
-        importStaggered(
-                        worldList,
-                        listener,
-                        worldName -> importWorld(
-                                player, worldName, creator, BuildWorldType.IMPORTED, generator, "void", false))
-                .thenRun(() -> plugin.getMessages().sendMessage(player, "worlds_importall_finished"));
+        this.importCoordinator.importWorlds(player, worldList, generator, creator);
     }
 
     public boolean isImportingAllWorlds() {
-        return importingAllWorlds.get();
+        return this.importCoordinator.isImportingAllWorlds();
     }
 
     @Override
     public CompletableFuture<Integer> importWorlds() {
-        if (!importingAllWorlds.compareAndSet(false, true)) {
-            return CompletableFuture.failedFuture(new IllegalStateException("A bulk import is already in progress"));
-        }
-
-        String[] directories = scanImportableDirectories();
-        if (directories.length == 0) {
-            importingAllWorlds.set(false);
-            return CompletableFuture.completedFuture(0);
-        }
-
-        return importStaggered(
-                directories,
-                new BulkImportListener() {},
-                worldName -> importWorld(worldName).build() != null);
-    }
-
-    /**
-     * Per-world progress callbacks for a staggered bulk import.
-     */
-    private interface BulkImportListener {
-
-        default void skippedExisting(String worldName) {}
-
-        default void invalidName(String worldName, String invalidChar) {}
-
-        default void imported(String worldName) {}
-    }
-
-    /**
-     * Imports the given worlds one per configured delay interval, skipping names that are already imported or contain
-     * invalid characters. Clears {@link #importingAllWorlds} and completes with the import count once all names have
-     * been processed.
-     */
-    private CompletableFuture<Integer> importStaggered(
-            String[] worldNames, BulkImportListener listener, Predicate<String> importer) {
-        int delay = plugin.getConfigService().current().world().importAllDelay();
-        String invalidCharacters = plugin.getConfigService().current().world().invalidCharacters();
-
-        CompletableFuture<Integer> result = new CompletableFuture<>();
-        AtomicInteger index = new AtomicInteger(0);
-        AtomicInteger imported = new AtomicInteger(0);
-
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                int i = index.getAndIncrement();
-                if (i >= worldNames.length) {
-                    this.cancel();
-                    importingAllWorlds.set(false);
-                    result.complete(imported.get());
-                    return;
-                }
-
-                String worldName = worldNames[i];
-                if (worldStorage.worldExists(worldName)) {
-                    listener.skippedExisting(worldName);
-                    return;
-                }
-
-                String invalidChar = StringCleaner.firstInvalidChar(worldName, invalidCharacters);
-                if (invalidChar != null) {
-                    listener.invalidName(worldName, invalidChar);
-                    return;
-                }
-
-                if (importer.test(worldName)) {
-                    imported.incrementAndGet();
-                    listener.imported(worldName);
-                }
-            }
-        }.runTaskTimer(plugin, 0, 20L * delay);
-
-        return result;
-    }
-
-    private String[] scanImportableDirectories() {
-        String[] directories = Bukkit.getWorldContainer().list((dir, name) -> {
-            File worldFolder = new File(dir, name);
-            return worldFolder.isDirectory()
-                    && new File(worldFolder, "level.dat").exists()
-                    && !worldStorage.worldExists(name);
-        });
-        return directories != null ? directories : new String[0];
+        return this.importCoordinator.importWorlds();
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.creation;
+
+import com.cryptomorin.xseries.XSound;
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.builder.Builder;
+import de.eintosti.buildsystem.api.world.creation.WorldBuilder;
+import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
+import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.menu.PlayerChatInput;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
+import org.bukkit.entity.Player;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Drives the chat-input flow for creating a new world: prompting for a name, optionally a custom generator, then
+ * building and teleporting the player.
+ */
+@NullMarked
+public class WorldCreationPrompts {
+
+    private final BuildSystemPlugin plugin;
+    private final WorldServiceImpl worldService;
+
+    public WorldCreationPrompts(BuildSystemPlugin plugin, WorldServiceImpl worldService) {
+        this.plugin = plugin;
+        this.worldService = worldService;
+    }
+
+    public void startWorldNameInput(
+            Player player,
+            BuildWorldType worldType,
+            @Nullable String template,
+            boolean privateWorld,
+            @Nullable Folder folder) {
+        player.closeInventory();
+        PlayerChatInput.requestSanitizedName(
+                plugin,
+                player,
+                "enter_world_name",
+                "worlds_world_creation_invalid_characters",
+                "worlds_world_creation_name_bank",
+                worldName -> {
+                    if (worldType == BuildWorldType.CUSTOM) {
+                        startCustomGeneratorInput(player, worldName, template, privateWorld, folder);
+                    } else {
+                        buildAndTeleport(
+                                player,
+                                worldService
+                                        .newWorld(worldName)
+                                        .type(worldType)
+                                        .template(template)
+                                        .privateWorld(privateWorld)
+                                        .folder(folder));
+                    }
+                });
+    }
+
+    private void startCustomGeneratorInput(
+            Player player, String worldName, @Nullable String template, boolean privateWorld, @Nullable Folder folder) {
+        new PlayerChatInput(plugin, player, "enter_generator_name", input -> {
+            // Generator names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is emulated: a
+            // generator is permitted unless an admin has explicitly denied its specific node.
+            String generatorNode = "buildsystem.create.generator." + input.trim();
+            boolean allowed = !player.isPermissionSet(generatorNode) || player.hasPermission(generatorNode);
+            if (!allowed) {
+                plugin.getMessages().sendPermissionError(player);
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                return;
+            }
+
+            CustomGenerator customGenerator = CustomGeneratorImpl.of(input, worldName);
+            if (customGenerator == null) {
+                plugin.getMessages().sendMessage(player, "worlds_import_unknown_generator");
+                XSound.ENTITY_ITEM_BREAK.play(player);
+                return;
+            }
+
+            buildAndTeleport(
+                    player,
+                    worldService
+                            .newWorld(worldName)
+                            .type(BuildWorldType.CUSTOM)
+                            .template(template)
+                            .privateWorld(privateWorld)
+                            .customGenerator(customGenerator)
+                            .folder(folder));
+        });
+    }
+
+    private void buildAndTeleport(Player player, WorldBuilder worldBuilder) {
+        BuildWorld world =
+                worldBuilder.creator(Builder.of(player)).notify(player).build();
+        if (world != null) {
+            world.getTeleporter().teleport(player);
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImportCoordinator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImportCoordinator.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.creation;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.builder.Builder;
+import de.eintosti.buildsystem.api.world.creation.generator.Generator;
+import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.StringCleaner;
+import de.eintosti.buildsystem.world.WorldServiceImpl;
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Coordinates bulk imports of worlds, running them staggered over a configured delay so the server is not stalled.
+ */
+@NullMarked
+public class WorldImportCoordinator {
+
+    private final AtomicBoolean importingAllWorlds = new AtomicBoolean(false);
+
+    private final BuildSystemPlugin plugin;
+    private final WorldServiceImpl worldService;
+    private final WorldStorageImpl worldStorage;
+
+    public WorldImportCoordinator(
+            BuildSystemPlugin plugin, WorldServiceImpl worldService, WorldStorageImpl worldStorage) {
+        this.plugin = plugin;
+        this.worldService = worldService;
+        this.worldStorage = worldStorage;
+    }
+
+    public void importWorlds(Player player, String[] worldList, Generator generator, @Nullable Builder creator) {
+        int delay = plugin.getConfigService().current().world().importAllDelay();
+        plugin.getMessages()
+                .sendMessage(
+                        player, "worlds_importall_started", Map.entry("%amount%", String.valueOf(worldList.length)));
+        plugin.getMessages().sendMessage(player, "worlds_importall_delay", Map.entry("%delay%", String.valueOf(delay)));
+
+        importingAllWorlds.set(true);
+        BulkImportListener listener = new BulkImportListener() {
+            @Override
+            public void skippedExisting(String worldName) {
+                plugin.getMessages()
+                        .sendMessage(
+                                player, "worlds_importall_world_already_imported", Map.entry("%world%", worldName));
+            }
+
+            @Override
+            public void invalidName(String worldName, String invalidChar) {
+                plugin.getMessages()
+                        .sendMessage(
+                                player,
+                                "worlds_importall_invalid_character",
+                                Map.entry("%world%", worldName),
+                                Map.entry("%char%", invalidChar));
+            }
+
+            @Override
+            public void imported(String worldName) {
+                plugin.getMessages()
+                        .sendMessage(player, "worlds_importall_world_imported", Map.entry("%world%", worldName));
+            }
+        };
+        importStaggered(
+                        worldList,
+                        listener,
+                        worldName -> worldService.importWorld(
+                                player, worldName, creator, BuildWorldType.IMPORTED, generator, "void", false))
+                .thenRun(() -> plugin.getMessages().sendMessage(player, "worlds_importall_finished"));
+    }
+
+    public boolean isImportingAllWorlds() {
+        return importingAllWorlds.get();
+    }
+
+    public CompletableFuture<Integer> importWorlds() {
+        if (!importingAllWorlds.compareAndSet(false, true)) {
+            return CompletableFuture.failedFuture(new IllegalStateException("A bulk import is already in progress"));
+        }
+
+        String[] directories = scanImportableDirectories();
+        if (directories.length == 0) {
+            importingAllWorlds.set(false);
+            return CompletableFuture.completedFuture(0);
+        }
+
+        return importStaggered(
+                directories,
+                new BulkImportListener() {},
+                worldName -> worldService.importWorld(worldName).build() != null);
+    }
+
+    /**
+     * Per-world progress callbacks for a staggered bulk import.
+     */
+    private interface BulkImportListener {
+
+        default void skippedExisting(String worldName) {}
+
+        default void invalidName(String worldName, String invalidChar) {}
+
+        default void imported(String worldName) {}
+    }
+
+    /**
+     * Imports the given worlds one per configured delay interval, skipping names that are already imported or contain
+     * invalid characters. Clears {@link #importingAllWorlds} and completes with the import count once all names have
+     * been processed.
+     */
+    private CompletableFuture<Integer> importStaggered(
+            String[] worldNames, BulkImportListener listener, Predicate<String> importer) {
+        int delay = plugin.getConfigService().current().world().importAllDelay();
+        String invalidCharacters = plugin.getConfigService().current().world().invalidCharacters();
+
+        CompletableFuture<Integer> result = new CompletableFuture<>();
+        AtomicInteger index = new AtomicInteger(0);
+        AtomicInteger imported = new AtomicInteger(0);
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                int i = index.getAndIncrement();
+                if (i >= worldNames.length) {
+                    this.cancel();
+                    importingAllWorlds.set(false);
+                    result.complete(imported.get());
+                    return;
+                }
+
+                String worldName = worldNames[i];
+                if (worldStorage.worldExists(worldName)) {
+                    listener.skippedExisting(worldName);
+                    return;
+                }
+
+                String invalidChar = StringCleaner.firstInvalidChar(worldName, invalidCharacters);
+                if (invalidChar != null) {
+                    listener.invalidName(worldName, invalidChar);
+                    return;
+                }
+
+                if (importer.test(worldName)) {
+                    imported.incrementAndGet();
+                    listener.imported(worldName);
+                }
+            }
+        }.runTaskTimer(plugin, 0, 20L * delay);
+
+        return result;
+    }
+
+    private String[] scanImportableDirectories() {
+        String[] directories = Bukkit.getWorldContainer().list((dir, name) -> {
+            File worldFolder = new File(dir, name);
+            return worldFolder.isDirectory()
+                    && new File(worldFolder, "level.dat").exists()
+                    && !worldStorage.worldExists(name);
+        });
+        return directories != null ? directories : new String[0];
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoadBootstrap.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldLoadBootstrap.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.lifecycle;
+
+import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.storage.FolderStorageImpl;
+import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.world.creation.BukkitWorldFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Loads persisted {@link BuildWorld}s at startup, assigns them to their {@link Folder}s and pre-loads the Bukkit worlds
+ * that must always be available.
+ */
+@NullMarked
+public class WorldLoadBootstrap {
+
+    private final BuildSystemPlugin plugin;
+    private final FolderStorageImpl folderStorage;
+    private final WorldStorageImpl worldStorage;
+
+    public WorldLoadBootstrap(
+            BuildSystemPlugin plugin, FolderStorageImpl folderStorage, WorldStorageImpl worldStorage) {
+        this.plugin = plugin;
+        this.folderStorage = folderStorage;
+        this.worldStorage = worldStorage;
+    }
+
+    public void loadWorlds() {
+        this.worldStorage
+                .load()
+                .thenAccept(worlds -> Bukkit.getScheduler().runTask(plugin, () -> {
+                    worlds.forEach(worldStorage::addBuildWorld);
+                    assignWorldsToFolders();
+
+                    boolean loadAllWorlds = !plugin.getConfigService()
+                            .current()
+                            .world()
+                            .unload()
+                            .enabled();
+                    if (loadAllWorlds) {
+                        plugin.getLogger().info("*** All worlds will be loaded now ***");
+                    }
+
+                    List<BuildWorld> notLoaded = new ArrayList<>();
+                    worldStorage.getBuildWorlds().forEach(buildWorld -> {
+                        if (preLoadWorld(buildWorld, loadAllWorlds) == LoadResult.FAILED) {
+                            notLoaded.add(buildWorld);
+                        }
+                    });
+                    notLoaded.forEach(worldStorage::removeBuildWorld);
+
+                    plugin.getLogger().info("Loaded " + worlds.size() + " worlds from storage");
+                }))
+                .exceptionally(throwable -> {
+                    plugin.getLogger().log(Level.SEVERE, "Failed to load worlds from storage", throwable);
+                    return null;
+                });
+    }
+
+    /**
+     * Assigns all {@link BuildWorld}s to their respective {@link Folder}s, dropping references to worlds that no longer
+     * exist.
+     *
+     * <p>Must be called after all folders and worlds have been loaded.
+     */
+    private void assignWorldsToFolders() {
+        folderStorage.getFolders().forEach(folder -> {
+            List<UUID> invalidWorlds = new ArrayList<>();
+            folder.getWorldUUIDs().stream()
+                    .map(worldUUID -> {
+                        BuildWorld buildWorld = worldStorage.getBuildWorld(worldUUID);
+                        if (buildWorld == null) {
+                            invalidWorlds.add(worldUUID);
+                            plugin.getLogger()
+                                    .warning("World with UUID " + worldUUID + " does not exist. Removing from folder: "
+                                            + folder.getName());
+                        }
+                        return buildWorld;
+                    })
+                    .filter(Objects::nonNull)
+                    .forEach(buildWorld -> buildWorld.setFolder(folder));
+            invalidWorlds.forEach(folder::removeWorld);
+        });
+    }
+
+    /**
+     * Attempts to load the Bukkit world backing the given {@link BuildWorld} at startup.
+     *
+     * @param buildWorld The world to load
+     * @param alwaysLoad Whether the world should always be loaded, regardless of being blacklisted
+     * @return The result of the load attempt
+     */
+    private LoadResult preLoadWorld(BuildWorld buildWorld, boolean alwaysLoad) {
+        String worldName = buildWorld.getName();
+        boolean shouldPreLoad = alwaysLoad
+                || plugin.getConfigService()
+                        .current()
+                        .world()
+                        .unload()
+                        .blacklistedWorlds()
+                        .contains(worldName);
+        if (!shouldPreLoad) {
+            return LoadResult.NOT_LOADED;
+        }
+
+        World world = new BukkitWorldFactory(plugin, buildWorld).generate(BukkitWorldFactory.VersionCheck.REQUIRED);
+        if (world == null) {
+            return LoadResult.FAILED;
+        }
+
+        buildWorld.getData().setLastLoaded(System.currentTimeMillis());
+        plugin.getLogger().info("✔ World loaded: " + worldName);
+        return LoadResult.LOADED;
+    }
+
+    private enum LoadResult {
+
+        /**
+         * The {@link BuildWorld} was successfully loaded.
+         */
+        LOADED,
+
+        /**
+         * The {@link BuildWorld} was attempted to be loaded, but failed.
+         */
+        FAILED,
+
+        /**
+         * Not attempted: unloading is enabled and the world is not blacklisted, so it may stay unloaded.
+         */
+        NOT_LOADED
+    }
+}


### PR DESCRIPTION
Four behavior-preserving structural refactors — no public API or behavior changes; diffs are almost entirely code moves; all existing tests stay green. (Rebuilt fresh on current master so it cleanly inherits the merged #449–#462 work; supersedes the earlier #463.)

## 1. Split `WorldServiceImpl` (was ~600 lines)
Extracted three collaborators; the service keeps its public methods and delegates:
- `WorldImportCoordinator` — bulk import (staggered scheduling, listener, scan).
- `WorldCreationPrompts` — chat-input creation flow (preserves the #323 generator gating verbatim).
- `WorldLoadBootstrap` — startup world loading / folder assignment.

## 2. Internal `Services` holder
Service fields + construction moved into a package-private `Services` (init order preserved exactly); the `plugin.getXxx()` getters delegate one-line, so all call sites are untouched.

## 3. Split `Messages`
- `MessageStore` — file load/merge, missing-key copy-back, lookup, prefix.
- `Messages` — renderer (placeholders/resolver/color/send). Every public signature unchanged; `applyResolver` stays static for its test.

## 4. Extract `BuildSystemMetrics`
bStats chart setup (~40 lines) moved out of `BuildSystemPlugin`, which drops **348 → 273 lines**.

Preserved verbatim from merged master: world lifecycle event firing, #323 generator gating, `Optional<World>`, ServicesManager binding. `./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)