### PR TITLE
refactor(api)!: WorldData flat-accessor only; internalize Property + capabilities

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
@@ -64,7 +64,7 @@ public interface BuildWorld extends Displayable {
 
     /**
      * Gets the {@link Profileable} representation of this build world which is applied when
-     * {@link WorldData#material()} is set to {@link Material#PLAYER_HEAD}.
+     * {@link WorldData#getMaterial()} is set to {@link Material#PLAYER_HEAD}.
      *
      * @return The {@link Profileable} representation of this build world
      */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.api.world.access;
 
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
@@ -73,11 +72,27 @@ public interface WorldPermissions {
      *   <li>They have the bypass permission for the check
      * </ul>
      *
+     * <p>This overload performs the world-level check only (archive and builder rules), without any
+     * setting-specific gate.
+     *
      * @param player The player attempting to modify the world
-     * @param check The specific data property representing the modification to be checked
      * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
+     * @since TODO
      */
-    boolean canModify(Player player, Property<Boolean> check);
+    boolean canModify(Player player);
+
+    /**
+     * Checks if a {@link Player} is allowed to perform a modification gated by a specific {@link WorldSetting}.
+     *
+     * <p>In addition to the world-level rules of {@link #canModify(Player)}, the player is denied when the setting is
+     * enabled and they lack the setting's {@link WorldSetting#getBypassPermission() bypass permission}.
+     *
+     * @param player The player attempting to modify the world
+     * @param setting The world setting gating the modification
+     * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
+     * @since TODO
+     */
+    boolean canModify(Player player, WorldSetting setting);
 
     /**
      * Checks if the given {@link Player} is permitted to execute a specific command within the context of the current

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldSetting.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldSetting.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.api.world.access;
+
+import de.eintosti.buildsystem.api.world.data.WorldData;
+import java.util.function.Predicate;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A protectable boolean world setting that gates whether a player may modify the world in a particular way.
+ *
+ * @since TODO
+ */
+@NullMarked
+public enum WorldSetting {
+
+    /**
+     * Whether blocks may be broken in the world.
+     */
+    BLOCK_BREAKING("buildsystem.bypass.settings", WorldData::isBlockBreaking),
+
+    /**
+     * Whether blocks may be placed in the world.
+     */
+    BLOCK_PLACEMENT("buildsystem.bypass.settings", WorldData::isBlockPlacement),
+
+    /**
+     * Whether blocks may be interacted with in the world.
+     */
+    BLOCK_INTERACTIONS("buildsystem.bypass.settings", WorldData::isBlockInteractions);
+
+    private final String bypassPermission;
+    private final Predicate<WorldData> enabled;
+
+    WorldSetting(String bypassPermission, Predicate<WorldData> enabled) {
+        this.bypassPermission = bypassPermission;
+        this.enabled = enabled;
+    }
+
+    /**
+     * Gets the permission node that lets a player modify the world even when this setting would otherwise deny it.
+     *
+     * @return The bypass permission node
+     */
+    public String getBypassPermission() {
+        return bypassPermission;
+    }
+
+    /**
+     * Gets whether this setting is currently enabled for the given world data.
+     *
+     * @param data The world data to read
+     * @return {@code true} if the setting is enabled, otherwise {@code false}
+     */
+    public boolean isEnabled(WorldData data) {
+        return enabled.test(data);
+    }
+}

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/Visibility.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/Visibility.java
@@ -50,7 +50,7 @@ public enum Visibility {
      * Returns the appropriate {@link Visibility} enum based on whether a world is private.
      *
      * @param isPrivateWorld A boolean indicating if the world is private
-     * @return {@link #PRIVATE} if {@link WorldData#privateWorld()} is true, otherwise {@link #PUBLIC}
+     * @return {@link #PRIVATE} if {@link WorldData#isPrivateWorld()} is true, otherwise {@link #PUBLIC}
      */
     public static Visibility matchVisibility(boolean isPrivateWorld) {
         return isPrivateWorld ? PRIVATE : PUBLIC;

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
@@ -18,7 +18,6 @@
 package de.eintosti.buildsystem.api.world.data;
 
 import com.cryptomorin.xseries.XMaterial;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.Backup;
 import org.bukkit.Difficulty;
@@ -36,23 +35,12 @@ import org.jspecify.annotations.Nullable;
 public interface WorldData {
 
     /**
-     * Retrieves a {@link Property} object representing the custom spawn location of the {@link BuildWorld}. The value is
-     * stored as a string in the format {@code x;y;z;yaw;pitch}.
-     *
-     * @return A {@link Property} containing the custom spawn string
-     * @see #getCustomSpawnLocation()
-     */
-    Property<String> customSpawn();
-
-    /**
      * Gets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
      *
      * @return The custom spawn string
      * @since TODO
      */
-    default String getCustomSpawn() {
-        return customSpawn().get();
-    }
+    String getCustomSpawn();
 
     /**
      * Sets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
@@ -60,9 +48,7 @@ public interface WorldData {
      * @param customSpawn The custom spawn string
      * @since TODO
      */
-    default void setCustomSpawn(String customSpawn) {
-        customSpawn().set(customSpawn);
-    }
+    void setCustomSpawn(String customSpawn);
 
     /**
      * Gets the {@link BuildWorld}'s custom spawn as a {@link Location} object.
@@ -72,22 +58,12 @@ public interface WorldData {
     @Nullable Location getCustomSpawnLocation();
 
     /**
-     * Retrieves a {@link Property} object representing the permission required to enter the {@link BuildWorld}. Returns
-     * "-" if no specific permission is required.
-     *
-     * @return A {@link Property} containing the permission string
-     */
-    Property<String> permission();
-
-    /**
-     * Gets the permission required to enter the {@link BuildWorld}.
+     * Gets the permission required to enter the {@link BuildWorld}. Returns "-" if no specific permission is required.
      *
      * @return The permission string
      * @since TODO
      */
-    default String getPermission() {
-        return permission().get();
-    }
+    String getPermission();
 
     /**
      * Sets the permission required to enter the {@link BuildWorld}.
@@ -95,17 +71,7 @@ public interface WorldData {
      * @param permission The permission string
      * @since TODO
      */
-    default void setPermission(String permission) {
-        permission().set(permission);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the project description of the {@link BuildWorld}. This typically
-     * provides a brief overview or purpose of the world.
-     *
-     * @return A {@link Property} containing the project description string
-     */
-    Property<String> project();
+    void setPermission(String permission);
 
     /**
      * Gets the project description of the {@link BuildWorld}.
@@ -113,9 +79,7 @@ public interface WorldData {
      * @return The project description string
      * @since TODO
      */
-    default String getProject() {
-        return project().get();
-    }
+    String getProject();
 
     /**
      * Sets the project description of the {@link BuildWorld}.
@@ -123,16 +87,7 @@ public interface WorldData {
      * @param project The project description string
      * @since TODO
      */
-    default void setProject(String project) {
-        project().set(project);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the {@link Difficulty} of the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing the world's difficulty setting
-     */
-    Property<Difficulty> difficulty();
+    void setProject(String project);
 
     /**
      * Gets the {@link Difficulty} of the {@link BuildWorld}.
@@ -140,9 +95,7 @@ public interface WorldData {
      * @return The world's difficulty setting
      * @since TODO
      */
-    default Difficulty getDifficulty() {
-        return difficulty().get();
-    }
+    Difficulty getDifficulty();
 
     /**
      * Sets the {@link Difficulty} of the {@link BuildWorld}.
@@ -150,17 +103,7 @@ public interface WorldData {
      * @param difficulty The world's difficulty setting
      * @since TODO
      */
-    default void setDifficulty(Difficulty difficulty) {
-        difficulty().set(difficulty);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the {@link XMaterial} used to display the {@link BuildWorld} in
-     * the navigator menus.
-     *
-     * @return A {@link Property} containing the material used for display
-     */
-    Property<XMaterial> material();
+    void setDifficulty(Difficulty difficulty);
 
     /**
      * Gets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
@@ -168,9 +111,7 @@ public interface WorldData {
      * @return The material used for display
      * @since TODO
      */
-    default XMaterial getMaterial() {
-        return material().get();
-    }
+    XMaterial getMaterial();
 
     /**
      * Sets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
@@ -178,17 +119,7 @@ public interface WorldData {
      * @param material The material used for display
      * @since TODO
      */
-    default void setMaterial(XMaterial material) {
-        material().set(material);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the current {@link BuildWorldStatus} of the world. This indicates
-     * the building progression or state of the world.
-     *
-     * @return A {@link Property} containing the current build status
-     */
-    Property<BuildWorldStatus> status();
+    void setMaterial(XMaterial material);
 
     /**
      * Gets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
@@ -196,9 +127,7 @@ public interface WorldData {
      * @return The current build status
      * @since TODO
      */
-    default BuildWorldStatus getStatus() {
-        return status().get();
-    }
+    BuildWorldStatus getStatus();
 
     /**
      * Sets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
@@ -206,16 +135,7 @@ public interface WorldData {
      * @param status The current build status
      * @since TODO
      */
-    default void setStatus(BuildWorldStatus status) {
-        status().set(status);
-    }
-
-    /**
-     * Retrieves a {@link Property} object indicating whether block breaking is allowed in the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
-     */
-    Property<Boolean> blockBreaking();
+    void setStatus(BuildWorldStatus status);
 
     /**
      * Gets whether block breaking is allowed in the {@link BuildWorld}.
@@ -223,9 +143,7 @@ public interface WorldData {
      * @return {@code true} if allowed, otherwise {@code false}
      * @since TODO
      */
-    default boolean isBlockBreaking() {
-        return blockBreaking().get();
-    }
+    boolean isBlockBreaking();
 
     /**
      * Sets whether block breaking is allowed in the {@link BuildWorld}.
@@ -233,27 +151,15 @@ public interface WorldData {
      * @param blockBreaking {@code true} if allowed, otherwise {@code false}
      * @since TODO
      */
-    default void setBlockBreaking(boolean blockBreaking) {
-        blockBreaking().set(blockBreaking);
-    }
+    void setBlockBreaking(boolean blockBreaking);
 
     /**
-     * Retrieves a {@link Property} object indicating whether block interactions (e.g., opening doors, chests) are
-     * enabled in the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Property<Boolean> blockInteractions();
-
-    /**
-     * Gets whether block interactions are enabled in the {@link BuildWorld}.
+     * Gets whether block interactions (e.g., opening doors, chests) are enabled in the {@link BuildWorld}.
      *
      * @return {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default boolean isBlockInteractions() {
-        return blockInteractions().get();
-    }
+    boolean isBlockInteractions();
 
     /**
      * Sets whether block interactions are enabled in the {@link BuildWorld}.
@@ -261,16 +167,7 @@ public interface WorldData {
      * @param blockInteractions {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default void setBlockInteractions(boolean blockInteractions) {
-        blockInteractions().set(blockInteractions);
-    }
-
-    /**
-     * Retrieves a {@link Property} object indicating whether block placement is allowed in the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if allowed, otherwise {@code false}
-     */
-    Property<Boolean> blockPlacement();
+    void setBlockInteractions(boolean blockInteractions);
 
     /**
      * Gets whether block placement is allowed in the {@link BuildWorld}.
@@ -278,9 +175,7 @@ public interface WorldData {
      * @return {@code true} if allowed, otherwise {@code false}
      * @since TODO
      */
-    default boolean isBlockPlacement() {
-        return blockPlacement().get();
-    }
+    boolean isBlockPlacement();
 
     /**
      * Sets whether block placement is allowed in the {@link BuildWorld}.
@@ -288,27 +183,16 @@ public interface WorldData {
      * @param blockPlacement {@code true} if allowed, otherwise {@code false}
      * @since TODO
      */
-    default void setBlockPlacement(boolean blockPlacement) {
-        blockPlacement().set(blockPlacement);
-    }
+    void setBlockPlacement(boolean blockPlacement);
 
     /**
-     * Retrieves a {@link Property} object indicating whether the "builders feature" is enabled in the
-     * {@link BuildWorld}. When enabled, only designated builders can modify the world.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Property<Boolean> buildersEnabled();
-
-    /**
-     * Gets whether the "builders feature" is enabled in the {@link BuildWorld}.
+     * Gets whether the "builders feature" is enabled in the {@link BuildWorld}. When enabled, only designated builders
+     * can modify the world.
      *
      * @return {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default boolean isBuildersEnabled() {
-        return buildersEnabled().get();
-    }
+    boolean isBuildersEnabled();
 
     /**
      * Sets whether the "builders feature" is enabled in the {@link BuildWorld}.
@@ -316,16 +200,7 @@ public interface WorldData {
      * @param buildersEnabled {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default void setBuildersEnabled(boolean buildersEnabled) {
-        buildersEnabled().set(buildersEnabled);
-    }
-
-    /**
-     * Retrieves a {@link Property} object indicating whether explosions are enabled in the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Property<Boolean> explosions();
+    void setBuildersEnabled(boolean buildersEnabled);
 
     /**
      * Gets whether explosions are enabled in the {@link BuildWorld}.
@@ -333,9 +208,7 @@ public interface WorldData {
      * @return {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default boolean isExplosions() {
-        return explosions().get();
-    }
+    boolean isExplosions();
 
     /**
      * Sets whether explosions are enabled in the {@link BuildWorld}.
@@ -343,17 +216,7 @@ public interface WorldData {
      * @param explosions {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default void setExplosions(boolean explosions) {
-        explosions().set(explosions);
-    }
-
-    /**
-     * Retrieves a {@link Property} object indicating whether entities in the {@link BuildWorld} have artificial
-     * intelligence.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Property<Boolean> mobAi();
+    void setExplosions(boolean explosions);
 
     /**
      * Gets whether entities in the {@link BuildWorld} have artificial intelligence.
@@ -361,9 +224,7 @@ public interface WorldData {
      * @return {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default boolean isMobAi() {
-        return mobAi().get();
-    }
+    boolean isMobAi();
 
     /**
      * Sets whether entities in the {@link BuildWorld} have artificial intelligence.
@@ -371,27 +232,15 @@ public interface WorldData {
      * @param mobAi {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default void setMobAi(boolean mobAi) {
-        mobAi().set(mobAi);
-    }
+    void setMobAi(boolean mobAi);
 
     /**
-     * Retrieves a {@link Property} object indicating whether physics (e.g., gravity, fluid flow) is applied to blocks in
-     * the {@link BuildWorld}.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if enabled, otherwise {@code false}
-     */
-    Property<Boolean> physics();
-
-    /**
-     * Gets whether physics is applied to blocks in the {@link BuildWorld}.
+     * Gets whether physics (e.g., gravity, fluid flow) is applied to blocks in the {@link BuildWorld}.
      *
      * @return {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default boolean isPhysics() {
-        return physics().get();
-    }
+    boolean isPhysics();
 
     /**
      * Sets whether physics is applied to blocks in the {@link BuildWorld}.
@@ -399,28 +248,16 @@ public interface WorldData {
      * @param physics {@code true} if enabled, otherwise {@code false}
      * @since TODO
      */
-    default void setPhysics(boolean physics) {
-        physics().set(physics);
-    }
+    void setPhysics(boolean physics);
 
     /**
-     * Retrieves a {@link Property} object indicating whether this world is pinned to the top of the navigator, ahead of
-     * unpinned worlds regardless of the active sort order.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if pinned, otherwise {@code false}
-     * @since TODO
-     */
-    Property<Boolean> pinned();
-
-    /**
-     * Gets whether this world is pinned to the top of the navigator.
+     * Gets whether this world is pinned to the top of the navigator, ahead of unpinned worlds regardless of the active
+     * sort order.
      *
      * @return {@code true} if pinned, otherwise {@code false}
      * @since TODO
      */
-    default boolean isPinned() {
-        return pinned().get();
-    }
+    boolean isPinned();
 
     /**
      * Sets whether this world is pinned to the top of the navigator.
@@ -428,27 +265,16 @@ public interface WorldData {
      * @param pinned {@code true} if pinned, otherwise {@code false}
      * @since TODO
      */
-    default void setPinned(boolean pinned) {
-        pinned().set(pinned);
-    }
+    void setPinned(boolean pinned);
 
     /**
-     * Retrieves a {@link Property} object indicating whether the {@link BuildWorld} is set to private visibility. A
-     * private world is typically only accessible to its creator and designated builders.
-     *
-     * @return A {@link Property} containing a boolean: {@code true} if private, otherwise {@code false}
-     */
-    Property<Boolean> privateWorld();
-
-    /**
-     * Gets whether the {@link BuildWorld} is set to private visibility.
+     * Gets whether the {@link BuildWorld} is set to private visibility. A private world is typically only accessible to
+     * its creator and designated builders.
      *
      * @return {@code true} if private, otherwise {@code false}
      * @since TODO
      */
-    default boolean isPrivateWorld() {
-        return privateWorld().get();
-    }
+    boolean isPrivateWorld();
 
     /**
      * Sets whether the {@link BuildWorld} is set to private visibility.
@@ -456,16 +282,7 @@ public interface WorldData {
      * @param privateWorld {@code true} if private, otherwise {@code false}
      * @since TODO
      */
-    default void setPrivateWorld(boolean privateWorld) {
-        privateWorld().set(privateWorld);
-    }
-
-    /**
-     * Gets the number of seconds that have passed since that last {@link Backup} of the {@link BuildWorld} was created.
-     *
-     * @return The number of seconds since the last backup
-     */
-    Property<Integer> timeSinceBackup();
+    void setPrivateWorld(boolean privateWorld);
 
     /**
      * Gets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
@@ -473,9 +290,7 @@ public interface WorldData {
      * @return The number of seconds since the last backup
      * @since TODO
      */
-    default int getTimeSinceBackup() {
-        return timeSinceBackup().get();
-    }
+    int getTimeSinceBackup();
 
     /**
      * Sets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
@@ -483,17 +298,7 @@ public interface WorldData {
      * @param timeSinceBackup The number of seconds since the last backup
      * @since TODO
      */
-    default void setTimeSinceBackup(int timeSinceBackup) {
-        timeSinceBackup().set(timeSinceBackup);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
-     * {@link BuildWorld} was edited.
-     *
-     * @return A {@link Property} containing the last edited timestamp
-     */
-    Property<Long> lastEdited();
+    void setTimeSinceBackup(int timeSinceBackup);
 
     /**
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
@@ -501,9 +306,7 @@ public interface WorldData {
      * @return The last edited timestamp
      * @since TODO
      */
-    default long getLastEdited() {
-        return lastEdited().get();
-    }
+    long getLastEdited();
 
     /**
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
@@ -511,17 +314,7 @@ public interface WorldData {
      * @param lastEdited The last edited timestamp
      * @since TODO
      */
-    default void setLastEdited(long lastEdited) {
-        lastEdited().set(lastEdited);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
-     * {@link BuildWorld} was loaded.
-     *
-     * @return A {@link Property} containing the last loaded timestamp
-     */
-    Property<Long> lastLoaded();
+    void setLastEdited(long lastEdited);
 
     /**
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
@@ -529,9 +322,7 @@ public interface WorldData {
      * @return The last loaded timestamp
      * @since TODO
      */
-    default long getLastLoaded() {
-        return lastLoaded().get();
-    }
+    long getLastLoaded();
 
     /**
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
@@ -539,17 +330,7 @@ public interface WorldData {
      * @param lastLoaded The last loaded timestamp
      * @since TODO
      */
-    default void setLastLoaded(long lastLoaded) {
-        lastLoaded().set(lastLoaded);
-    }
-
-    /**
-     * Retrieves a {@link Property} object representing the timestamp (in milliseconds since epoch) of the last time the
-     * {@link BuildWorld} was unloaded.
-     *
-     * @return A {@link Property} containing the last unloaded timestamp
-     */
-    Property<Long> lastUnloaded();
+    void setLastLoaded(long lastLoaded);
 
     /**
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
@@ -557,9 +338,7 @@ public interface WorldData {
      * @return The last unloaded timestamp
      * @since TODO
      */
-    default long getLastUnloaded() {
-        return lastUnloaded().get();
-    }
+    long getLastUnloaded();
 
     /**
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
@@ -567,7 +346,5 @@ public interface WorldData {
      * @param lastUnloaded The last unloaded timestamp
      * @since TODO
      */
-    default void setLastUnloaded(long lastUnloaded) {
-        lastUnloaded().set(lastUnloaded);
-    }
+    void setLastUnloaded(long lastUnloaded);
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
@@ -51,7 +51,7 @@ public enum NavigatorCategory {
      * Represents the category for private worlds. This navigator inventory contains {@link BuildWorld}s that are set as
      * private. These worlds can typically only be modified by their creator and explicitly added {@link Builder}s.
      *
-     * @see WorldData#privateWorld()
+     * @see WorldData#isPrivateWorld()
      */
     PRIVATE;
 
@@ -66,9 +66,9 @@ public enum NavigatorCategory {
      */
     public static NavigatorCategory of(BuildWorld buildWorld) {
         WorldData worldData = buildWorld.getData();
-        if (worldData.privateWorld().get()) {
+        if (worldData.isPrivateWorld()) {
             return PRIVATE;
-        } else if (worldData.status().get() == BuildWorldStatus.ARCHIVE) {
+        } else if (worldData.getStatus() == BuildWorldStatus.ARCHIVE) {
             return ARCHIVE;
         } else {
             return PUBLIC;

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/WorldSort.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/WorldSort.java
@@ -97,7 +97,7 @@ public enum WorldSort {
      */
     private static String getProjectSortKey(Displayable displayable) {
         return switch (displayable) {
-            case BuildWorld world -> world.getData().project().get().toLowerCase(Locale.ROOT);
+            case BuildWorld world -> world.getData().getProject().toLowerCase(Locale.ROOT);
             case Folder folder -> folder.getProject().toLowerCase(Locale.ROOT);
             default -> "";
         };
@@ -112,7 +112,7 @@ public enum WorldSort {
      */
     private static int getStatusSortKey(Displayable displayable) {
         if (displayable instanceof BuildWorld buildWorld) {
-            return buildWorld.getData().status().get().getStage();
+            return buildWorld.getData().getStatus().getStage();
         }
         return BuildWorldStatus.FINISHED.getStage();
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
@@ -81,11 +81,11 @@ public class ExplosionsCommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (!worldData.explosions().get()) {
-            worldData.explosions().set(true);
+        if (!worldData.isExplosions()) {
+            worldData.setExplosions(true);
             messages.sendMessage(player, "explosions_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.explosions().set(false);
+            worldData.setExplosions(false);
             messages.sendMessage(player, "explosions_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
@@ -81,15 +81,15 @@ public class NoAICommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (worldData.mobAi().get()) {
-            worldData.mobAi().set(false);
+        if (worldData.isMobAi()) {
+            worldData.setMobAi(false);
             messages.sendMessage(player, "noai_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.mobAi().set(true);
+            worldData.setMobAi(true);
             messages.sendMessage(player, "noai_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
 
-        boolean hasAi = worldData.mobAi().get();
+        boolean hasAi = worldData.isMobAi();
         world.getLivingEntities().forEach(entity -> entity.setAI(hasAi));
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
@@ -91,11 +91,11 @@ public class PhysicsCommand extends CommandBase {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (!worldData.physics().get()) {
-            worldData.physics().set(true);
+        if (!worldData.isPhysics()) {
+            worldData.setPhysics(true);
             messages.sendMessage(player, "physics_activated", Map.entry("%world%", buildWorld.getName()));
         } else {
-            worldData.physics().set(false);
+            worldData.setPhysics(false);
             messages.sendMessage(player, "physics_deactivated", Map.entry("%world%", buildWorld.getName()));
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/InfoSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/InfoSubCommand.java
@@ -55,34 +55,25 @@ public class InfoSubCommand extends AbstractSubCommand {
                 Map.entry("%world%", buildWorld.getName()),
                 Map.entry("%uuid%", buildWorld.getUniqueId().toString()),
                 Map.entry("%creator%", getCreator(builders)),
-                Map.entry("%item%", worldData.material().get().name()),
+                Map.entry("%item%", worldData.getMaterial().name()),
                 Map.entry("%type%", messages.getString(Messages.getMessageKey(buildWorld.getType()), player)),
-                Map.entry("%private%", worldData.privateWorld().get()),
-                Map.entry("%builders_enabled%", worldData.buildersEnabled().get()),
+                Map.entry("%private%", worldData.isPrivateWorld()),
+                Map.entry("%builders_enabled%", worldData.isBuildersEnabled()),
                 Map.entry("%builders%", builders.asPlaceholder(player)),
-                Map.entry("%block_breaking%", worldData.blockBreaking().get()),
-                Map.entry("%block_placement%", worldData.blockPlacement().get()),
-                Map.entry(
-                        "%status%",
-                        messages.getString(
-                                Messages.getMessageKey(worldData.status().get()), player)),
-                Map.entry("%project%", worldData.project().get()),
-                Map.entry("%permission%", worldData.permission().get()),
+                Map.entry("%block_breaking%", worldData.isBlockBreaking()),
+                Map.entry("%block_placement%", worldData.isBlockPlacement()),
+                Map.entry("%status%", messages.getString(Messages.getMessageKey(worldData.getStatus()), player)),
+                Map.entry("%project%", worldData.getProject()),
+                Map.entry("%permission%", worldData.getPermission()),
                 Map.entry("%time%", buildWorld.getWorldTime()),
                 Map.entry("%creation%", messages.formatDate(buildWorld.getCreation())),
-                Map.entry("%physics%", worldData.physics().get()),
-                Map.entry("%explosions%", worldData.explosions().get()),
-                Map.entry("%mobai%", worldData.mobAi().get()),
+                Map.entry("%physics%", worldData.isPhysics()),
+                Map.entry("%explosions%", worldData.isExplosions()),
+                Map.entry("%mobai%", worldData.isMobAi()),
                 Map.entry("%custom_spawn%", getCustomSpawn(buildWorld)),
-                Map.entry(
-                        "%lastedited%",
-                        messages.formatDate(worldData.lastEdited().get())),
-                Map.entry(
-                        "%lastloaded%",
-                        messages.formatDate(worldData.lastLoaded().get())),
-                Map.entry(
-                        "%lastunloaded%",
-                        messages.formatDate(worldData.lastUnloaded().get())));
+                Map.entry("%lastedited%", messages.formatDate(worldData.getLastEdited())),
+                Map.entry("%lastloaded%", messages.formatDate(worldData.getLastLoaded())),
+                Map.entry("%lastunloaded%", messages.formatDate(worldData.getLastUnloaded())));
     }
 
     private String getCreator(Builders builders) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetSpawnSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/SetSpawnSubCommand.java
@@ -51,8 +51,7 @@ public class SetSpawnSubCommand extends AbstractSubCommand {
         Location playerLocation = player.getLocation();
         buildWorld
                 .getData()
-                .customSpawn()
-                .set("%s;%s;%s;%s;%s"
+                .setCustomSpawn("%s;%s;%s;%s;%s"
                         .formatted(
                                 playerLocation.getX(),
                                 playerLocation.getY(),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
@@ -89,13 +89,13 @@ public class PlayerJoinListener implements Listener {
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
         if (buildWorld != null) {
             WorldData worldData = buildWorld.getData();
-            if (!worldData.physics().get() && player.hasPermission("buildsystem.physics.message")) {
+            if (!worldData.isPhysics() && player.hasPermission("buildsystem.physics.message")) {
                 plugin.getMessages()
                         .sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", worldName));
             }
 
             if (plugin.getConfigService().current().settings().archive().vanish()
-                    && worldData.status().get() == BuildWorldStatus.ARCHIVE) {
+                    && worldData.getStatus() == BuildWorldStatus.ARCHIVE) {
                 player.addPotionEffect(
                         new PotionEffect(XPotion.INVISIBILITY.get(), PotionEffect.INFINITE_DURATION, 0, false, false),
                         false);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/DisabledInteractionsListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/DisabledInteractionsListener.java
@@ -22,6 +22,7 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XTag;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.player.customblock.CustomBlockManager;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy;
@@ -97,8 +98,7 @@ public class DisabledInteractionsListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld().getName());
-        if (buildWorld != null
-                && policy.mayModify(player, buildWorld, buildWorld.getData().blockPlacement()) != Denial.NONE) {
+        if (buildWorld != null && policy.mayModify(player, buildWorld, WorldSetting.BLOCK_PLACEMENT) != Denial.NONE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/InstantSignPlacementListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/InstantSignPlacementListener.java
@@ -21,6 +21,7 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XTag;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.player.customblock.CustomBlockManager;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy;
@@ -88,8 +89,7 @@ public class InstantSignPlacementListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld().getName());
-        if (buildWorld != null
-                && policy.mayModify(player, buildWorld, buildWorld.getData().blockPlacement()) != Denial.NONE) {
+        if (buildWorld != null && policy.mayModify(player, buildWorld, WorldSetting.BLOCK_PLACEMENT) != Denial.NONE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/IronDoorListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/IronDoorListener.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.listener.settings;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy.Denial;
@@ -77,8 +78,7 @@ public class IronDoorListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld().getName());
-        if (buildWorld != null
-                && policy.mayModify(player, buildWorld, buildWorld.getData().blockPlacement()) != Denial.NONE) {
+        if (buildWorld != null && policy.mayModify(player, buildWorld, WorldSetting.BLOCK_PLACEMENT) != Denial.NONE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlantPlacementListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlantPlacementListener.java
@@ -22,6 +22,7 @@ import com.cryptomorin.xseries.XTag;
 import com.google.common.collect.Sets;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy.Denial;
@@ -111,8 +112,7 @@ public class PlantPlacementListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld().getName());
-        if (buildWorld != null
-                && policy.mayModify(player, buildWorld, buildWorld.getData().blockPlacement()) != Denial.NONE) {
+        if (buildWorld != null && policy.mayModify(player, buildWorld, WorldSetting.BLOCK_PLACEMENT) != Denial.NONE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/SlabListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/SlabListener.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.listener.settings;
 
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy;
 import de.eintosti.buildsystem.protection.WorldProtectionPolicy.Denial;
@@ -63,8 +64,7 @@ public class SlabListener implements Listener {
         }
 
         BuildWorld buildWorld = worldStorage.getBuildWorld(player.getWorld().getName());
-        if (buildWorld != null
-                && policy.mayModify(player, buildWorld, buildWorld.getData().blockPlacement()) != Denial.NONE) {
+        if (buildWorld != null && policy.mayModify(player, buildWorld, WorldSetting.BLOCK_PLACEMENT) != Denial.NONE) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
@@ -19,9 +19,9 @@ package de.eintosti.buildsystem.listener.world;
 
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.event.world.BuildWorldManipulationEvent;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.event.EventDispatcher;
@@ -115,7 +115,7 @@ public class WorldManipulateListener implements Listener {
         WorldData worldData = buildWorld.getData();
         Cancellable parentEvent = event.getParentEvent();
 
-        Property<Boolean> setting = worldSettingFor(parentEvent, worldData);
+        WorldSetting setting = worldSettingFor(parentEvent);
         if (!buildWorld.getPermissions().canModify(player, setting)) {
             parentEvent.setCancelled(true);
             denyPlayerInteraction(event);
@@ -126,11 +126,11 @@ public class WorldManipulateListener implements Listener {
         updateStatus(worldData, player);
     }
 
-    private Property<Boolean> worldSettingFor(Cancellable event, WorldData data) {
+    private WorldSetting worldSettingFor(Cancellable event) {
         return switch (event) {
-            case BlockBreakEvent ignored -> data.blockBreaking();
-            case BlockPlaceEvent ignored -> data.blockPlacement();
-            default -> data.blockInteractions();
+            case BlockBreakEvent ignored -> WorldSetting.BLOCK_BREAKING;
+            case BlockPlaceEvent ignored -> WorldSetting.BLOCK_PLACEMENT;
+            default -> WorldSetting.BLOCK_INTERACTIONS;
         };
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/settings/SettingsService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/settings/SettingsService.java
@@ -132,16 +132,14 @@ public class SettingsService {
             WorldData worldData = buildWorld.getData();
             Builders builders = buildWorld.getBuilders();
 
-            status = plugin.getMessages()
-                    .getString(Messages.getMessageKey(worldData.status().get()), player);
-            permission = worldData.permission().get();
-            project = worldData.project().get();
+            status = plugin.getMessages().getString(Messages.getMessageKey(worldData.getStatus()), player);
+            permission = worldData.getPermission();
+            project = worldData.getProject();
             creator = builders.hasCreator() ? builders.getCreator().getName() : "-";
             creation = plugin.getMessages().formatDate(buildWorld.getCreation());
-            lastEdited = plugin.getMessages().formatDate(worldData.lastEdited().get());
-            lastLoaded = plugin.getMessages().formatDate(worldData.lastLoaded().get());
-            lastUnloaded =
-                    plugin.getMessages().formatDate(worldData.lastUnloaded().get());
+            lastEdited = plugin.getMessages().formatDate(worldData.getLastEdited());
+            lastLoaded = plugin.getMessages().formatDate(worldData.getLastLoaded());
+            lastUnloaded = plugin.getMessages().formatDate(worldData.getLastUnloaded());
         }
 
         return new Map.Entry[] {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
@@ -17,8 +17,8 @@
  */
 package de.eintosti.buildsystem.protection;
 
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import org.bukkit.entity.Player;
@@ -65,12 +65,12 @@ public final class WorldProtectionPolicy {
         return Denial.NONE;
     }
 
-    public Denial checkSetting(Player player, BuildWorld world, Property<Boolean> setting) {
+    public Denial checkSetting(Player player, BuildWorld world, WorldSetting setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }
 
-        if (!setting.get()) {
+        if (!setting.isEnabled(world.getData())) {
             return Denial.SETTING_DISABLED;
         }
 
@@ -90,7 +90,7 @@ public final class WorldProtectionPolicy {
         return checkBuilders(player, world);
     }
 
-    public Denial mayModify(Player player, BuildWorld world, Property<Boolean> setting) {
+    public Denial mayModify(Player player, BuildWorld world, WorldSetting setting) {
         if (world.getPermissions().canBypassBuildRestriction(player)) {
             return Denial.NONE;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -190,18 +190,18 @@ public final class BuildWorldImpl implements BuildWorld {
 
     @Override
     public XMaterial getIcon() {
-        return this.worldData.material().get();
+        return this.worldData.getMaterial();
     }
 
     @Override
     public void setIcon(XMaterial material) {
-        this.worldData.material().set(material);
+        this.worldData.setMaterial(material);
     }
 
     @Override
     public String getDisplayName(Player player) {
         String title = plugin.getMessages().getString("world_item_title", player, Map.entry("%world%", this.name));
-        if (this.worldData.pinned().get()) {
+        if (this.worldData.isPinned()) {
             return plugin.getMessages().getString("world_item_pinned_prefix", player) + title;
         }
         return title;
@@ -213,29 +213,16 @@ public final class BuildWorldImpl implements BuildWorld {
         Map.Entry<String, Object>[] placeholders = List.of(
                         Map.entry(
                                 "%status%",
-                                plugin.getMessages()
-                                        .getString(
-                                                Messages.getMessageKey(
-                                                        worldData.status().get()),
-                                                player)),
-                        Map.entry("%project%", worldData.project().get()),
-                        Map.entry("%permission%", worldData.permission().get()),
+                                plugin.getMessages().getString(Messages.getMessageKey(worldData.getStatus()), player)),
+                        Map.entry("%project%", worldData.getProject()),
+                        Map.entry("%permission%", worldData.getPermission()),
                         Map.entry(
                                 "%creator%",
                                 builders.hasCreator() ? builders.getCreator().getName() : "-"),
                         Map.entry("%creation%", plugin.getMessages().formatDate(getCreation())),
-                        Map.entry(
-                                "%lastedited%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastEdited().get())),
-                        Map.entry(
-                                "%lastloaded%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastLoaded().get())),
-                        Map.entry(
-                                "%lastunloaded%",
-                                plugin.getMessages()
-                                        .formatDate(worldData.lastUnloaded().get())))
+                        Map.entry("%lastedited%", plugin.getMessages().formatDate(worldData.getLastEdited())),
+                        Map.entry("%lastloaded%", plugin.getMessages().formatDate(worldData.getLastLoaded())),
+                        Map.entry("%lastunloaded%", plugin.getMessages().formatDate(worldData.getLastUnloaded())))
                 .toArray(Map.Entry[]::new);
 
         List<String> messageList = getPermissions().canPerformCommand(player, WorldsArgument.EDIT.getPermission())
@@ -298,13 +285,13 @@ public final class BuildWorldImpl implements BuildWorld {
     @Override
     public Difficulty cycleDifficulty() {
         Difficulty newDifficulty =
-                switch (worldData.difficulty().get()) {
+                switch (worldData.getDifficulty()) {
                     case PEACEFUL -> Difficulty.EASY;
                     case EASY -> Difficulty.NORMAL;
                     case NORMAL -> Difficulty.HARD;
                     case HARD -> Difficulty.PEACEFUL;
                 };
-        worldData.difficulty().set(newDifficulty);
+        worldData.setDifficulty(newDifficulty);
         return newDifficulty;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupService.java
@@ -10,7 +10,6 @@ package de.eintosti.buildsystem.world.backup;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.BackupProfile;
@@ -154,7 +153,7 @@ public class BackupService {
         if (autoBackup.onlyActiveWorlds()) {
             for (Player pl : Bukkit.getOnlinePlayers()) {
                 BuildWorld buildWorld = worldStorage.getBuildWorld(pl.getWorld().getName());
-                if (buildWorld != null && buildWorld.getPermissions().canModify(pl, Property.TRUE)) {
+                if (buildWorld != null && buildWorld.getPermissions().canModify(pl)) {
                     worlds.add(buildWorld);
                 }
             }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -18,14 +18,14 @@
 package de.eintosti.buildsystem.world.data;
 
 import com.cryptomorin.xseries.XMaterial;
-import de.eintosti.buildsystem.api.data.Bypassable;
-import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.world.data.type.Bypassable;
 import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
+import de.eintosti.buildsystem.world.data.type.Overridable;
 import de.eintosti.buildsystem.world.data.type.PersistentProperty;
+import de.eintosti.buildsystem.world.data.type.Property;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -144,13 +144,18 @@ public class WorldDataImpl implements WorldData {
     }
 
     @Override
-    public Property<String> customSpawn() {
-        return customSpawn;
+    public String getCustomSpawn() {
+        return customSpawn.get();
+    }
+
+    @Override
+    public void setCustomSpawn(String customSpawn) {
+        this.customSpawn.set(customSpawn);
     }
 
     @Override
     public @Nullable Location getCustomSpawnLocation() {
-        String customSpawn = customSpawn().get();
+        String customSpawn = this.customSpawn.get();
         if (customSpawn.isBlank()) {
             return null;
         }
@@ -166,93 +171,183 @@ public class WorldDataImpl implements WorldData {
     }
 
     @Override
-    public Property<String> permission() {
-        return permission;
+    public String getPermission() {
+        return permission.get();
     }
 
     @Override
-    public Property<String> project() {
-        return project;
+    public void setPermission(String permission) {
+        this.permission.set(permission);
     }
 
     @Override
-    public Property<Difficulty> difficulty() {
-        return difficulty;
+    public String getProject() {
+        return project.get();
     }
 
     @Override
-    public Property<XMaterial> material() {
-        return material;
+    public void setProject(String project) {
+        this.project.set(project);
     }
 
     @Override
-    public Property<BuildWorldStatus> status() {
-        return status;
+    public Difficulty getDifficulty() {
+        return difficulty.get();
     }
 
     @Override
-    public Property<Boolean> blockBreaking() {
-        return blockBreaking;
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty.set(difficulty);
     }
 
     @Override
-    public Property<Boolean> blockInteractions() {
-        return blockInteractions;
+    public XMaterial getMaterial() {
+        return material.get();
     }
 
     @Override
-    public Property<Boolean> blockPlacement() {
-        return blockPlacement;
+    public void setMaterial(XMaterial material) {
+        this.material.set(material);
     }
 
     @Override
-    public Property<Boolean> buildersEnabled() {
-        return buildersEnabled;
+    public BuildWorldStatus getStatus() {
+        return status.get();
     }
 
     @Override
-    public Property<Boolean> explosions() {
-        return explosions;
+    public void setStatus(BuildWorldStatus status) {
+        this.status.set(status);
     }
 
     @Override
-    public Property<Boolean> mobAi() {
-        return mobAi;
+    public boolean isBlockBreaking() {
+        return blockBreaking.get();
     }
 
     @Override
-    public Property<Boolean> physics() {
-        return physics;
+    public void setBlockBreaking(boolean blockBreaking) {
+        this.blockBreaking.set(blockBreaking);
     }
 
     @Override
-    public Property<Boolean> pinned() {
-        return pinned;
+    public boolean isBlockInteractions() {
+        return blockInteractions.get();
     }
 
     @Override
-    public Property<Boolean> privateWorld() {
-        return privateWorld;
+    public void setBlockInteractions(boolean blockInteractions) {
+        this.blockInteractions.set(blockInteractions);
     }
 
     @Override
-    public Property<Integer> timeSinceBackup() {
-        return timeSinceBackup;
+    public boolean isBlockPlacement() {
+        return blockPlacement.get();
     }
 
     @Override
-    public Property<Long> lastEdited() {
-        return lastEdited;
+    public void setBlockPlacement(boolean blockPlacement) {
+        this.blockPlacement.set(blockPlacement);
     }
 
     @Override
-    public Property<Long> lastLoaded() {
-        return lastLoaded;
+    public boolean isBuildersEnabled() {
+        return buildersEnabled.get();
     }
 
     @Override
-    public Property<Long> lastUnloaded() {
-        return lastUnloaded;
+    public void setBuildersEnabled(boolean buildersEnabled) {
+        this.buildersEnabled.set(buildersEnabled);
+    }
+
+    @Override
+    public boolean isExplosions() {
+        return explosions.get();
+    }
+
+    @Override
+    public void setExplosions(boolean explosions) {
+        this.explosions.set(explosions);
+    }
+
+    @Override
+    public boolean isMobAi() {
+        return mobAi.get();
+    }
+
+    @Override
+    public void setMobAi(boolean mobAi) {
+        this.mobAi.set(mobAi);
+    }
+
+    @Override
+    public boolean isPhysics() {
+        return physics.get();
+    }
+
+    @Override
+    public void setPhysics(boolean physics) {
+        this.physics.set(physics);
+    }
+
+    @Override
+    public boolean isPinned() {
+        return pinned.get();
+    }
+
+    @Override
+    public void setPinned(boolean pinned) {
+        this.pinned.set(pinned);
+    }
+
+    @Override
+    public boolean isPrivateWorld() {
+        return privateWorld.get();
+    }
+
+    @Override
+    public void setPrivateWorld(boolean privateWorld) {
+        this.privateWorld.set(privateWorld);
+    }
+
+    @Override
+    public int getTimeSinceBackup() {
+        return timeSinceBackup.get();
+    }
+
+    @Override
+    public void setTimeSinceBackup(int timeSinceBackup) {
+        this.timeSinceBackup.set(timeSinceBackup);
+    }
+
+    @Override
+    public long getLastEdited() {
+        return lastEdited.get();
+    }
+
+    @Override
+    public void setLastEdited(long lastEdited) {
+        this.lastEdited.set(lastEdited);
+    }
+
+    @Override
+    public long getLastLoaded() {
+        return lastLoaded.get();
+    }
+
+    @Override
+    public void setLastLoaded(long lastLoaded) {
+        this.lastLoaded.set(lastLoaded);
+    }
+
+    @Override
+    public long getLastUnloaded() {
+        return lastUnloaded.get();
+    }
+
+    @Override
+    public void setLastUnloaded(long lastUnloaded) {
+        this.lastUnloaded.set(lastUnloaded);
     }
 
     public void setWorldName(String worldName) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Bypassable.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Bypassable.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
 import org.jspecify.annotations.NullMarked;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Capability.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Capability.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
 /**
  * A marker interface for a "capability" or "attachment" that can be added to a {@link Property}.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/ConfigurableProperty.java
@@ -17,9 +17,6 @@
  */
 package de.eintosti.buildsystem.world.data.type;
 
-import de.eintosti.buildsystem.api.data.Capability;
-import de.eintosti.buildsystem.api.data.Overridable;
-import de.eintosti.buildsystem.api.data.Property;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Overridable.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Overridable.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/PersistentProperty.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.world.data.type;
 
-import de.eintosti.buildsystem.api.data.Property;
 import org.jspecify.annotations.NullMarked;
 
 /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Property.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/type/Property.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.eintosti.buildsystem.api.data;
+package de.eintosti.buildsystem.world.data.type;
 
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
@@ -18,14 +18,12 @@
 package de.eintosti.buildsystem.world.lifecycle;
 
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Bypassable;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
-import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
@@ -72,7 +70,16 @@ public class WorldPermissionsImpl implements WorldPermissions {
     }
 
     @Override
-    public boolean canModify(Player player, Property<Boolean> check) {
+    public boolean canModify(Player player) {
+        return evaluateModify(player, null);
+    }
+
+    @Override
+    public boolean canModify(Player player, WorldSetting setting) {
+        return evaluateModify(player, setting);
+    }
+
+    private boolean evaluateModify(Player player, @Nullable WorldSetting setting) {
         if (buildWorld == null) {
             return true;
         }
@@ -86,12 +93,13 @@ public class WorldPermissionsImpl implements WorldPermissions {
             return false;
         }
 
-        if (canBypassModification(player, check)) {
-            return true;
-        }
-
-        if (!check.get()) {
-            return false;
+        if (setting != null) {
+            if (player.hasPermission(setting.getBypassPermission())) {
+                return true;
+            }
+            if (!setting.isEnabled(buildWorld.getData())) {
+                return false;
+            }
         }
 
         Builders builders = buildWorld.getBuilders();
@@ -99,24 +107,6 @@ public class WorldPermissionsImpl implements WorldPermissions {
                 || builders.isBuilder(player)
                 || player.hasPermission("buildsystem.bypass.builders")
                 || !buildWorld.getData().isBuildersEnabled();
-    }
-
-    /**
-     * Checks if the player has the bypass permission for the given check.
-     *
-     * @param player The player to check
-     * @param check The specific data property representing the modification to be checked
-     * @return {@code true} if the player can bypass the modification, otherwise {@code false}
-     */
-    private boolean canBypassModification(Player player, Property<Boolean> check) {
-        if (!(check instanceof ConfigurableProperty<Boolean> configurableProperty)) {
-            return false;
-        }
-
-        return configurableProperty
-                .getCapability(Bypassable.class)
-                .map(bypassable -> player.hasPermission(bypassable.permission()))
-                .orElse(false);
     }
 
     @Override
@@ -155,11 +145,11 @@ public class WorldPermissionsImpl implements WorldPermissions {
         }
 
         WorldData worldData = buildWorld.getData();
-        if (worldData.status().get() == BuildWorldStatus.ARCHIVE) {
+        if (worldData.getStatus() == BuildWorldStatus.ARCHIVE) {
             return player.hasPermission("buildsystem.bypass.permission.archive");
         }
 
-        return worldData.privateWorld().get()
+        return worldData.isPrivateWorld()
                 ? player.hasPermission("buildsystem.bypass.permission.private")
                 : player.hasPermission("buildsystem.bypass.permission.public");
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -24,7 +24,6 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.google.common.collect.Sets;
 import de.eintosti.buildsystem.BuildSystemPlugin;
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.Visibility;
@@ -40,7 +39,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -93,7 +93,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.pin",
                             "worldeditor_pin_item",
                             "worldeditor_pin_lore",
-                            WorldData::pinned)),
+                            WorldData::isPinned,
+                            WorldData::setPinned)),
             entry(
                     20,
                     new Toggle(
@@ -101,7 +102,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.breaking",
                             "worldeditor_blockbreaking_item",
                             "worldeditor_blockbreaking_lore",
-                            WorldData::blockBreaking)),
+                            WorldData::isBlockBreaking,
+                            WorldData::setBlockBreaking)),
             entry(
                     21,
                     new Toggle(
@@ -109,7 +111,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.placement",
                             "worldeditor_blockplacement_item",
                             "worldeditor_blockplacement_lore",
-                            WorldData::blockPlacement)),
+                            WorldData::isBlockPlacement,
+                            WorldData::setBlockPlacement)),
             entry(
                     22,
                     new Toggle(
@@ -117,7 +120,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.physics",
                             "worldeditor_physics_item",
                             "worldeditor_physics_lore",
-                            WorldData::physics)),
+                            WorldData::isPhysics,
+                            WorldData::setPhysics)),
             entry(
                     24,
                     new Toggle(
@@ -125,7 +129,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.explosions",
                             "worldeditor_explosions_item",
                             "worldeditor_explosions_lore",
-                            WorldData::explosions)),
+                            WorldData::isExplosions,
+                            WorldData::setExplosions)),
             entry(
                     31,
                     new Toggle(
@@ -133,7 +138,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.mobai",
                             "worldeditor_mobai_item",
                             "worldeditor_mobai_lore",
-                            WorldData::mobAi)),
+                            WorldData::isMobAi,
+                            WorldData::setMobAi)),
             entry(
                     33,
                     new Toggle(
@@ -141,7 +147,8 @@ public class EditMenu extends Menu {
                             "buildsystem.edit.interactions",
                             "worldeditor_blockinteractions_item",
                             "worldeditor_blockinteractions_lore",
-                            WorldData::blockInteractions)));
+                            WorldData::isBlockInteractions,
+                            WorldData::setBlockInteractions)));
 
     private record Toggle(
             XMaterial material,
@@ -149,7 +156,8 @@ public class EditMenu extends Menu {
             String permission,
             String itemKey,
             String loreKey,
-            Function<WorldData, Property<Boolean>> data) {
+            Predicate<WorldData> getter,
+            BiConsumer<WorldData, Boolean> setter) {
 
         /**
          * Creates a toggle whose icon is the same whether the setting is enabled or not.
@@ -159,8 +167,9 @@ public class EditMenu extends Menu {
                 String permission,
                 String itemKey,
                 String loreKey,
-                Function<WorldData, Property<Boolean>> data) {
-            this(material, material, permission, itemKey, loreKey, data);
+                Predicate<WorldData> getter,
+                BiConsumer<WorldData, Boolean> setter) {
+            this(material, material, permission, itemKey, loreKey, getter, setter);
         }
 
         XMaterial iconFor(boolean enabled) {
@@ -200,7 +209,7 @@ public class EditMenu extends Menu {
     private void addToggleItems(Player player, Inventory inventory) {
         WorldData worldData = buildWorld.getData();
         TOGGLES.forEach((slot, toggle) -> {
-            boolean enabled = toggle.data().apply(worldData).get();
+            boolean enabled = toggle.getter().test(worldData);
             plugin.getMenuItems()
                     .addToggleItem(
                             player,
@@ -458,8 +467,8 @@ public class EditMenu extends Menu {
         }
 
         if (requirePermission(player, toggle.permission())) {
-            Property<Boolean> data = toggle.data().apply(buildWorld.getData());
-            data.set(!data.get());
+            WorldData worldData = buildWorld.getData();
+            toggle.setter().accept(worldData, !toggle.getter().test(worldData));
             reopen(player);
         }
         return true;

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/protection/WorldProtectionPolicyTest.java
@@ -21,9 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.eintosti.buildsystem.api.data.Property;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.access.WorldPermissions;
+import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldData;
@@ -135,14 +135,14 @@ class WorldProtectionPolicyTest {
 
     @Test
     void settingDisabled_returnsSettingDisabled() {
-        Property<Boolean> setting = mockProperty(false);
-        assertEquals(Denial.SETTING_DISABLED, policy.checkSetting(player, world, setting));
+        when(data.isBlockPlacement()).thenReturn(false);
+        assertEquals(Denial.SETTING_DISABLED, policy.checkSetting(player, world, WorldSetting.BLOCK_PLACEMENT));
     }
 
     @Test
     void settingEnabled_returnsNone() {
-        Property<Boolean> setting = mockProperty(true);
-        assertEquals(Denial.NONE, policy.checkSetting(player, world, setting));
+        when(data.isBlockPlacement()).thenReturn(true);
+        assertEquals(Denial.NONE, policy.checkSetting(player, world, WorldSetting.BLOCK_PLACEMENT));
     }
 
     @Test
@@ -156,29 +156,22 @@ class WorldProtectionPolicyTest {
 
     @Test
     void mayModify_withSetting_settingDisabled_winsOverBuilders() {
-        Property<Boolean> setting = mockProperty(false);
+        when(data.isBlockPlacement()).thenReturn(false);
         when(data.isBuildersEnabled()).thenReturn(true);
 
-        assertEquals(Denial.SETTING_DISABLED, policy.mayModify(player, world, setting));
+        assertEquals(Denial.SETTING_DISABLED, policy.mayModify(player, world, WorldSetting.BLOCK_PLACEMENT));
     }
 
     @Test
     void mayModify_withSetting_archiveWinsOverSetting() {
         when(data.getStatus()).thenReturn(BuildWorldStatus.ARCHIVE);
-        Property<Boolean> setting = mockProperty(false);
+        when(data.isBlockPlacement()).thenReturn(false);
 
-        assertEquals(Denial.ARCHIVED, policy.mayModify(player, world, setting));
+        assertEquals(Denial.ARCHIVED, policy.mayModify(player, world, WorldSetting.BLOCK_PLACEMENT));
     }
 
     @Test
     void mayModify_allClear_returnsNone() {
         assertEquals(Denial.NONE, policy.mayModify(player, world));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> Property<T> mockProperty(T value) {
-        Property<T> property = mock(Property.class);
-        when(property.get()).thenReturn(value);
-        return property;
     }
 }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorageRoundTripTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorageRoundTripTest.java
@@ -116,13 +116,13 @@ class YamlWorldStorageRoundTripTest {
         newStorage().save(sampleWorld(UUID.randomUUID(), "DataWorld")).join();
 
         BuildWorld world = newStorage().load().join().iterator().next();
-        assertEquals(BuildWorldStatus.FINISHED, world.getData().status().get());
-        assertEquals("MyProject", world.getData().project().get());
-        assertEquals("buildsystem.test", world.getData().permission().get());
-        assertEquals(Difficulty.NORMAL, world.getData().difficulty().get());
-        assertTrue(world.getData().privateWorld().get());
-        assertTrue(world.getData().blockBreaking().get());
-        assertEquals(42, world.getData().timeSinceBackup().get());
+        assertEquals(BuildWorldStatus.FINISHED, world.getData().getStatus());
+        assertEquals("MyProject", world.getData().getProject());
+        assertEquals("buildsystem.test", world.getData().getPermission());
+        assertEquals(Difficulty.NORMAL, world.getData().getDifficulty());
+        assertTrue(world.getData().isPrivateWorld());
+        assertTrue(world.getData().isBlockBreaking());
+        assertEquals(42, world.getData().getTimeSinceBackup());
     }
 
     @Test

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
@@ -18,6 +18,8 @@
 package de.eintosti.buildsystem.world.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import org.jspecify.annotations.NullMarked;
@@ -31,34 +33,24 @@ class WorldDataAccessorTest {
     }
 
     @Test
-    void flatSetter_updatesUnderlyingProperty() {
+    void valueAccessor_roundTrips() {
         WorldDataImpl data = worldData();
 
         data.setStatus(BuildWorldStatus.FINISHED);
-
         assertEquals(BuildWorldStatus.FINISHED, data.getStatus());
-        assertEquals(BuildWorldStatus.FINISHED, data.status().get());
-    }
 
-    @Test
-    void propertySetter_reflectsInFlatGetter() {
-        WorldDataImpl data = worldData();
-
-        data.status().set(BuildWorldStatus.ARCHIVE);
-
+        data.setStatus(BuildWorldStatus.ARCHIVE);
         assertEquals(BuildWorldStatus.ARCHIVE, data.getStatus());
-        assertEquals(BuildWorldStatus.ARCHIVE, data.status().get());
     }
 
     @Test
-    void booleanFlatAccessor_staysInSyncWithProperty() {
+    void booleanAccessor_roundTrips() {
         WorldDataImpl data = worldData();
 
         data.setPhysics(false);
-        assertEquals(false, data.isPhysics());
-        assertEquals(false, data.physics().get());
+        assertFalse(data.isPhysics());
 
-        data.physics().set(true);
-        assertEquals(true, data.isPhysics());
+        data.setPhysics(true);
+        assertTrue(data.isPhysics());
     }
 }


### PR DESCRIPTION
The final API-quality break before stabilization — collapses the `WorldData` dual surface and removes the `Property`/capability machinery from the public API entirely.

## Why

`WorldData` exposed **both** 19 `Property<T>` accessors and the flat accessors (a 57-method dual surface), and `Property`/`Capability`/`Bypassable`/`Overridable` lived in the public `api.data` package despite being used **only internally** (the public `Property` didn't even expose `getCapability`, so consumers could never use them). This tightens the public surface to exactly what consumers need.

## Changes

- **`WorldData` is flat-accessor only.** The 19 `Property<T> xxx()` accessors are removed; `getStatus()`/`setStatus()`, `isPhysics()`/`setPhysics()`, etc. are the sole public data API.
- **`WorldPermissions.canModify(Player, Property<Boolean>)` → key-based.** Replaced by `canModify(Player)` (world-level) and `canModify(Player, WorldSetting)`. New **`WorldSetting`** enum (`BLOCK_BREAKING`/`BLOCK_PLACEMENT`/`BLOCK_INTERACTIONS`) carries each setting's bypass-permission node and value reader. Behavior is identical (verified line-by-line against the old `canModify`).
- **`Property`, `Capability`, `Bypassable`, `Overridable` moved** from `api.data` to core `world.data.type`. The `api.data` package no longer exists — the public API has no `Property` type at all.
- `WorldDataImpl` now implements the flat accessors directly over its internal property fields (the `Property`/`ConfigurableProperty` mechanism stays, internal). `EditMenu` toggles use getter/setter function pairs (`WorldData::isPinned, WorldData::setPinned`).

## Verification

- `grep Property buildsystem-api/src` → nothing; `WorldData` has no `Property` accessors; `api.data` gone.
- `./gradlew clean build` (compile + tests + javadoc) and `spotlessCheck` pass.
- `WorldProtectionPolicyTest` updated to the `WorldSetting` API; `WorldDataAccessorTest` simplified to a flat round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)