### PR TITLE
refactor(api)!: replace boolean save params with a SaveBehavior enum

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.creation.WorldBuilder;
 import de.eintosti.buildsystem.api.world.creation.WorldImporter;
 import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.api.world.lifecycle.SaveBehavior;
 import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.NullMarked;
 
@@ -97,14 +98,14 @@ public interface WorldService {
      * does not delete the world's directory.
      *
      * @param buildWorld The world to unimport
-     * @param save Whether to save the world before unloading
+     * @param saveBehavior Whether to save the world before unloading
      * @return A future that completes when the unimport operation is finished
      */
-    CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, boolean save);
+    CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, SaveBehavior saveBehavior);
 
     /**
-     * Delete an existing {@link BuildWorld}. In comparison to {@link #unimportWorld(BuildWorld, boolean)}, deleting a
-     * world deletes the world's directory.
+     * Delete an existing {@link BuildWorld}. In comparison to {@link #unimportWorld(BuildWorld, SaveBehavior)}, deleting
+     * a world deletes the world's directory.
      *
      * @param buildWorld The world to be deleted
      * @return A future that completes when the delete operation is finished

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/SaveBehavior.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/SaveBehavior.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.api.world.lifecycle;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Whether a world's state should be written to disk before it is unloaded.
+ *
+ * @since TODO
+ */
+@NullMarked
+public enum SaveBehavior {
+
+    /**
+     * Save the world to disk before unloading it.
+     */
+    SAVE,
+
+    /**
+     * Unload the world without saving, discarding any unsaved changes.
+     */
+    DISCARD;
+
+    /**
+     * Whether this behavior writes the world to disk.
+     *
+     * @return {@code true} for {@link #SAVE}, {@code false} for {@link #DISCARD}
+     */
+    public boolean savesToDisk() {
+        return this == SAVE;
+    }
+}

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/WorldUnloader.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/WorldUnloader.java
@@ -60,7 +60,7 @@ public interface WorldUnloader {
     /**
      * Forces the unloading of the world, bypassing any checks or grace periods.
      *
-     * @param save Whether the world should be saved before unloading
+     * @param saveBehavior Whether the world should be saved before unloading
      */
-    void forceUnload(boolean save);
+    void forceUnload(SaveBehavior saveBehavior);
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/UnimportSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/UnimportSubCommand.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.command.subcommand.worlds;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.lifecycle.SaveBehavior;
 import de.eintosti.buildsystem.command.subcommand.AbstractSubCommand;
 import de.eintosti.buildsystem.command.subcommand.Argument;
 import java.util.List;
@@ -42,7 +43,7 @@ public class UnimportSubCommand extends AbstractSubCommand {
         }
 
         plugin.getWorldService()
-                .unimportWorld(buildWorld, true)
+                .unimportWorld(buildWorld, SaveBehavior.SAVE)
                 .thenRun(() -> messages.sendMessage(
                         player, "worlds_unimport_finished", Map.entry("%world%", buildWorld.getName())));
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -34,6 +34,7 @@ import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
 import de.eintosti.buildsystem.api.world.creation.generator.Generator;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.api.world.lifecycle.SaveBehavior;
 import de.eintosti.buildsystem.storage.FolderStorageImpl;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
 import de.eintosti.buildsystem.storage.yaml.YamlFolderStorage;
@@ -176,8 +177,8 @@ public class WorldServiceImpl implements WorldService {
     }
 
     @Override
-    public CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, boolean save) {
-        buildWorld.getUnloader().forceUnload(save);
+    public CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, SaveBehavior saveBehavior) {
+        buildWorld.getUnloader().forceUnload(saveBehavior);
         this.worldStorage.removeBuildWorld(buildWorld);
         Bukkit.getServer().getPluginManager().callEvent(new BuildWorldUnimportEvent(buildWorld));
         removePlayersFromWorld(buildWorld.getName(), "worlds_unimport_players_world");
@@ -243,7 +244,7 @@ public class WorldServiceImpl implements WorldService {
         // Registry removal and metadata persistence are awaited before folder deletion
         // so a crash mid-delete leaves an orphaned folder (re-importable) rather than
         // an orphaned registry entry pointing at a deleted folder.
-        return unimportWorld(buildWorld, false).thenRunAsync(() -> {
+        return unimportWorld(buildWorld, SaveBehavior.DISCARD).thenRunAsync(() -> {
             try {
                 FileUtils.deleteDirectory(deleteFolder);
             } catch (IOException e) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
@@ -25,6 +25,7 @@ import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.Backup;
 import de.eintosti.buildsystem.api.world.backup.BackupProfile;
 import de.eintosti.buildsystem.api.world.backup.BackupStorage;
+import de.eintosti.buildsystem.api.world.lifecycle.SaveBehavior;
 import de.eintosti.buildsystem.api.world.lifecycle.WorldTeleporter;
 import de.eintosti.buildsystem.util.FileUtils;
 import de.eintosti.buildsystem.util.StringUtils;
@@ -140,7 +141,7 @@ public class BackupProfileImpl implements BackupProfile {
         Location spawn = spawnService.getSpawn();
         boolean isSpawn = spawn != null && Objects.equals(spawn.getWorld(), world);
 
-        this.buildWorld.getUnloader().forceUnload(false);
+        this.buildWorld.getUnloader().forceUnload(SaveBehavior.DISCARD);
         try {
             FileUtils.deleteDirectory(new File(Bukkit.getWorldContainer(), worldName));
         } catch (IOException e) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldUnloaderImpl.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.world.lifecycle;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.event.world.BuildWorldPostUnloadEvent;
 import de.eintosti.buildsystem.api.event.world.BuildWorldUnloadEvent;
+import de.eintosti.buildsystem.api.world.lifecycle.SaveBehavior;
 import de.eintosti.buildsystem.api.world.lifecycle.WorldUnloader;
 import de.eintosti.buildsystem.world.BuildWorldImpl;
 import java.util.Arrays;
@@ -142,11 +143,12 @@ public class WorldUnloaderImpl implements WorldUnloader {
             return;
         }
 
-        forceUnload(true);
+        forceUnload(SaveBehavior.SAVE);
     }
 
     @Override
-    public void forceUnload(boolean save) {
+    public void forceUnload(SaveBehavior saveBehavior) {
+        boolean save = saveBehavior.savesToDisk();
         BuildWorldUnloadEvent unloadEvent = new BuildWorldUnloadEvent(buildWorld);
         Bukkit.getServer().getPluginManager().callEvent(unloadEvent);
         if (unloadEvent.isCancelled()) {


### PR DESCRIPTION
Small API-quality break, done now while unreleased.

`WorldService.unimportWorld(world, boolean save)` and `WorldUnloader.forceUnload(boolean save)` took a bare boolean, so call sites read `unimportWorld(world, true)` — "true" what?

Replaced with a self-documenting **`SaveBehavior { SAVE, DISCARD }`** enum (`api.world.lifecycle`):

```java
worldService.unimportWorld(world, SaveBehavior.SAVE);
world.getUnloader().forceUnload(SaveBehavior.DISCARD);
```

`SaveBehavior.savesToDisk()` keeps the internal boolean logic tidy. All call sites updated (UnimportSubCommand → SAVE, delete path / BackupProfile → DISCARD). `./gradlew clean build` + `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)