### PR TITLE
refactor: unify menu framework

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldManipulationEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldManipulationEvent.java
@@ -25,20 +25,20 @@ import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * This event reduces duplicated code.
- *
- * <p>It will be called when:
+ * Fired when a player modifies a {@link BuildWorld}, providing a single hook for the many distinct Bukkit events that
+ * represent world modification, such as:
  *
  * <ul>
- *   <li>Breaking Blocks
- *   <li>Placing Blocks
- *   <li>Other modification-related stuff
+ *   <li>breaking a block
+ *   <li>placing a block
+ *   <li>other modification-related interactions
  * </ul>
  *
- * Cancelling this event will affect the parent-Event, which has caused the ManipulationEvent to fire.
+ * <p>This event wraps the {@link #getParentEvent() parent Bukkit event} that triggered it: its cancellation state is
+ * delegated to the parent, so cancelling this event also cancels the underlying interaction (and vice versa).
  *
- * <p>Expect the manipulation event to be canceled at {@link org.bukkit.event.EventPriority#LOW} if the player is not
- * allowed to interact with the world.
+ * <p>BuildSystem itself cancels this event at {@link org.bukkit.event.EventPriority#LOW} when the player is not allowed
+ * to modify the world; listeners running at a later priority can observe or override that decision.
  *
  * @since TODO
  */
@@ -68,7 +68,10 @@ public class BuildWorldManipulationEvent extends BuildWorldEvent implements Canc
     }
 
     /**
-     * @return the event which has caused the manipulation event to fire.
+     * Gets the underlying Bukkit event that triggered this manipulation event. This event's cancellation state is
+     * delegated to the returned parent.
+     *
+     * @return The parent event that caused this manipulation event to fire
      */
     public Cancellable getParentEvent() {
         return parentEvent;

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/player/settings/NavigatorType.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/player/settings/NavigatorType.java
@@ -19,12 +19,14 @@ package de.eintosti.buildsystem.api.player.settings;
 
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.inventory.Inventory;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Represents the type of the navigator.
  *
  * @since 3.0.0
  */
+@NullMarked
 public enum NavigatorType {
 
     /**

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/storage/Storage.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/storage/Storage.java
@@ -22,50 +22,61 @@ import java.util.concurrent.CompletableFuture;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A generic interface for storage operations.
+ * A generic, backend-agnostic interface for asynchronous persistence operations.
+ *
+ * <p>All operations are performed off the main server thread and report their result through a {@link CompletableFuture}.
+ * If an operation fails, the returned future completes exceptionally with the underlying cause.
  *
  * @param <T> The type of objects to be stored
+ * @apiNote The returned futures complete on a background thread. Bukkit's API is not thread-safe, so any continuation
+ *     that touches the server (worlds, entities, scheduler, etc.) must first hop back onto the main thread, e.g. via
+ *     {@code thenAccept(result -> Bukkit.getScheduler().runTask(plugin, () -> ...))}.
  * @since 3.0.0
  */
 @NullMarked
 public interface Storage<T> {
 
     /**
-     * Saves the given object to the storage.
+     * Saves the given object to the storage, overwriting any existing entry with the same key.
      *
      * @param object The object to save
-     * @return A {@link CompletableFuture} that completes when the save operation is done
+     * @return A {@link CompletableFuture} that completes when the object has been persisted, or completes exceptionally
+     *     if the operation fails
      */
     CompletableFuture<Void> save(T object);
 
     /**
-     * Saves all the given objects to the storage.
+     * Saves all the given objects to the storage, overwriting any existing entries with the same keys.
      *
      * @param objects The objects to save
-     * @return A {@link CompletableFuture} that completes when the save operation is done
+     * @return A {@link CompletableFuture} that completes when every object has been persisted, or completes exceptionally
+     *     if the operation fails
      */
     CompletableFuture<Void> save(Collection<T> objects);
 
     /**
-     * Loads all objects from the storage.
+     * Loads all objects currently held in the storage.
      *
-     * @return A {@link CompletableFuture} that completes with a collection of loaded objects
+     * @return A {@link CompletableFuture} that completes with all stored objects, or with an empty collection if the
+     *     storage holds none; completes exceptionally if the operation fails
      */
     CompletableFuture<Collection<T>> load();
 
     /**
-     * Deletes the given object from the storage.
+     * Deletes the given object from the storage. Completes normally even if no matching entry exists.
      *
      * @param object The object to delete
-     * @return A {@link CompletableFuture} that completes when the deletion finishes
+     * @return A {@link CompletableFuture} that completes when the deletion finishes, or completes exceptionally if the
+     *     operation fails
      */
     CompletableFuture<Void> delete(T object);
 
     /**
-     * Deletes the object with the given key from the storage.
+     * Deletes the object stored under the given key. Completes normally even if no matching entry exists.
      *
      * @param key The key of the object to delete
-     * @return A {@link CompletableFuture} that completes when the deletion finishes
+     * @return A {@link CompletableFuture} that completes when the deletion finishes, or completes exceptionally if the
+     *     operation fails
      */
     CompletableFuture<Void> delete(String key);
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
@@ -68,7 +68,7 @@ public interface BuildWorld extends Displayable {
      *
      * @return The {@link Profileable} representation of this build world
      */
-    Profileable asProfilable();
+    Profileable asProfileable();
 
     /**
      * Gets this world's {@link BuildWorldType}.

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/builder/Builders.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/builder/Builders.java
@@ -68,6 +68,7 @@ public interface Builders {
      *
      * @return List of builders
      */
+    @Unmodifiable
     Collection<Builder> getAllBuilders();
 
     /**

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
@@ -18,16 +18,12 @@
 package de.eintosti.buildsystem.api.world.display;
 
 import com.cryptomorin.xseries.XMaterial;
-import de.eintosti.buildsystem.api.world.BuildWorld;
 import java.util.List;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -37,18 +33,6 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 public interface Displayable {
-
-    /**
-     * The {@link PersistentDataContainer} key under which {@link #asItemStack(Player)} stores the
-     * {@link DisplayableType#name() type name} of a displayable item.
-     */
-    NamespacedKey DISPLAYABLE_TYPE_KEY = new NamespacedKey("buildsystem", "displayable_type");
-
-    /**
-     * The {@link PersistentDataContainer} key under which {@link #asItemStack(Player)} stores the {@link #getName() name}
-     * of a displayable item.
-     */
-    NamespacedKey DISPLAYABLE_NAME_KEY = new NamespacedKey("buildsystem", "displayable_name");
 
     /**
      * Gets the unique name of this displayable item.
@@ -107,16 +91,6 @@ public interface Displayable {
     List<String> getLore(Player player);
 
     /**
-     * Gets the {@link DisplayableType} that classifies this displayable.
-     *
-     * <p>Implementations declare their own type, allowing {@link #asItemStack(Player)} to tag the item without relying on
-     * the concrete class.
-     *
-     * @return The type of this displayable
-     */
-    DisplayableType getDisplayableType();
-
-    /**
      * Converts this displayable to an {@link ItemStack} for display.
      *
      * @param player The player viewing the inventory
@@ -125,24 +99,17 @@ public interface Displayable {
     default ItemStack asItemStack(Player player) {
         ItemStack itemStack = getIcon().parseItem();
         if (itemStack == null) {
-            throw new IllegalStateException("Icon material " + getIcon() + " could not be parsed into an ItemStack.");
+            throw new IllegalStateException("Icon material %s could not be parsed into an ItemStack.".formatted(getIcon()));
         }
 
         ItemMeta itemMeta = itemStack.getItemMeta();
         if (itemMeta == null) {
-            throw new IllegalStateException("ItemMeta for " + getIcon() + " is null. This should not happen.");
+            throw new IllegalStateException("ItemMeta for %s is null. This should not happen.".formatted(getIcon()));
         }
 
         itemMeta.setDisplayName(getDisplayName(player));
         itemMeta.setLore(getLore(player));
         itemMeta.addItemFlags(ItemFlag.values());
-
-        PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-        pdc.set(
-                DISPLAYABLE_TYPE_KEY,
-                PersistentDataType.STRING,
-                getDisplayableType().name());
-        pdc.set(DISPLAYABLE_NAME_KEY, PersistentDataType.STRING, getName());
 
         itemStack.setItemMeta(itemMeta);
 
@@ -158,21 +125,5 @@ public interface Displayable {
      */
     default void addToInventory(Inventory inventory, int slot, Player player) {
         inventory.setItem(slot, asItemStack(player));
-    }
-
-    /**
-     * Represents the distinct types of items that can be displayed in an inventory within the BuildSystem.
-     */
-    enum DisplayableType {
-
-        /**
-         * Indicates that the displayable item is a {@link BuildWorld}.
-         */
-        BUILD_WORLD,
-
-        /**
-         * Indicates that the displayable item is a {@link Folder}.
-         */
-        FOLDER
     }
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
@@ -28,7 +28,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -38,6 +37,18 @@ import org.jspecify.annotations.NullMarked;
  */
 @NullMarked
 public interface Displayable {
+
+    /**
+     * The {@link PersistentDataContainer} key under which {@link #asItemStack(Player)} stores the
+     * {@link DisplayableType#name() type name} of a displayable item.
+     */
+    NamespacedKey DISPLAYABLE_TYPE_KEY = new NamespacedKey("buildsystem", "displayable_type");
+
+    /**
+     * The {@link PersistentDataContainer} key under which {@link #asItemStack(Player)} stores the {@link #getName() name}
+     * of a displayable item.
+     */
+    NamespacedKey DISPLAYABLE_NAME_KEY = new NamespacedKey("buildsystem", "displayable_name");
 
     /**
      * Gets the unique name of this displayable item.
@@ -96,6 +107,16 @@ public interface Displayable {
     List<String> getLore(Player player);
 
     /**
+     * Gets the {@link DisplayableType} that classifies this displayable.
+     *
+     * <p>Implementations declare their own type, allowing {@link #asItemStack(Player)} to tag the item without relying on
+     * the concrete class.
+     *
+     * @return The type of this displayable
+     */
+    DisplayableType getDisplayableType();
+
+    /**
      * Converts this displayable to an {@link ItemStack} for display.
      *
      * @param player The player viewing the inventory
@@ -116,19 +137,12 @@ public interface Displayable {
         itemMeta.setLore(getLore(player));
         itemMeta.addItemFlags(ItemFlag.values());
 
-        DisplayableType type =
-                switch (this) {
-                    case BuildWorld ignored -> DisplayableType.BUILD_WORLD;
-                    case Folder ignored -> DisplayableType.FOLDER;
-                    default ->
-                        throw new IllegalStateException(
-                                "Unknown displayable type: " + this.getClass().getSimpleName());
-                };
-
-        JavaPlugin plugin = JavaPlugin.getProvidingPlugin(getClass());
         PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-        pdc.set(new NamespacedKey(plugin, "displayable_type"), PersistentDataType.STRING, type.name());
-        pdc.set(new NamespacedKey(plugin, "displayable_name"), PersistentDataType.STRING, getName());
+        pdc.set(
+                DISPLAYABLE_TYPE_KEY,
+                PersistentDataType.STRING,
+                getDisplayableType().name());
+        pdc.set(DISPLAYABLE_NAME_KEY, PersistentDataType.STRING, getName());
 
         itemStack.setItemMeta(itemMeta);
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ButtonMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ButtonMenu.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.menu;
+
+import de.eintosti.buildsystem.i18n.Messages;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link Menu} whose slots are described as a registry of {@link MenuButton}s, so each slot's render and click
+ * behavior is declared once instead of being split across a {@code populate} call and a {@code handleClick} switch.
+ *
+ * <p>Subclasses {@link #register(int, MenuButton) register} their buttons (typically from their constructor) and
+ * delegate {@link #populate(Player)} to {@link #renderButtons(Player)}. Clicks are handled by the base
+ * {@link #handleClick(InventoryClickEvent)}, which routes to the registered button or to {@link #onUnhandledClick}; a
+ * subclass overrides {@code populate} (to fill background items before rendering) and {@code onUnhandledClick} (e.g. to
+ * treat a click on the border as "go back") rather than touching click dispatch directly.
+ *
+ * @param <B> The concrete button type, allowing subclasses to attach their own per-slot metadata while reusing the
+ *     shared registry, render loop, and click dispatch
+ */
+@NullMarked
+public abstract class ButtonMenu<B extends MenuButton> extends Menu {
+
+    private final Map<Integer, B> buttons = new LinkedHashMap<>();
+
+    /**
+     * Creates the menu and its backing inventory.
+     *
+     * @param messages The message provider
+     * @param size The inventory size in slots (a multiple of 9)
+     * @param title The inventory title shown to the player
+     */
+    protected ButtonMenu(Messages messages, int size, String title) {
+        super(messages, size, title);
+    }
+
+    /**
+     * Registers (or replaces) the button shown at the given slot.
+     *
+     * @param slot The inventory slot
+     * @param button The button to place at the slot
+     */
+    protected final void register(int slot, B button) {
+        buttons.put(slot, button);
+    }
+
+    /**
+     * Removes all registered buttons. Useful for menus whose buttons are rebuilt from data that loads after construction
+     * (e.g. asynchronously); the menu clears, re-{@link #register registers}, and re-{@link #renderButtons renders}.
+     */
+    protected final void clearButtons() {
+        buttons.clear();
+    }
+
+    /**
+     * {@return the registered slot &rarr; button view, in insertion order} Subclasses use this to derive per-slot
+     * metadata (e.g. required permissions) from the same registry that drives rendering and clicks.
+     */
+    protected final Map<Integer, B> buttons() {
+        return buttons;
+    }
+
+    /**
+     * Renders every registered button into this menu's inventory. Subclasses typically call this from
+     * {@link #populate(Player)} after filling any background items.
+     *
+     * @param player The viewing player
+     */
+    protected final void renderButtons(Player player) {
+        Inventory inventory = getInventory();
+        buttons.forEach((slot, button) -> button.render(player, inventory, slot));
+    }
+
+    /**
+     * Cancels the click (menus never let players take their items) and routes it to the registered button at the clicked
+     * slot, or to {@link #onUnhandledClick} when the slot has no button. Subclasses customise behaviour through
+     * {@link #onUnhandledClick} (e.g. a "back" filler) rather than overriding this method.
+     *
+     * @param event The click event
+     */
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        B button = buttonAt(event);
+        if (button != null) {
+            button.onClick(player, event);
+        } else {
+            onUnhandledClick(player, event);
+        }
+    }
+
+    /**
+     * Hook for a click on a slot with no registered button — a decorative filler, an empty slot, or the player's own
+     * inventory. The default does nothing; menus override it to, for example, treat a click on the border as "go back".
+     *
+     * @param player The clicking player
+     * @param event The click event (already cancelled)
+     */
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {}
+
+    /**
+     * {@return the button at the clicked slot, or {@code null} if the click landed outside this menu's inventory (e.g.
+     * the player's own inventory) or on an unregistered slot} Uses the {@link InventoryClickEvent#getRawSlot() raw slot}
+     * bounded to this menu's size, so a click in the player's inventory can never collide with a top-inventory button.
+     *
+     * @param event The click event
+     */
+    protected final @Nullable B buttonAt(InventoryClickEvent event) {
+        int rawSlot = event.getRawSlot();
+        if (rawSlot < 0 || rawSlot >= getInventory().getSize()) {
+            return null;
+        }
+        return buttons.get(rawSlot);
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuButton.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuButton.java
@@ -23,9 +23,12 @@ import org.bukkit.inventory.Inventory;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * A single slot in a heterogeneous menu: it knows how to render its icon and how to react to a click. Menus that map
- * each slot to its own behavior keep a {@code Map<Integer, MenuButton>} so the slot &rarr; behavior contract is declared
- * once per button instead of split across a {@code populate} call and a {@code handleClick} switch branch.
+ * A single slot in a {@link ButtonMenu}: it knows how to render its icon and how to react to a click. A menu keeps a
+ * {@code Map<Integer, MenuButton>} so the slot &rarr; behavior contract is declared once per button instead of being
+ * split across a {@code populate} call and a {@code handleClick} switch.
+ *
+ * <p>The owning slot is supplied to {@link #render} at render time, so a button does not need to capture its own slot;
+ * the same button definition can be registered at any slot.
  */
 @NullMarked
 public interface MenuButton {
@@ -35,8 +38,9 @@ public interface MenuButton {
      *
      * @param player The viewing player
      * @param inventory The inventory to render into
+     * @param slot The slot this button occupies
      */
-    void render(Player player, Inventory inventory);
+    void render(Player player, Inventory inventory, int slot);
 
     /**
      * Handles a click on this button. The button is fully responsible for its own outcome, including re-opening the menu
@@ -46,4 +50,96 @@ public interface MenuButton {
      * @param event The click event
      */
     void onClick(Player player, InventoryClickEvent event);
+
+    /**
+     * {@return a new {@link Builder} for assembling a {@code MenuButton} from a renderer and a click handler} Either part
+     * may be omitted: an unset renderer draws nothing and an unset click handler does nothing.
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Renders a button into the slot it occupies.
+     */
+    @FunctionalInterface
+    interface Renderer {
+
+        /**
+         * Renders into the given slot.
+         *
+         * @param player The viewing player
+         * @param inventory The inventory to render into
+         * @param slot The slot this button occupies
+         */
+        void render(Player player, Inventory inventory, int slot);
+    }
+
+    /**
+     * Reacts to a click on a button.
+     */
+    @FunctionalInterface
+    interface ClickHandler {
+
+        /**
+         * Handles the click.
+         *
+         * @param player The clicking player
+         * @param event The click event
+         */
+        void onClick(Player player, InventoryClickEvent event);
+    }
+
+    /**
+     * Fluent builder for a plain {@link MenuButton}. Menus that attach their own per-slot metadata implement
+     * {@code MenuButton} directly instead of using this builder.
+     */
+    final class Builder {
+
+        private Renderer renderer = (player, inventory, slot) -> {};
+        private ClickHandler clickHandler = (player, event) -> {};
+
+        private Builder() {}
+
+        /**
+         * Sets how the button renders into its slot.
+         *
+         * @param renderer The renderer
+         * @return This builder
+         */
+        public Builder render(Renderer renderer) {
+            this.renderer = renderer;
+            return this;
+        }
+
+        /**
+         * Sets how the button reacts to a click.
+         *
+         * @param clickHandler The click handler
+         * @return This builder
+         */
+        public Builder onClick(ClickHandler clickHandler) {
+            this.clickHandler = clickHandler;
+            return this;
+        }
+
+        /**
+         * {@return the assembled {@link MenuButton}}
+         */
+        public MenuButton build() {
+            Renderer builtRenderer = renderer;
+            ClickHandler builtClickHandler = clickHandler;
+            return new MenuButton() {
+                @Override
+                public void render(Player player, Inventory inventory, int slot) {
+                    builtRenderer.render(player, inventory, slot);
+                }
+
+                @Override
+                public void onClick(Player player, InventoryClickEvent event) {
+                    builtClickHandler.onClick(player, event);
+                }
+            };
+        }
+    }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -23,8 +23,6 @@ import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.api.world.BuildWorld;
-import de.eintosti.buildsystem.api.world.display.Displayable;
-import de.eintosti.buildsystem.api.world.display.Displayable.DisplayableType;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.player.settings.SettingsService;
@@ -39,7 +37,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
@@ -59,8 +56,6 @@ public final class MenuItems {
     private final Messages messages;
     private final SettingsService settingsService;
 
-    public final NamespacedKey displayableNameKey;
-    public final NamespacedKey displayableTypeKey;
     public final NamespacedKey navigatorKey;
 
     public MenuItems(
@@ -69,8 +64,6 @@ public final class MenuItems {
         this.configService = configService;
         this.messages = messages;
         this.settingsService = settingsService;
-        this.displayableNameKey = Displayable.DISPLAYABLE_NAME_KEY;
-        this.displayableTypeKey = Displayable.DISPLAYABLE_TYPE_KEY;
         this.navigatorKey = new NamespacedKey(plugin, "navigator");
     }
 
@@ -119,7 +112,6 @@ public final class MenuItems {
                 .name(displayName)
                 .lore(lore)
                 .build();
-        storeWorldInformation(defaultHead, buildWorld);
         inventory.setItem(slot, defaultHead);
 
         XSkull.createItem()
@@ -138,7 +130,6 @@ public final class MenuItems {
                     itemMeta.setDisplayName(displayName);
                     itemMeta.setLore(lore);
                     itemStack.setItemMeta(itemMeta);
-                    storeWorldInformation(itemStack, buildWorld);
                     Bukkit.getScheduler().runTask(plugin, () -> inventory.setItem(slot, itemStack));
                 })
                 .exceptionally(throwable -> {
@@ -149,17 +140,6 @@ public final class MenuItems {
                                     throwable);
                     return null;
                 });
-    }
-
-    private void storeWorldInformation(ItemStack itemStack, BuildWorld buildWorld) {
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        if (itemMeta == null) {
-            return;
-        }
-        PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-        pdc.set(displayableTypeKey, PersistentDataType.STRING, DisplayableType.BUILD_WORLD.name());
-        pdc.set(displayableNameKey, PersistentDataType.STRING, buildWorld.getName());
-        itemStack.setItemMeta(itemMeta);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -23,6 +23,7 @@ import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.display.Displayable;
 import de.eintosti.buildsystem.api.world.display.Displayable.DisplayableType;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
@@ -68,8 +69,8 @@ public final class MenuItems {
         this.configService = configService;
         this.messages = messages;
         this.settingsService = settingsService;
-        this.displayableNameKey = new NamespacedKey(plugin, "displayable_name");
-        this.displayableTypeKey = new NamespacedKey(plugin, "displayable_type");
+        this.displayableNameKey = Displayable.DISPLAYABLE_NAME_KEY;
+        this.displayableTypeKey = Displayable.DISPLAYABLE_TYPE_KEY;
         this.navigatorKey = new NamespacedKey(plugin, "navigator");
     }
 
@@ -124,9 +125,9 @@ public final class MenuItems {
         XSkull.createItem()
                 .profile(
                         buildWorld.getData().isPrivateWorld()
-                                ? buildWorld.asProfilable()
+                                ? buildWorld.asProfileable()
                                 : Profileable.username(buildWorld.getName()))
-                .fallback(buildWorld.asProfilable())
+                .fallback(buildWorld.asProfileable())
                 .lenient()
                 .applyAsync()
                 .thenAcceptAsync(itemStack -> {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/PaginatedMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/PaginatedMenu.java
@@ -37,9 +37,13 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>The page-change and refusal sounds are overridable ({@link #playPageSound}/{@link #playRefuseSound}) for menus
  * that want different audio feedback.
+ *
+ * <p>Being a {@link ButtonMenu}, a paginated menu may also {@link #register(int, MenuButton) register} fixed control
+ * buttons (e.g. the page arrows and a close button) whose clicks are routed by the base {@code handleClick}, while the
+ * variable page content is rendered separately by its {@code populate}.
  */
 @NullMarked
-public abstract class PaginatedMenu extends Menu {
+public abstract class PaginatedMenu extends ButtonMenu<MenuButton> {
 
     private int page = 0;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/PaginatedMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/PaginatedMenu.java
@@ -18,7 +18,10 @@
 package de.eintosti.buildsystem.menu;
 
 import com.cryptomorin.xseries.XSound;
+import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.i18n.Messages;
+import java.util.List;
+import java.util.function.Function;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -122,6 +125,81 @@ public abstract class PaginatedMenu extends ButtonMenu<MenuButton> {
         }
         playRefuseSound(player);
         return false;
+    }
+
+    /**
+     * {@return a button that flips to the previous page and re-{@link #populate populates}} If already on the first page
+     * it does nothing beyond the refusal feedback from {@link #previousPage}. Register it at the slot the menu uses for
+     * its "previous page" control.
+     *
+     * @param skullTexture The skull texture for the arrow icon
+     * @param itemsPerPage The number of items shown per page
+     */
+    protected final MenuButton previousPageButton(String skullTexture, int itemsPerPage) {
+        return pageButton(skullTexture, "gui_previous_page", true, itemsPerPage);
+    }
+
+    /**
+     * {@return a button that flips to the next page and re-{@link #populate populates}} If already on the last page it
+     * does nothing beyond the refusal feedback from {@link #nextPage}. Register it at the slot the menu uses for its
+     * "next page" control.
+     *
+     * @param skullTexture The skull texture for the arrow icon
+     * @param itemsPerPage The number of items shown per page
+     */
+    protected final MenuButton nextPageButton(String skullTexture, int itemsPerPage) {
+        return pageButton(skullTexture, "gui_next_page", false, itemsPerPage);
+    }
+
+    /**
+     * Registers a button for each item visible on the current page, placing the i-th visible item at
+     * {@code contentSlots[i]}. The page window is derived from {@link #page()} and {@code contentSlots.length}; the
+     * {@code itemsPerPage} the page arrows use should equal that length.
+     *
+     * @param contentSlots The slots that hold page content, in order
+     * @param items The full, unpaged item list
+     * @param buttonFactory Builds the button for a given item
+     * @param <T> The item type
+     */
+    protected final <T> void registerPageItems(
+            int[] contentSlots, List<T> items, Function<T, MenuButton> buttonFactory) {
+        int startIndex = page() * contentSlots.length;
+        for (int i = 0; i < contentSlots.length && startIndex + i < items.size(); i++) {
+            register(contentSlots[i], buttonFactory.apply(items.get(startIndex + i)));
+        }
+    }
+
+    /**
+     * Registers a button for each item visible on the current page across {@code count} contiguous slots starting at
+     * {@code firstSlot}. Convenience for the common case where page content occupies a contiguous slot range.
+     *
+     * @param firstSlot The first content slot
+     * @param count The number of content slots (also the items-per-page)
+     * @param items The full, unpaged item list
+     * @param buttonFactory Builds the button for a given item
+     * @param <T> The item type
+     */
+    protected final <T> void registerPageItems(
+            int firstSlot, int count, List<T> items, Function<T, MenuButton> buttonFactory) {
+        int[] slots = new int[count];
+        for (int i = 0; i < count; i++) {
+            slots[i] = firstSlot + i;
+        }
+        registerPageItems(slots, items, buttonFactory);
+    }
+
+    private MenuButton pageButton(String skullTexture, String nameKey, boolean previous, int itemsPerPage) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> ItemBuilder.skull(Profileable.detect(skullTexture))
+                        .name(messages.getString(nameKey, player))
+                        .into(inventory, slot))
+                .onClick((player, event) -> {
+                    boolean moved = previous ? previousPage(player, itemsPerPage) : nextPage(player, itemsPerPage);
+                    if (moved) {
+                        populate(player);
+                    }
+                })
+                .build();
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/customblock/CustomBlockMenu.java
@@ -20,16 +20,16 @@ package de.eintosti.buildsystem.player.customblock;
 import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import java.util.Map;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class CustomBlockMenu extends Menu {
+public class CustomBlockMenu extends ButtonMenu<MenuButton> {
 
     /**
      * A selectable custom block. {@code giveMaterial} is the material the item is handed out as; the default
@@ -78,6 +78,18 @@ public class CustomBlockMenu extends Menu {
     public CustomBlockMenu(BuildSystemPlugin plugin, Player player) {
         super(plugin.getMessages(), 45, plugin.getMessages().getString("blocks_title", player));
         this.plugin = plugin;
+
+        BLOCK_BY_SLOT.forEach((slot, entry) -> register(slot, blockButton(entry)));
+    }
+
+    private MenuButton blockButton(BlockEntry entry) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> ItemBuilder.skull(
+                                Profileable.detect(entry.block().getSkullUrl()))
+                        .name(messages.getString(entry.block().getMessageKey(), player))
+                        .into(inventory, slot))
+                .onClick((player, event) -> giveCustomBlock(player, entry.block(), entry.giveMaterial()))
+                .build();
     }
 
     @Override
@@ -87,7 +99,7 @@ public class CustomBlockMenu extends Menu {
             plugin.getMenuItems().addGlassPane(player, getInventory(), i);
         }
 
-        BLOCK_BY_SLOT.forEach((slot, entry) -> setCustomBlock(player, slot, entry.block()));
+        renderButtons(player);
     }
 
     /**
@@ -95,23 +107,6 @@ public class CustomBlockMenu extends Menu {
      */
     Map<Integer, BlockEntry> blockBySlot() {
         return BLOCK_BY_SLOT;
-    }
-
-    private void setCustomBlock(Player player, int position, CustomBlock customBlock) {
-        ItemBuilder.skull(Profileable.detect(customBlock.getSkullUrl()))
-                .name(messages.getString(customBlock.getMessageKey(), player))
-                .into(getInventory(), position);
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        BlockEntry entry = BLOCK_BY_SLOT.get(event.getSlot());
-        if (entry != null) {
-            giveCustomBlock(player, entry.block(), entry.giveMaterial());
-        }
     }
 
     private void giveCustomBlock(Player player, CustomBlock customBlock, XMaterial material) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/DesignMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/DesignMenu.java
@@ -21,8 +21,9 @@ import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.Settings;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.bukkit.entity.Player;
@@ -31,7 +32,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class DesignMenu extends Menu {
+public class DesignMenu extends ButtonMenu<MenuButton> {
 
     /**
      * The colors selectable in the design menu, keyed by the slot they occupy. {@link LinkedHashMap} keeps insertion
@@ -67,6 +68,25 @@ public class DesignMenu extends Menu {
     public DesignMenu(BuildSystemPlugin plugin, Player player) {
         super(plugin.getMessages(), 36, plugin.getMessages().getString("design_title", player));
         this.plugin = plugin;
+
+        COLOR_SLOTS.forEach((slot, entry) -> register(slot, colorButton(entry)));
+    }
+
+    private MenuButton colorButton(ColorEntry entry) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    Settings settings = plugin.getSettingsService().getSettings(player);
+                    boolean selected = settings.getDesignColor() == entry.color();
+                    ItemBuilder.of(entry.material())
+                            .name((selected ? "§a" : "§7") + messages.getString(entry.messageKey(), player))
+                            .glow(selected)
+                            .into(inventory, slot);
+                })
+                .onClick((player, event) -> {
+                    plugin.getSettingsService().getSettings(player).setDesignColor(entry.color());
+                    new DesignMenu(plugin, player).open(player);
+                })
+                .build();
     }
 
     @Override
@@ -74,42 +94,15 @@ public class DesignMenu extends Menu {
         plugin.getMenuItems().fillRange(player, getInventory(), 0, 9);
         plugin.getMenuItems().fillRange(player, getInventory(), 27, 36);
 
-        COLOR_SLOTS.forEach(
-                (slot, entry) -> setItem(player, slot, entry.material(), entry.messageKey(), entry.color()));
-    }
-
-    private void setItem(Player player, int position, XMaterial material, String key, DesignColor color) {
-        Settings settings = plugin.getSettingsService().getSettings(player);
-
-        boolean selected = settings.getDesignColor() == color;
-        String displayName = messages.getString(key, player);
-        ItemBuilder.of(material)
-                .name((selected ? "§a" : "§7") + displayName)
-                .glow(selected)
-                .into(getInventory(), position);
+        renderButtons(player);
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        // A click on the border glass returns to the settings menu.
         ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null) {
-            return;
-        }
-
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        if (itemStack.getType().toString().contains("STAINED_GLASS_PANE")) {
+        if (itemStack != null && itemStack.getType().toString().contains("STAINED_GLASS_PANE")) {
             new SettingsMenu(plugin, player).open(player);
-            return;
         }
-
-        ColorEntry entry = COLOR_SLOTS.get(event.getSlot());
-        if (entry != null) {
-            Settings settings = plugin.getSettingsService().getSettings(player);
-            settings.setDesignColor(entry.color());
-        }
-
-        new DesignMenu(plugin, player).open(player);
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
@@ -24,8 +24,8 @@ import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.NavigatorType;
 import de.eintosti.buildsystem.api.player.settings.Settings;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
 import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.player.noclip.NoClipService;
 import de.eintosti.buildsystem.player.settings.SettingsService;
@@ -44,7 +44,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-public class SettingsMenu extends Menu {
+public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
 
     private static final int DESIGN_SLOT = 11;
     private static final String PERMISSION_PREFIX = "buildsystem.setting.";
@@ -65,67 +65,109 @@ public class SettingsMenu extends Menu {
      * permission), its {@link ClickOutcome} classification, and its render/click behavior. Replaces the old private
      * {@code Toggle} record and the hand-rolled dispatch.
      */
-    private record SettingsButton(
+    record SettingsButton(
             @Nullable String node,
             ClickOutcome outcome,
-            BiConsumer<Player, Inventory> renderer,
+            MenuButton.Renderer renderer,
             BiConsumer<Player, InventoryClickEvent> clickHandler)
             implements MenuButton {
 
         @Override
-        public void render(Player player, Inventory inventory) {
-            renderer.accept(player, inventory);
+        public void render(Player player, Inventory inventory, int slot) {
+            renderer.render(player, inventory, slot);
         }
 
         @Override
         public void onClick(Player player, InventoryClickEvent event) {
             clickHandler.accept(player, event);
         }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Fluent builder for a {@link SettingsButton}. {@code outcome} defaults to {@link ClickOutcome#TOGGLE}; the
+         * {@code node}, renderer, and click handler default to none/no-op until set.
+         */
+        static final class Builder {
+
+            private @Nullable String node;
+            private ClickOutcome outcome = ClickOutcome.TOGGLE;
+            private MenuButton.Renderer renderer = (player, inventory, slot) -> {};
+            private BiConsumer<Player, InventoryClickEvent> clickHandler = (player, event) -> {};
+
+            private Builder() {}
+
+            Builder node(@Nullable String node) {
+                this.node = node;
+                return this;
+            }
+
+            Builder outcome(ClickOutcome outcome) {
+                this.outcome = outcome;
+                return this;
+            }
+
+            Builder render(MenuButton.Renderer renderer) {
+                this.renderer = renderer;
+                return this;
+            }
+
+            Builder onClick(BiConsumer<Player, InventoryClickEvent> clickHandler) {
+                this.clickHandler = clickHandler;
+                return this;
+            }
+
+            SettingsButton build() {
+                return new SettingsButton(node, outcome, renderer, clickHandler);
+            }
+        }
     }
 
     private final BuildSystemPlugin plugin;
     private final SettingsService settingsManager;
-    private final Map<Integer, SettingsButton> buttons;
 
     public SettingsMenu(BuildSystemPlugin plugin, Player player) {
         super(plugin.getMessages(), 45, plugin.getMessages().getString("settings_title", player));
         this.plugin = plugin;
         this.settingsManager = plugin.getSettingsService();
-        this.buttons = buildButtons();
+        buildButtons();
     }
 
-    private Map<Integer, SettingsButton> buildButtons() {
-        Map<Integer, SettingsButton> map = new LinkedHashMap<>();
+    private void buildButtons() {
+        register(
+                DESIGN_SLOT,
+                SettingsButton.builder()
+                        .outcome(ClickOutcome.SUBMENU)
+                        .render(this::renderDesign)
+                        .onClick((player, event) -> {
+                            new DesignMenu(plugin, player).open(player);
+                            XSound.ENTITY_ITEM_PICKUP.play(player);
+                        })
+                        .build());
 
-        map.put(DESIGN_SLOT, new SettingsButton(null, ClickOutcome.SUBMENU, this::renderDesign, (player, event) -> {
-            new DesignMenu(plugin, player).open(player);
-            XSound.ENTITY_ITEM_PICKUP.play(player);
-        }));
-
-        map.put(
+        register(
                 12,
                 toggleButton(
-                        12,
                         "clear-inventory",
                         "settings_clear_inventory_item",
                         "settings_clear_inventory_lore",
                         s -> s.isClearInventory() ? XMaterial.MINECART : XMaterial.CHEST_MINECART,
                         Settings::isClearInventory,
                         (player, s) -> s.setClearInventory(!s.isClearInventory())));
-        map.put(
+        register(
                 13,
                 toggleButton(
-                        13,
                         "disable-interact",
                         "settings_disableinteract_item",
                         "settings_disableinteract_lore",
                         XMaterial.DIAMOND_AXE,
                         Settings::isDisableInteract,
                         (player, s) -> s.setDisableInteract(!s.isDisableInteract())));
-        map.put(
+        register(
                 14,
                 toggleButton(
-                        14,
                         "hide-players",
                         "settings_hideplayers_item",
                         "settings_hideplayers_lore",
@@ -135,30 +177,27 @@ public class SettingsMenu extends Menu {
                             s.setHidePlayers(!s.isHidePlayers());
                             toggleHidePlayers(player, s);
                         }));
-        map.put(
+        register(
                 15,
                 toggleButton(
-                        15,
                         "instant-place-signs",
                         "settings_instantplacesigns_item",
                         "settings_instantplacesigns_lore",
                         XMaterial.OAK_SIGN,
                         Settings::isInstantPlaceSigns,
                         (player, s) -> s.setInstantPlaceSigns(!s.isInstantPlaceSigns())));
-        map.put(
+        register(
                 20,
                 toggleButton(
-                        20,
                         "keep-navigator",
                         "settings_keep_navigator_item",
                         "settings_keep_navigator_lore",
                         XMaterial.SLIME_BLOCK,
                         Settings::isKeepNavigator,
                         (player, s) -> s.setKeepNavigator(!s.isKeepNavigator())));
-        map.put(
+        register(
                 21,
                 toggleButton(
-                        21,
                         "navigator-type",
                         "settings_new_navigator_item",
                         "settings_new_navigator_lore",
@@ -169,98 +208,89 @@ public class SettingsMenu extends Menu {
                                 .item(),
                         s -> s.getNavigatorType() == NavigatorType.NEW,
                         this::toggleNavigatorType));
-        map.put(
+        register(
                 22,
                 toggleButton(
-                        22,
                         "night-vision",
                         "settings_nightvision_item",
                         "settings_nightvision_lore",
                         XMaterial.GOLDEN_CARROT,
                         Settings::isNightVision,
                         this::toggleNightVision));
-        map.put(
+        register(
                 23,
                 toggleButton(
-                        23,
                         "no-clip",
                         "settings_no_clip_item",
                         "settings_no_clip_lore",
                         XMaterial.BRICKS,
                         Settings::isNoClip,
                         this::toggleNoClip));
-        map.put(
+        register(
                 24,
                 toggleButton(
-                        24,
                         "open-trapdoors",
                         "settings_open_trapdoors_item",
                         "settings_open_trapdoors_lore",
                         XMaterial.IRON_TRAPDOOR,
                         Settings::isOpenTrapDoors,
                         (player, s) -> s.setOpenTrapDoors(!s.isOpenTrapDoors())));
-        map.put(
+        register(
                 29,
                 toggleButton(
-                        29,
                         "place-plants",
                         "settings_placeplants_item",
                         "settings_placeplants_lore",
                         XMaterial.FERN,
                         Settings::isPlacePlants,
                         (player, s) -> s.setPlacePlants(!s.isPlacePlants())));
-        map.put(30, scoreboardButton());
-        map.put(
+        register(30, scoreboardButton());
+        register(
                 31,
                 toggleButton(
-                        31,
                         "slab-breaking",
                         "settings_slab_breaking_item",
                         "settings_slab_breaking_lore",
                         XMaterial.SMOOTH_STONE_SLAB,
                         Settings::isSlabBreaking,
                         (player, s) -> s.setSlabBreaking(!s.isSlabBreaking())));
-        map.put(
+        register(
                 32,
                 toggleButton(
-                        32,
                         "spawn-teleport",
                         "settings_spawnteleport_item",
                         "settings_spawnteleport_lore",
                         XMaterial.MAGMA_CREAM,
                         Settings::isSpawnTeleport,
                         (player, s) -> s.setSpawnTeleport(!s.isSpawnTeleport())));
-
-        return map;
     }
 
     private SettingsButton toggleButton(
-            int slot,
             String node,
             String itemKey,
             String loreKey,
             XMaterial material,
             Predicate<Settings> enabled,
             BiConsumer<Player, Settings> flip) {
-        return toggleButton(slot, node, itemKey, loreKey, s -> material, enabled, flip);
+        return toggleButton(node, itemKey, loreKey, s -> material, enabled, flip);
     }
 
     /**
      * Builds a toggle slot. The icon/state are read from live {@link Settings} at render time, and the flip runs against
-     * live settings at click time — equivalent to the previous per-click snapshot.
+     * live settings at click time — equivalent to the previous per-click snapshot. The slot is supplied at render time,
+     * so it is declared only once, where the button is {@link #register(int, MenuButton) registered}.
      */
     private SettingsButton toggleButton(
-            int slot,
             String node,
             String itemKey,
             String loreKey,
             Function<Settings, XMaterial> material,
             Predicate<Settings> enabled,
             BiConsumer<Player, Settings> flip) {
-        return new SettingsButton(
-                node,
-                ClickOutcome.TOGGLE,
-                (player, inventory) -> {
+        return SettingsButton.builder()
+                .node(node)
+                .outcome(ClickOutcome.TOGGLE)
+                .render((player, inventory, slot) -> {
                     Settings settings = settingsManager.getSettings(player);
                     plugin.getMenuItems()
                             .addToggleItem(
@@ -271,18 +301,19 @@ public class SettingsMenu extends Menu {
                                     enabled.test(settings),
                                     itemKey,
                                     loreKey);
-                },
-                (player, event) -> handleToggle(player, node, () -> {
+                })
+                .onClick((player, event) -> handleToggle(player, node, () -> {
                     flip.accept(player, settingsManager.getSettings(player));
                     return true;
-                }));
+                }))
+                .build();
     }
 
     private SettingsButton scoreboardButton() {
-        return new SettingsButton(
-                "scoreboard",
-                ClickOutcome.REJECTABLE,
-                (player, inventory) -> {
+        return SettingsButton.builder()
+                .node("scoreboard")
+                .outcome(ClickOutcome.REJECTABLE)
+                .render((player, inventory, slot) -> {
                     boolean scoreboardEnabled =
                             plugin.getConfigService().current().settings().scoreboard();
                     Settings settings = settingsManager.getSettings(player);
@@ -290,7 +321,7 @@ public class SettingsMenu extends Menu {
                             .addToggleItem(
                                     player,
                                     inventory,
-                                    30,
+                                    slot,
                                     XMaterial.PAPER,
                                     settings.isScoreboard(),
                                     scoreboardEnabled
@@ -299,15 +330,16 @@ public class SettingsMenu extends Menu {
                                     scoreboardEnabled
                                             ? "settings_scoreboard_lore"
                                             : "settings_scoreboard_disabled_lore");
-                },
-                (player, event) -> {
+                })
+                .onClick((player, event) -> {
                     boolean scoreboardEnabled =
                             plugin.getConfigService().current().settings().scoreboard();
                     handleToggle(
                             player,
                             "scoreboard",
                             () -> toggleScoreboard(player, settingsManager.getSettings(player), scoreboardEnabled));
-                });
+                })
+                .build();
     }
 
     /**
@@ -333,12 +365,11 @@ public class SettingsMenu extends Menu {
 
     @Override
     protected void populate(Player player) {
-        Inventory inv = getInventory();
-        plugin.getMenuItems().fillRange(player, inv, 0, 45);
-        buttons.forEach((slot, button) -> button.render(player, inv));
+        plugin.getMenuItems().fillRange(player, getInventory(), 0, 45);
+        renderButtons(player);
     }
 
-    private void renderDesign(Player player, Inventory inventory) {
+    private void renderDesign(Player player, Inventory inventory, int slot) {
         DesignColor color = settingsManager.getSettings(player).getDesignColor();
         XMaterial material =
                 XMaterial.matchXMaterial(color.name() + "_STAINED_GLASS").orElse(XMaterial.BLACK_STAINED_GLASS);
@@ -347,18 +378,7 @@ public class SettingsMenu extends Menu {
                 .name(messages.getString("settings_change_design_item", player))
                 .lore(messages.getStringList("settings_change_design_lore", player))
                 .glow(true)
-                .into(inventory, DESIGN_SLOT);
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        MenuButton button = buttons.get(event.getSlot());
-        if (button != null) {
-            button.onClick(player, event);
-        }
+                .into(inventory, slot);
     }
 
     /**
@@ -367,7 +387,7 @@ public class SettingsMenu extends Menu {
      */
     Map<Integer, String> permissionNodeBySlot() {
         Map<Integer, String> nodes = new LinkedHashMap<>();
-        buttons.forEach((slot, button) -> {
+        buttons().forEach((slot, button) -> {
             String node = button.node();
             if (node != null) {
                 nodes.put(slot, PERMISSION_PREFIX + node);
@@ -382,7 +402,7 @@ public class SettingsMenu extends Menu {
      */
     Map<Integer, ClickOutcome> outcomeBySlot() {
         Map<Integer, ClickOutcome> outcomes = new LinkedHashMap<>();
-        buttons.forEach((slot, button) -> outcomes.put(slot, button.outcome()));
+        buttons().forEach((slot, button) -> outcomes.put(slot, button.outcome()));
         return outcomes;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
@@ -26,7 +26,6 @@ import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import java.util.Map;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -68,6 +67,10 @@ public class SpeedMenu extends ButtonMenu<MenuButton> {
                                 .name(messages.getString(option.nameKey(), player))
                                 .build()))
                 .onClick((player, event) -> {
+                    if (!player.hasPermission("buildsystem.speed")) {
+                        player.closeInventory();
+                        return;
+                    }
                     setSpeed(player, option.speed(), option.displayNumber());
                     XSound.ENTITY_CHICKEN_EGG.play(player);
                     player.closeInventory();
@@ -90,18 +93,6 @@ public class SpeedMenu extends ButtonMenu<MenuButton> {
      */
     Map<Integer, SpeedOption> speedBySlot() {
         return SPEED_BY_SLOT;
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        Player player = (Player) event.getWhoClicked();
-        if (!player.hasPermission("buildsystem.speed")) {
-            event.setCancelled(true);
-            player.closeInventory();
-            return;
-        }
-
-        super.handleClick(event);
     }
 
     private void setSpeed(Player player, float speed, int num) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
@@ -20,17 +20,17 @@ package de.eintosti.buildsystem.player.menu;
 import com.cryptomorin.xseries.XSound;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import java.util.Map;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class SpeedMenu extends Menu {
+public class SpeedMenu extends ButtonMenu<MenuButton> {
 
     private static final String SKULL_SPEED_1 = "71bc2bcfb2bd3759e6b1e86fc7a79585e1127dd357fc202893f9de241bc9e530";
     private static final String SKULL_SPEED_2 = "4cd9eeee883468881d83848a46bf3012485c23f75753b8fbe8487341419847";
@@ -56,6 +56,23 @@ public class SpeedMenu extends Menu {
     public SpeedMenu(BuildSystemPlugin plugin, Player player) {
         super(plugin.getMessages(), 27, plugin.getMessages().getString("speed_title", player));
         this.settingsService = plugin.getSettingsService();
+
+        SPEED_BY_SLOT.forEach((slot, option) -> register(slot, speedButton(option)));
+    }
+
+    private MenuButton speedButton(SpeedOption option) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> inventory.setItem(
+                        slot,
+                        ItemBuilder.skull(Profileable.detect(option.skullTexture()))
+                                .name(messages.getString(option.nameKey(), player))
+                                .build()))
+                .onClick((player, event) -> {
+                    setSpeed(player, option.speed(), option.displayNumber());
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                    player.closeInventory();
+                })
+                .build();
     }
 
     @Override
@@ -65,7 +82,7 @@ public class SpeedMenu extends Menu {
                     .setItem(i, ItemBuilder.glassPane(player, settingsService).build());
         }
 
-        SPEED_BY_SLOT.forEach((slot, option) -> addSpeedItem(player, slot, option.skullTexture(), option.nameKey()));
+        renderButtons(player);
     }
 
     /**
@@ -75,37 +92,16 @@ public class SpeedMenu extends Menu {
         return SPEED_BY_SLOT;
     }
 
-    private void addSpeedItem(Player player, int slot, String skullTexture, String nameKey) {
-        getInventory()
-                .setItem(
-                        slot,
-                        ItemBuilder.skull(Profileable.detect(skullTexture))
-                                .name(messages.getString(nameKey, player))
-                                .build());
-    }
-
     @Override
     public void handleClick(InventoryClickEvent event) {
-        ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null) {
-            return;
-        }
-
-        event.setCancelled(true);
         Player player = (Player) event.getWhoClicked();
         if (!player.hasPermission("buildsystem.speed")) {
+            event.setCancelled(true);
             player.closeInventory();
             return;
         }
 
-        SpeedOption option = SPEED_BY_SLOT.get(event.getSlot());
-        if (option == null) {
-            return;
-        }
-        setSpeed(player, option.speed(), option.displayNumber());
-
-        XSound.ENTITY_CHICKEN_EGG.play(player);
-        player.closeInventory();
+        super.handleClick(event);
     }
 
     private void setSpeed(Player player, float speed, int num) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -249,11 +249,6 @@ public final class BuildWorldImpl implements BuildWorld {
     }
 
     @Override
-    public DisplayableType getDisplayableType() {
-        return DisplayableType.BUILD_WORLD;
-    }
-
-    @Override
     public void addToInventory(Inventory inventory, int slot, Player player) {
         if (getIcon() == XMaterial.PLAYER_HEAD) {
             plugin.getMenuItems().addWorldItem(inventory, slot, this, getDisplayName(player), getLore(player));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -249,6 +249,11 @@ public final class BuildWorldImpl implements BuildWorld {
     }
 
     @Override
+    public DisplayableType getDisplayableType() {
+        return DisplayableType.BUILD_WORLD;
+    }
+
+    @Override
     public void addToInventory(Inventory inventory, int slot, Player player) {
         if (getIcon() == XMaterial.PLAYER_HEAD) {
             plugin.getMenuItems().addWorldItem(inventory, slot, this, getDisplayName(player), getLore(player));
@@ -258,7 +263,7 @@ public final class BuildWorldImpl implements BuildWorld {
     }
 
     @Override
-    public Profileable asProfilable() {
+    public Profileable asProfileable() {
         return builders.hasCreator() ? Profileable.of(builders.getCreator().getUniqueId()) : Profileable.username(name);
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
@@ -148,6 +148,11 @@ public class FolderImpl implements Folder {
     }
 
     @Override
+    public DisplayableType getDisplayableType() {
+        return DisplayableType.FOLDER;
+    }
+
+    @Override
     public NavigatorCategory getCategory() {
         return this.category;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
@@ -148,11 +148,6 @@ public class FolderImpl implements Folder {
     }
 
     @Override
-    public DisplayableType getDisplayableType() {
-        return DisplayableType.FOLDER;
-    }
-
-    @Override
     public NavigatorCategory getCategory() {
         return this.category;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/ArchivedWorldsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/ArchivedWorldsMenu.java
@@ -33,15 +33,19 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class ArchivedWorldsMenu extends DisplayablesMenu {
 
+    private static final int SLOT_CREATE_FOLDER = 49;
+
     public ArchivedWorldsMenu(BuildSystemPlugin plugin, Player player) {
         super(
                 plugin,
                 player,
-                NavigatorCategory.ARCHIVE,
-                plugin.getMessages().getString("archive_title", player),
-                plugin.getMessages().getString("archive_no_worlds", player),
-                Visibility.IGNORE,
-                Sets.newHashSet(BuildWorldStatus.ARCHIVE));
+                Options.builder()
+                        .category(NavigatorCategory.ARCHIVE)
+                        .title(plugin.getMessages().getString("archive_title", player))
+                        .emptyMessage(plugin.getMessages().getString("archive_no_worlds", player))
+                        .requiredVisibility(Visibility.IGNORE)
+                        .validStatuses(Sets.newHashSet(BuildWorldStatus.ARCHIVE))
+                        .build());
     }
 
     @Override
@@ -49,7 +53,7 @@ public class ArchivedWorldsMenu extends DisplayablesMenu {
         if (player.hasPermission("buildsystem.create.folder")) {
             ItemBuilder.skull(Profileable.detect(CREATE_FOLDER_PROFILE))
                     .name(plugin.getMessages().getString("world_navigator_create_folder", player))
-                    .into(inventory, 49);
+                    .into(inventory, SLOT_CREATE_FOLDER);
         }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsConfirmationMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsConfirmationMenu.java
@@ -21,16 +21,19 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.backup.Backup;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.util.StringUtils;
 import java.util.Map;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class BackupsConfirmationMenu extends Menu {
+public class BackupsConfirmationMenu extends ButtonMenu<MenuButton> {
+
+    private static final int SLOT_CONFIRM = 11;
+    private static final int SLOT_CANCEL = 15;
 
     private final Backup backup;
     private final String dateFormat;
@@ -39,6 +42,36 @@ public class BackupsConfirmationMenu extends Menu {
         super(plugin.getMessages(), 27, plugin.getMessages().getString("restore_backup_title", player));
         this.backup = backup;
         this.dateFormat = plugin.getConfigService().current().settings().dateFormat();
+
+        register(
+                SLOT_CONFIRM,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.of(XMaterial.LIME_DYE)
+                                .name(messages.getString("restore_backup_confirm_name", p))
+                                .lore(messages.getStringList(
+                                        "restore_backup_confirm_lore",
+                                        p,
+                                        Map.entry(
+                                                "%timestamp%",
+                                                StringUtils.formatTime(backup.creationTime(), dateFormat))))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            p.closeInventory();
+                            XSound.ENTITY_PLAYER_LEVELUP.play(p);
+                            backup.owner().restoreBackup(backup, p);
+                        })
+                        .build());
+        register(
+                SLOT_CANCEL,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.of(XMaterial.RED_DYE)
+                                .name(messages.getString("restore_backup_cancel_name", p))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            p.closeInventory();
+                            XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(p);
+                        })
+                        .build());
     }
 
     @Override
@@ -53,33 +86,6 @@ public class BackupsConfirmationMenu extends Menu {
             ItemBuilder.of(XMaterial.RED_STAINED_GLASS_PANE).name("§c").into(getInventory(), slot);
         }
 
-        ItemBuilder.of(XMaterial.LIME_DYE)
-                .name(messages.getString("restore_backup_confirm_name", player))
-                .lore(messages.getStringList(
-                        "restore_backup_confirm_lore",
-                        player,
-                        Map.entry("%timestamp%", StringUtils.formatTime(backup.creationTime(), dateFormat))))
-                .into(getInventory(), 11);
-        ItemBuilder.of(XMaterial.RED_DYE)
-                .name(messages.getString("restore_backup_cancel_name", player))
-                .into(getInventory(), 15);
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        switch (event.getSlot()) {
-            case 11 -> {
-                player.closeInventory();
-                XSound.ENTITY_PLAYER_LEVELUP.play(player);
-                backup.owner().restoreBackup(backup, player);
-            }
-            case 15 -> {
-                player.closeInventory();
-                XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(player);
-            }
-        }
+        renderButtons(player);
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BackupsMenu.java
@@ -21,23 +21,19 @@ import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.backup.Backup;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.util.StringUtils;
 import de.eintosti.buildsystem.world.backup.BackupServiceImpl;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class BackupsMenu extends Menu {
+public class BackupsMenu extends ButtonMenu<MenuButton> {
 
     private static final int SLOT_INFO = 4;
     private static final int FIRST_BACKUP_SLOT = 9;
@@ -46,7 +42,6 @@ public class BackupsMenu extends Menu {
     private final BuildSystemPlugin plugin;
     private final BackupServiceImpl backupService;
     private final BuildWorld buildWorld;
-    private final List<Backup> backups = new ArrayList<>();
 
     public BackupsMenu(BuildSystemPlugin plugin, BuildWorld buildWorld, Player player) {
         super(plugin.getMessages(), 36, plugin.getMessages().getString("backups_title", player));
@@ -74,40 +69,51 @@ public class BackupsMenu extends Menu {
     }
 
     /**
-     * Loads the {@link Backup} for the world and adds them to the inventory on completion.
+     * Loads the {@link Backup}s for the world and, once they arrive, registers a button per backup and renders them.
+     * The backups load asynchronously, so the button registry is (re)built on the main thread in the completion
+     * callback rather than at construction.
      *
      * @param player The player to display the backups to
      */
     private void loadBackups(Player player) {
-        // Inventory and the backing list may only be touched on the main thread; the click handler reads both.
+        // The registry and inventory may only be touched on the main thread; hop back before mutating them.
         backupService
                 .getProfile(buildWorld)
                 .listBackups()
                 .thenAccept(loaded -> Bukkit.getScheduler().runTask(plugin, () -> {
-                    backups.clear();
-                    backups.addAll(loaded);
-
-                    for (int i = 0; i < loaded.size(); i++) {
-                        ItemBuilder.of(XMaterial.GRASS_BLOCK)
-                                .name(messages.getString(
-                                        "backups_backup_name",
-                                        player,
-                                        Map.entry(
-                                                "%timestamp%",
-                                                StringUtils.formatTime(
-                                                        loaded.get(i).creationTime(),
-                                                        plugin.getConfigService()
-                                                                .current()
-                                                                .settings()
-                                                                .dateFormat()))))
-                                .into(getInventory(), FIRST_BACKUP_SLOT + i);
+                    clearButtons();
+                    for (int i = 0; i < loaded.size() && i < MAX_BACKUPS; i++) {
+                        register(FIRST_BACKUP_SLOT + i, backupButton(loaded.get(i)));
                     }
+                    renderButtons(player);
                 }))
                 .exceptionally(throwable -> {
                     plugin.getLogger()
                             .log(Level.SEVERE, "Failed to list backups for world: " + buildWorld.getName(), throwable);
                     return null;
                 });
+    }
+
+    private MenuButton backupButton(Backup backup) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> ItemBuilder.of(XMaterial.GRASS_BLOCK)
+                        .name(messages.getString(
+                                "backups_backup_name",
+                                player,
+                                Map.entry(
+                                        "%timestamp%",
+                                        StringUtils.formatTime(
+                                                backup.creationTime(),
+                                                plugin.getConfigService()
+                                                        .current()
+                                                        .settings()
+                                                        .dateFormat()))))
+                        .into(inventory, slot))
+                .onClick((player, event) -> {
+                    player.closeInventory();
+                    new BackupsConfirmationMenu(plugin, backup, player).open(player);
+                })
+                .build();
     }
 
     private int getBackupIntervalSeconds() {
@@ -118,27 +124,5 @@ public class BackupsMenu extends Menu {
         int timeSinceBackup = buildWorld.getData().getTimeSinceBackup();
         int secondsRemaining = Math.max(0, getBackupIntervalSeconds() - timeSinceBackup);
         return "%02d:%02d".formatted(secondsRemaining / 60, secondsRemaining % 60);
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null || itemStack.getType() == Material.AIR || !itemStack.hasItemMeta()) {
-            return;
-        }
-
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        int slot = event.getSlot();
-        int backupIndex = slot - FIRST_BACKUP_SLOT;
-        if (slot >= FIRST_BACKUP_SLOT
-                && slot < FIRST_BACKUP_SLOT + MAX_BACKUPS
-                && backupIndex < backups.size()
-                && itemStack.getType() == XMaterial.GRASS_BLOCK.get()) {
-            Backup backup = backups.get(backupIndex);
-            player.closeInventory();
-            new BackupsConfirmationMenu(plugin, backup, player).open(player);
-        }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BuilderMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/BuilderMenu.java
@@ -23,17 +23,16 @@ import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
-import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.command.subcommand.worlds.AddBuilderSubCommand;
 import de.eintosti.buildsystem.command.subcommand.worlds.WorldsArgument;
 import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.PaginatedMenu;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -71,127 +70,109 @@ public class BuilderMenu extends PaginatedMenu {
 
     @Override
     protected void populate(Player player) {
+        clearButtons();
         Inventory inv = getInventory();
 
         plugin.getMenuItems().fillRange(player, inv, 0, 9);
         plugin.getMenuItems().fillRange(player, inv, 18, 27);
-
-        addCreatorInfoItem(inv, buildWorld.getBuilders(), player);
-        addBuilderAddItem(inv, player);
-
-        ItemBuilder.skull(Profileable.detect(SkullTextures.PREVIOUS_PAGE))
-                .name(messages.getString("gui_previous_page", player))
-                .into(inv, SLOT_PREVIOUS_PAGE);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.NEXT_PAGE))
-                .name(messages.getString("gui_next_page", player))
-                .into(inv, SLOT_NEXT_PAGE);
-
-        // Clear builder slots from previous state
         plugin.getMenuItems().fillRange(player, inv, FIRST_BUILDER_SLOT, FIRST_BUILDER_SLOT + MAX_BUILDERS_PER_PAGE);
 
+        register(SLOT_CREATOR_INFO, creatorInfoButton());
+        register(SLOT_ADD_BUILDER, addBuilderButton());
+        register(SLOT_PREVIOUS_PAGE, previousPageButton(SkullTextures.PREVIOUS_PAGE, MAX_BUILDERS_PER_PAGE));
+        register(SLOT_NEXT_PAGE, nextPageButton(SkullTextures.NEXT_PAGE, MAX_BUILDERS_PER_PAGE));
+
         List<Builder> builderList = new ArrayList<>(buildWorld.getBuilders().getAllBuilders());
-        int startIndex = page() * MAX_BUILDERS_PER_PAGE;
-        for (int i = 0; i < MAX_BUILDERS_PER_PAGE && startIndex + i < builderList.size(); i++) {
-            inv.setItem(FIRST_BUILDER_SLOT + i, createBuilderItem(builderList.get(startIndex + i), player));
-        }
+        registerPageItems(FIRST_BUILDER_SLOT, MAX_BUILDERS_PER_PAGE, builderList, this::builderButton);
+
+        renderButtons(player);
     }
 
-    private void addCreatorInfoItem(Inventory inventory, Builders builders, Player player) {
-        ItemStack creatorInfoItem;
-        Builder creator = builders.getCreator();
-
-        if (creator == null) {
-            creatorInfoItem = ItemBuilder.of(XMaterial.BARRIER)
-                    .name(messages.getString("worldeditor_builders_no_creator_item", player))
-                    .build();
-        } else {
-            creatorInfoItem = ItemBuilder.skull(Profileable.of(creator.getUniqueId()))
-                    .name(messages.getString("worldeditor_builders_creator_item", player))
-                    .lore(messages.getString(
-                            "worldeditor_builders_creator_lore", player, Map.entry("%creator%", creator.getName())))
-                    .build();
-        }
-        inventory.setItem(SLOT_CREATOR_INFO, creatorInfoItem);
+    private MenuButton creatorInfoButton() {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    Builder creator = buildWorld.getBuilders().getCreator();
+                    ItemStack item = creator == null
+                            ? ItemBuilder.of(XMaterial.BARRIER)
+                                    .name(messages.getString("worldeditor_builders_no_creator_item", player))
+                                    .build()
+                            : ItemBuilder.skull(Profileable.of(creator.getUniqueId()))
+                                    .name(messages.getString("worldeditor_builders_creator_item", player))
+                                    .lore(messages.getString(
+                                            "worldeditor_builders_creator_lore",
+                                            player,
+                                            Map.entry("%creator%", creator.getName())))
+                                    .build();
+                    inventory.setItem(slot, item);
+                })
+                .build();
     }
 
-    private void addBuilderAddItem(Inventory inventory, Player player) {
-        ItemStack builderAddItem;
-        if (buildWorld.getBuilders().isCreator(player) || player.hasPermission(BuildSystemPlugin.ADMIN_PERMISSION)) {
-            builderAddItem = ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
-                    .name(messages.getString("worldeditor_builders_add_builder_item", player))
-                    .build();
-        } else {
-            builderAddItem = ItemBuilder.of(plugin.getMenuItems().getColoredGlassPane(player))
-                    .build();
-        }
-        inventory.setItem(SLOT_ADD_BUILDER, builderAddItem);
+    private MenuButton addBuilderButton() {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    if (buildWorld.getBuilders().isCreator(player)
+                            || player.hasPermission(BuildSystemPlugin.ADMIN_PERMISSION)) {
+                        inventory.setItem(
+                                slot,
+                                ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
+                                        .name(messages.getString("worldeditor_builders_add_builder_item", player))
+                                        .build());
+                    } else {
+                        inventory.setItem(
+                                slot,
+                                ItemBuilder.of(plugin.getMenuItems().getColoredGlassPane(player))
+                                        .build());
+                    }
+                })
+                .onClick((player, event) -> {
+                    if (event.getCurrentItem() == null
+                            || event.getCurrentItem().getType() != XMaterial.PLAYER_HEAD.get()) {
+                        returnToEditor(player);
+                        return;
+                    }
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                    new AddBuilderSubCommand(plugin).getAddBuilderInput(player, buildWorld, false);
+                })
+                .build();
     }
 
-    private ItemStack createBuilderItem(Builder builder, Player player) {
-        return ItemBuilder.skull(Profileable.username(builder.getName()))
-                .name(messages.getString(
-                        "worldeditor_builders_builder_item", player, Map.entry("%builder%", builder.getName())))
-                .lore(messages.getStringList("worldeditor_builders_builder_lore", player))
-                .pdc(this.builderNameKey, PersistentDataType.STRING, builder.getName())
+    private MenuButton builderButton(Builder builder) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> inventory.setItem(
+                        slot,
+                        ItemBuilder.skull(Profileable.username(builder.getName()))
+                                .name(messages.getString(
+                                        "worldeditor_builders_builder_item",
+                                        player,
+                                        Map.entry("%builder%", builder.getName())))
+                                .lore(messages.getStringList("worldeditor_builders_builder_lore", player))
+                                .pdc(this.builderNameKey, PersistentDataType.STRING, builder.getName())
+                                .build()))
+                .onClick((player, event) -> {
+                    // Only a shift-click removes a builder; a plain click returns to the editor.
+                    if (!event.isShiftClick()) {
+                        returnToEditor(player);
+                        return;
+                    }
+                    removeBuilder(player, builder.getName());
+                })
                 .build();
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
-        ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null || itemStack.getType() == Material.AIR || !itemStack.hasItemMeta()) {
-            return;
-        }
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        returnToEditor(player);
+    }
 
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        if (itemStack.getType() != XMaterial.PLAYER_HEAD.get()) {
-            if (buildWorld.getPermissions().canPerformCommand(player, WorldsArgument.EDIT.getPermission())) {
-                XSound.BLOCK_CHEST_OPEN.play(player);
-                new EditMenu(plugin, buildWorld, player).open(player);
-            }
-            return;
-        }
-
-        int slot = event.getSlot();
-        switch (slot) {
-            case SLOT_PREVIOUS_PAGE:
-                if (!previousPage(player, MAX_BUILDERS_PER_PAGE)) {
-                    return;
-                }
-                populate(player);
-                return;
-            case SLOT_ADD_BUILDER:
-                XSound.ENTITY_CHICKEN_EGG.play(player);
-                new AddBuilderSubCommand(plugin).getAddBuilderInput(player, buildWorld, false);
-                return;
-            case SLOT_NEXT_PAGE:
-                if (!nextPage(player, MAX_BUILDERS_PER_PAGE)) {
-                    return;
-                }
-                populate(player);
-                return;
-            default:
-                if (slot == SLOT_CREATOR_INFO || !event.isShiftClick()) {
-                    return;
-                }
-                removeBuilderByItem(player, itemStack);
+    private void returnToEditor(Player player) {
+        if (buildWorld.getPermissions().canPerformCommand(player, WorldsArgument.EDIT.getPermission())) {
+            XSound.BLOCK_CHEST_OPEN.play(player);
+            new EditMenu(plugin, buildWorld, player).open(player);
         }
     }
 
-    private void removeBuilderByItem(Player player, ItemStack itemStack) {
-        String builderName = itemStack
-                .getItemMeta()
-                .getPersistentDataContainer()
-                .get(this.builderNameKey, PersistentDataType.STRING);
-        if (builderName == null) {
-            player.closeInventory();
-            messages.sendMessage(player, "worlds_removebuilder_error");
-            plugin.getLogger().warning("Could not find UUID for null builder name");
-            return;
-        }
-
+    private void removeBuilder(Player player, String builderName) {
         plugin.getPlayerLookupService()
                 .lookupUniqueId(builderName)
                 .thenAccept(builderId -> Bukkit.getScheduler().runTask(plugin, () -> {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreatableWorldsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreatableWorldsMenu.java
@@ -53,7 +53,16 @@ public abstract class CreatableWorldsMenu extends DisplayablesMenu {
             String inventoryTitle,
             @Nullable String noWorldsMessage,
             Visibility requiredVisibility) {
-        super(plugin, player, category, inventoryTitle, noWorldsMessage, requiredVisibility, VALID_STATUSES);
+        super(
+                plugin,
+                player,
+                Options.builder()
+                        .category(category)
+                        .title(inventoryTitle)
+                        .emptyMessage(noWorldsMessage)
+                        .requiredVisibility(requiredVisibility)
+                        .validStatuses(VALID_STATUSES)
+                        .build());
         this.playerService = plugin.getPlayerService();
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.world.menu;
 
-import com.cryptomorin.xseries.XEnchantment;
 import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
@@ -26,18 +25,17 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.PaginatedMenu;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.util.FileUtils;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import java.io.File;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -54,6 +52,27 @@ public class CreateMenu extends PaginatedMenu {
     private static final int SLOT_TEMPLATE_NEXT_PAGE = 34;
     private static final int FIRST_TEMPLATE_SLOT = 29;
 
+    private static final String PREDEFINED_TAB_PROFILE =
+            "2cdc0feb7001e2c10fd5066e501b87e3d64793092b85a50c856d962f8be92c78";
+    private static final String GENERATOR_TAB_PROFILE =
+            "b2f79016cad84d1ae21609c4813782598e387961be13c15682752f126dce7a";
+    private static final String TEMPLATE_TAB_PROFILE =
+            "d17b8b43f8c4b5cfeb919c9f8fe93f26ceb6d2b133c2ab1eb339bd6621fd309c";
+
+    private static final Map<Integer, BuildWorldType> PREDEFINED_SLOTS = Map.of(
+            29, BuildWorldType.NORMAL,
+            30, BuildWorldType.FLAT,
+            31, BuildWorldType.NETHER,
+            32, BuildWorldType.END,
+            33, BuildWorldType.VOID);
+
+    private static final Map<BuildWorldType, String> PREDEFINED_MESSAGE_KEYS = Map.of(
+            BuildWorldType.NORMAL, "create_normal_world",
+            BuildWorldType.FLAT, "create_flat_world",
+            BuildWorldType.NETHER, "create_nether_world",
+            BuildWorldType.END, "create_end_world",
+            BuildWorldType.VOID, "create_void_world");
+
     private final BuildSystemPlugin plugin;
     private final WorldServiceImpl worldService;
     private final Page currentPage;
@@ -64,10 +83,6 @@ public class CreateMenu extends PaginatedMenu {
     private int numTemplates = 0;
 
     private File @Nullable [] templateFiles;
-
-    // Maps the slot a template item occupies on the current page to its raw directory name, so click handling can
-    // resolve the unformatted template name for permission checks without parsing the display string.
-    private final Map<Integer, String> templateSlots = new HashMap<>();
 
     public CreateMenu(
             BuildSystemPlugin plugin, Page initialPage, Visibility visibility, @Nullable Folder folder, Player player) {
@@ -86,69 +101,63 @@ public class CreateMenu extends PaginatedMenu {
 
     @Override
     protected void populate(Player player) {
+        clearButtons();
         plugin.getMenuItems().fillRange(player, getInventory(), 0, 29);
         plugin.getMenuItems().fillRange(player, getInventory(), 34, 45);
 
-        addPageItem(
-                Page.PREDEFINED,
-                ItemBuilder.skull(
-                                Profileable.detect("2cdc0feb7001e2c10fd5066e501b87e3d64793092b85a50c856d962f8be92c78"))
-                        .name(messages.getString("create_predefined_worlds", player))
-                        .build());
-        addPageItem(
-                Page.GENERATOR,
-                ItemBuilder.skull(Profileable.detect("b2f79016cad84d1ae21609c4813782598e387961be13c15682752f126dce7a"))
-                        .name(messages.getString("create_generators", player))
-                        .build());
-        addPageItem(
-                Page.TEMPLATES,
-                ItemBuilder.skull(
-                                Profileable.detect("d17b8b43f8c4b5cfeb919c9f8fe93f26ceb6d2b133c2ab1eb339bd6621fd309c"))
-                        .name(messages.getString("create_templates", player))
-                        .build());
+        registerTab(Page.PREDEFINED, PREDEFINED_TAB_PROFILE, "create_predefined_worlds");
+        registerTab(Page.GENERATOR, GENERATOR_TAB_PROFILE, "create_generators");
+        registerTab(Page.TEMPLATES, TEMPLATE_TAB_PROFILE, "create_templates");
 
         switch (currentPage) {
-            case PREDEFINED -> populatePredefined(player);
-            case GENERATOR -> populateGenerator(player);
-            case TEMPLATES -> populateTemplates(player);
-        }
-    }
-
-    private void addPageItem(Page page, ItemStack itemStack) {
-        if (currentPage == page) {
-            itemStack.addUnsafeEnchantment(XEnchantment.UNBREAKING.get(), 1);
-        }
-        getInventory().setItem(page.getSlot(), itemStack);
-    }
-
-    private static final Map<Integer, BuildWorldType> PREDEFINED_SLOTS = Map.of(
-            29, BuildWorldType.NORMAL,
-            30, BuildWorldType.FLAT,
-            31, BuildWorldType.NETHER,
-            32, BuildWorldType.END,
-            33, BuildWorldType.VOID);
-
-    private static final Map<BuildWorldType, String> PREDEFINED_MESSAGE_KEYS = Map.of(
-            BuildWorldType.NORMAL, "create_normal_world",
-            BuildWorldType.FLAT, "create_flat_world",
-            BuildWorldType.NETHER, "create_nether_world",
-            BuildWorldType.END, "create_end_world",
-            BuildWorldType.VOID, "create_void_world");
-
-    private void populatePredefined(Player player) {
-        PREDEFINED_SLOTS.forEach((slot, worldType) -> addPredefinedWorldItem(
-                player, slot, worldType, messages.getString(PREDEFINED_MESSAGE_KEYS.get(worldType), player)));
-    }
-
-    private void addPredefinedWorldItem(Player player, int position, BuildWorldType worldType, String displayName) {
-        XMaterial material = plugin.getCustomizableIcons().getIcon(worldType);
-
-        if (!canCreateType(player, worldType)) {
-            material = XMaterial.BARRIER;
-            displayName = "§c§m" + ChatColor.stripColor(displayName);
+            case PREDEFINED -> registerPredefined();
+            case GENERATOR -> registerGenerator(player);
+            case TEMPLATES -> registerTemplates(player);
         }
 
-        ItemBuilder.of(material).name(displayName).into(getInventory(), position);
+        renderButtons(player);
+    }
+
+    private void registerTab(Page page, String skullTexture, String nameKey) {
+        register(
+                page.getSlot(),
+                MenuButton.builder()
+                        .render((player, inventory, slot) -> ItemBuilder.skull(Profileable.detect(skullTexture))
+                                .name(messages.getString(nameKey, player))
+                                .glow(currentPage == page)
+                                .into(inventory, slot))
+                        .onClick((player, event) -> {
+                            Visibility visibility = createPrivateWorld ? Visibility.PRIVATE : Visibility.PUBLIC;
+                            new CreateMenu(plugin, page, visibility, folder, player).open(player);
+                            XSound.ENTITY_CHICKEN_EGG.play(player);
+                        })
+                        .build());
+    }
+
+    private void registerPredefined() {
+        PREDEFINED_SLOTS.forEach((slot, worldType) -> register(slot, predefinedButton(worldType)));
+    }
+
+    private MenuButton predefinedButton(BuildWorldType worldType) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    XMaterial material = plugin.getCustomizableIcons().getIcon(worldType);
+                    String displayName = messages.getString(PREDEFINED_MESSAGE_KEYS.get(worldType), player);
+                    if (!canCreateType(player, worldType)) {
+                        material = XMaterial.BARRIER;
+                        displayName = "§c§m" + ChatColor.stripColor(displayName);
+                    }
+                    ItemBuilder.of(material).name(displayName).into(inventory, slot);
+                })
+                .onClick((player, event) -> {
+                    if (!canCreateType(player, worldType)) {
+                        XSound.ENTITY_ITEM_BREAK.play(player);
+                        return;
+                    }
+                    worldService.startWorldNameInput(player, worldType, null, createPrivateWorld, folder);
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                })
+                .build();
     }
 
     private static boolean canCreateType(Player player, BuildWorldType worldType) {
@@ -156,33 +165,36 @@ public class CreateMenu extends PaginatedMenu {
                 "buildsystem.create.type." + worldType.name().toLowerCase(Locale.ROOT));
     }
 
-    private void populateGenerator(Player player) {
+    private void registerGenerator(Player player) {
         for (int slot = FIRST_PREDEFINED_SLOT; slot <= LAST_PREDEFINED_SLOT; slot++) {
             if (slot != SLOT_GENERATOR_CREATE) {
                 plugin.getMenuItems().addGlassPane(player, getInventory(), slot);
             }
         }
-        ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
-                .name(messages.getString("create_generators_create_world", player))
-                .into(getInventory(), SLOT_GENERATOR_CREATE);
+        register(
+                SLOT_GENERATOR_CREATE,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
+                                .name(messages.getString("create_generators_create_world", p))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            worldService.startWorldNameInput(
+                                    p, BuildWorldType.CUSTOM, null, createPrivateWorld, folder);
+                            XSound.ENTITY_CHICKEN_EGG.play(p);
+                        })
+                        .build());
     }
 
-    private void populateTemplates(Player player) {
-        ItemBuilder.skull(Profileable.detect(SkullTextures.PREVIOUS_PAGE))
-                .name(messages.getString("gui_previous_page", player))
-                .into(getInventory(), SLOT_TEMPLATE_PREVIOUS_PAGE);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.NEXT_PAGE))
-                .name(messages.getString("gui_next_page", player))
-                .into(getInventory(), SLOT_TEMPLATE_NEXT_PAGE);
+    private void registerTemplates(Player player) {
+        register(SLOT_TEMPLATE_PREVIOUS_PAGE, previousPageButton(SkullTextures.PREVIOUS_PAGE, MAX_TEMPLATES));
+        register(SLOT_TEMPLATE_NEXT_PAGE, nextPageButton(SkullTextures.NEXT_PAGE, MAX_TEMPLATES));
 
-        // Listed once per menu instance so page flips do not repeat directory I/O on the main thread
+        // Listed once per menu instance so page flips do not repeat directory I/O on the main thread.
         if (this.templateFiles == null) {
             this.templateFiles = FileUtils.resolve(plugin.getDataFolder(), "templates")
                     .toFile()
-                    .listFiles((file) -> file.isDirectory() && !file.isHidden());
+                    .listFiles(file -> file.isDirectory() && !file.isHidden());
         }
-        File[] templateFiles = this.templateFiles;
-
         this.numTemplates = templateFiles != null ? templateFiles.length : 0;
 
         plugin.getMenuItems().fillRange(player, getInventory(), FIRST_TEMPLATE_SLOT, SLOT_TEMPLATE_NEXT_PAGE);
@@ -197,103 +209,37 @@ public class CreateMenu extends PaginatedMenu {
             return;
         }
 
-        if (templateFiles == null) {
-            return;
-        }
-
-        this.templateSlots.clear();
-        int startIndex = page() * MAX_TEMPLATES;
-        for (int i = 0; i < MAX_TEMPLATES && startIndex + i < templateFiles.length; i++) {
-            String rawTemplateName = templateFiles[startIndex + i].getName();
-            int slot = FIRST_TEMPLATE_SLOT + i;
-            this.templateSlots.put(slot, rawTemplateName);
-            ItemBuilder.of(XMaterial.FILLED_MAP)
-                    .name(messages.getString("create_template", player, Map.entry("%template%", rawTemplateName)))
-                    .into(getInventory(), slot);
-        }
+        registerPageItems(
+                FIRST_TEMPLATE_SLOT, MAX_TEMPLATES, Arrays.asList(templateFiles), f -> templateButton(f.getName()));
     }
 
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        int slot = event.getSlot();
-        Page newPage = Page.of(slot);
-        if (newPage != null) {
-            Visibility vis = createPrivateWorld ? Visibility.PRIVATE : Visibility.PUBLIC;
-            new CreateMenu(plugin, newPage, vis, folder, player).open(player);
-            XSound.ENTITY_CHICKEN_EGG.play(player);
-            return;
-        }
-
-        switch (currentPage) {
-            case PREDEFINED: {
-                BuildWorldType worldType = PREDEFINED_SLOTS.get(slot);
-                if (worldType == null || !canCreateType(player, worldType)) {
-                    XSound.ENTITY_ITEM_BREAK.play(player);
-                    return;
-                }
-
-                worldService.startWorldNameInput(player, worldType, null, this.createPrivateWorld, this.folder);
-                XSound.ENTITY_CHICKEN_EGG.play(player);
-                break;
-            }
-
-            case GENERATOR: {
-                if (slot == SLOT_GENERATOR_CREATE) {
-                    worldService.startWorldNameInput(
-                            player, BuildWorldType.CUSTOM, null, this.createPrivateWorld, this.folder);
-                    XSound.ENTITY_CHICKEN_EGG.play(player);
-                }
-                break;
-            }
-
-            case TEMPLATES: {
-                ItemStack itemStack = event.getCurrentItem();
-                if (itemStack == null) {
-                    return;
-                }
-
-                XMaterial xMaterial = XMaterial.matchXMaterial(itemStack);
-                switch (xMaterial) {
-                    case FILLED_MAP: {
-                        // Template names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is
-                        // emulated: a template is permitted unless an admin has explicitly denied its specific node.
-                        String rawTemplateName = this.templateSlots.get(slot);
-                        String templateNode = "buildsystem.create.template." + rawTemplateName;
-                        boolean allowed = rawTemplateName != null
-                                && (!player.isPermissionSet(templateNode) || player.hasPermission(templateNode));
-                        if (!allowed) {
-                            XSound.ENTITY_ITEM_BREAK.play(player);
-                            return;
-                        }
-                        this.worldService.startWorldNameInput(
-                                player,
-                                BuildWorldType.TEMPLATE,
-                                itemStack.getItemMeta().getDisplayName(),
-                                this.createPrivateWorld,
-                                this.folder);
-                        break;
-                    }
-                    case PLAYER_HEAD:
-                        if (slot == SLOT_TEMPLATE_PREVIOUS_PAGE) {
-                            if (!previousPage(player, MAX_TEMPLATES)) {
-                                return;
-                            }
-                        } else if (slot == SLOT_TEMPLATE_NEXT_PAGE) {
-                            if (!nextPage(player, MAX_TEMPLATES)) {
-                                return;
-                            }
-                        }
-                        populateTemplates(player);
-                        break;
-                    default:
+    private MenuButton templateButton(String rawTemplateName) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> ItemBuilder.of(XMaterial.FILLED_MAP)
+                        .name(messages.getString("create_template", player, Map.entry("%template%", rawTemplateName)))
+                        .into(inventory, slot))
+                .onClick((player, event) -> {
+                    // Template names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is
+                    // emulated: a template is permitted unless an admin has explicitly denied its specific node.
+                    String templateNode = "buildsystem.create.template." + rawTemplateName;
+                    if (player.isPermissionSet(templateNode) && !player.hasPermission(templateNode)) {
+                        XSound.ENTITY_ITEM_BREAK.play(player);
                         return;
-                }
-                break;
-            }
-        }
+                    }
+
+                    ItemStack itemStack = event.getCurrentItem();
+                    if (itemStack == null || itemStack.getItemMeta() == null) {
+                        return;
+                    }
+
+                    worldService.startWorldNameInput(
+                            player,
+                            BuildWorldType.TEMPLATE,
+                            itemStack.getItemMeta().getDisplayName(),
+                            createPrivateWorld,
+                            folder);
+                })
+                .build();
     }
 
     public enum Page {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DeleteMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DeleteMenu.java
@@ -21,24 +21,51 @@ import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class DeleteMenu extends Menu {
+public class DeleteMenu extends ButtonMenu<MenuButton> {
 
-    private final BuildSystemPlugin plugin;
+    private static final int SLOT_CONFIRM = 11;
+    private static final int SLOT_CANCEL = 15;
+
     private final BuildWorld buildWorld;
 
     public DeleteMenu(BuildSystemPlugin plugin, BuildWorld buildWorld, Player player) {
         super(plugin.getMessages(), 27, plugin.getMessages().getString("delete_title", player));
-        this.plugin = plugin;
         this.buildWorld = buildWorld;
+
+        register(
+                SLOT_CONFIRM,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.of(XMaterial.LIME_DYE)
+                                .name(messages.getString("delete_world_confirm", p))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            XSound.ENTITY_PLAYER_LEVELUP.play(p);
+                            p.closeInventory();
+                            plugin.getWorldService().deleteWorld(p, buildWorld);
+                        })
+                        .build());
+        register(
+                SLOT_CANCEL,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.of(XMaterial.RED_DYE)
+                                .name(messages.getString("delete_world_cancel", p))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(p);
+                            p.closeInventory();
+                            messages.sendMessage(
+                                    p, "worlds_delete_canceled", Map.entry("%world%", buildWorld.getName()));
+                        })
+                        .build());
     }
 
     @Override
@@ -60,34 +87,11 @@ public class DeleteMenu extends Menu {
                         .name("§f")
                         .into(getInventory(), slot));
 
-        ItemBuilder.of(XMaterial.LIME_DYE)
-                .name(messages.getString("delete_world_confirm", player))
-                .into(getInventory(), 11);
         ItemBuilder.of(XMaterial.FILLED_MAP)
                 .name(messages.getString("delete_world_name", player, Map.entry("%world%", buildWorld.getName())))
                 .lore(messages.getStringList("delete_world_name_lore", player))
                 .into(getInventory(), 13);
-        ItemBuilder.of(XMaterial.RED_DYE)
-                .name(messages.getString("delete_world_cancel", player))
-                .into(getInventory(), 15);
-    }
 
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        switch (event.getSlot()) {
-            case 11 -> {
-                XSound.ENTITY_PLAYER_LEVELUP.play(player);
-                player.closeInventory();
-                plugin.getWorldService().deleteWorld(player, buildWorld);
-            }
-            case 15 -> {
-                XSound.ENTITY_ZOMBIE_BREAK_WOODEN_DOOR.play(player);
-                player.closeInventory();
-                messages.sendMessage(player, "worlds_delete_canceled", Map.entry("%world%", buildWorld.getName()));
-            }
-        }
+        renderButtons(player);
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
@@ -28,10 +28,10 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.display.*;
-import de.eintosti.buildsystem.api.world.display.Displayable.DisplayableType;
 import de.eintosti.buildsystem.api.world.display.WorldFilter.Mode;
 import de.eintosti.buildsystem.command.subcommand.worlds.WorldsArgument;
 import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.PaginatedMenu;
 import de.eintosti.buildsystem.menu.PlayerChatInput;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
@@ -47,9 +47,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -194,16 +191,13 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
         this.cachedDisplayables = collectDisplayables();
         Inventory inv = getInventory();
 
+        clearButtons();
         plugin.getMenuItems().fillWithGlass(inv, player);
         addWorldSortItem(inv);
         addWorldFilterItem(inv);
         addExtraItems(inv, player);
-        ItemBuilder.skull(Profileable.detect(PREVIOUS_PAGE_SKULL_PROFILE))
-                .name(plugin.getMessages().getString("gui_previous_page", player))
-                .into(inv, SLOT_PREVIOUS_PAGE);
-        ItemBuilder.skull(Profileable.detect(NEXT_PAGE_SKULL_PROFILE))
-                .name(plugin.getMessages().getString("gui_next_page", player))
-                .into(inv, SLOT_NEXT_PAGE);
+        register(SLOT_PREVIOUS_PAGE, previousPageButton(PREVIOUS_PAGE_SKULL_PROFILE, MAX_WORLDS_PER_PAGE));
+        register(SLOT_NEXT_PAGE, nextPageButton(NEXT_PAGE_SKULL_PROFILE, MAX_WORLDS_PER_PAGE));
 
         for (int i = FIRST_WORD_SLOT; i <= LAST_WORLD_SLOT; i++) {
             inv.setItem(i, null);
@@ -213,18 +207,25 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
             ItemBuilder.skull(Profileable.detect(NO_WORLDS_SKULL_PROFILE))
                     .name(noWorldsMessage)
                     .into(inv, SLOT_NO_WORLDS);
-            return;
+        } else {
+            registerPageItems(FIRST_WORD_SLOT, MAX_WORLDS_PER_PAGE, cachedDisplayables, this::displayableButton);
         }
 
-        int startIndex = page() * MAX_WORLDS_PER_PAGE;
-        int endIndex = Math.min(startIndex + MAX_WORLDS_PER_PAGE, cachedDisplayables.size());
-        int currentSlot = FIRST_WORD_SLOT;
-        for (int i = startIndex; i < endIndex; i++) {
-            if (currentSlot > LAST_WORLD_SLOT) {
-                break;
-            }
-            cachedDisplayables.get(i).addToInventory(inv, currentSlot++, player);
-        }
+        renderButtons(player);
+    }
+
+    private MenuButton displayableButton(Displayable displayable) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> displayable.addToInventory(inventory, slot, player))
+                .onClick((player, event) -> {
+                    if (displayable instanceof BuildWorld buildWorld) {
+                        manageWorldItemClick(event, buildWorld);
+                    } else if (displayable instanceof Folder folder) {
+                        new FolderContentMenu(plugin, player, category, folder, this, requiredVisibility, validStatuses)
+                                .open(player);
+                    }
+                })
+                .build();
     }
 
     protected void addExtraItems(Inventory inventory, Player player) {}
@@ -325,18 +326,21 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        // Page arrows are registered buttons; everything else is handled here. Ignore clicks outside this inventory.
+        int slot = event.getRawSlot();
+        if (slot < 0 || slot >= getInventory().getSize()) {
+            return;
+        }
         ItemStack itemStack = event.getCurrentItem();
         if (itemStack == null) {
             return;
         }
 
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
         Settings settings = settingsManager.getSettings(player);
         WorldDisplay worldDisplay = settings.getWorldDisplay();
 
-        switch (event.getSlot()) {
+        switch (slot) {
             case SLOT_WORLD_SORT -> {
                 WorldSort currentSort = worldDisplay.getWorldSort();
                 worldDisplay.setWorldSort(event.isLeftClick() ? currentSort.getNext() : currentSort.getPrevious());
@@ -361,20 +365,8 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
                 goBack(player, itemStack);
             }
             case SLOT_BACK -> goBack(player, itemStack);
-            case SLOT_PREVIOUS_PAGE -> {
-                if (previousPage(player, MAX_WORLDS_PER_PAGE)) {
-                    populate(player);
-                }
-            }
-            case SLOT_NEXT_PAGE -> {
-                if (nextPage(player, MAX_WORLDS_PER_PAGE)) {
-                    populate(player);
-                }
-            }
             default -> {
-                if (event.getSlot() >= FIRST_WORD_SLOT && event.getSlot() <= LAST_WORLD_SLOT) {
-                    handleDisplayableItemClick(event, itemStack);
-                } else if (event.getSlot() >= FIRST_BOTTOM_BAR_SLOT && event.getSlot() <= LAST_BOTTOM_BAR_SLOT) {
+                if (slot >= FIRST_BOTTOM_BAR_SLOT && slot <= LAST_BOTTOM_BAR_SLOT) {
                     goBack(player, itemStack);
                 }
             }
@@ -442,41 +434,6 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
 
         resetPage();
         open(player);
-    }
-
-    private void handleDisplayableItemClick(InventoryClickEvent event, ItemStack clickedItem) {
-        ItemMeta itemMeta = clickedItem.getItemMeta();
-        if (itemMeta == null || !itemMeta.hasDisplayName()) {
-            return;
-        }
-
-        PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
-        String displayableType = pdc.get(plugin.getMenuItems().displayableTypeKey, PersistentDataType.STRING);
-        String displayableName = pdc.get(plugin.getMenuItems().displayableNameKey, PersistentDataType.STRING);
-        if (displayableType == null || displayableName == null) {
-            return;
-        }
-
-        Player player = (Player) event.getWhoClicked();
-        switch (DisplayableType.valueOf(displayableType)) {
-            case BUILD_WORLD -> {
-                BuildWorld buildWorld = worldStorage.getBuildWorld(displayableName);
-                if (buildWorld == null) {
-                    plugin.getLogger().warning("Unable to find world with name: " + displayableName);
-                    return;
-                }
-                manageWorldItemClick(event, buildWorld);
-            }
-            case FOLDER -> {
-                Folder folder = folderStorage.getFolder(displayableName);
-                if (folder == null) {
-                    plugin.getLogger().warning("Unable to find folder with name: " + displayableName);
-                    return;
-                }
-                new FolderContentMenu(plugin, player, category, folder, this, requiredVisibility, validStatuses)
-                        .open(player);
-            }
-        }
     }
 
     private void manageWorldItemClick(InventoryClickEvent event, BuildWorld buildWorld) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
@@ -94,15 +94,8 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
     private final @Nullable String noWorldsMessage;
     private @Nullable List<Displayable> cachedDisplayables;
 
-    protected DisplayablesMenu(
-            BuildSystemPlugin plugin,
-            Player player,
-            NavigatorCategory category,
-            String inventoryTitle,
-            @Nullable String noWorldsMessage,
-            Visibility requiredVisibility,
-            Set<BuildWorldStatus> validStatuses) {
-        super(plugin.getMessages(), 54, inventoryTitle);
+    protected DisplayablesMenu(BuildSystemPlugin plugin, Player player, Options options) {
+        super(plugin.getMessages(), 54, options.title());
         this.plugin = plugin;
         this.playerService = plugin.getPlayerService();
         this.settingsManager = plugin.getSettingsService();
@@ -110,10 +103,85 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
         this.folderStorage = worldService.getFolderStorage();
         this.worldStorage = worldService.getWorldStorage();
         this.player = player;
-        this.category = category;
-        this.noWorldsMessage = noWorldsMessage;
-        this.requiredVisibility = requiredVisibility;
-        this.validStatuses = validStatuses;
+        this.category = options.category();
+        this.noWorldsMessage = options.emptyMessage();
+        this.requiredVisibility = options.requiredVisibility();
+        this.validStatuses = options.validStatuses();
+    }
+
+    /**
+     * The configuration of a {@link DisplayablesMenu}: which {@link NavigatorCategory category} it lists, its title and
+     * "no worlds" message, the {@link Visibility} it requires, and the {@link BuildWorldStatus statuses} it shows.
+     * Bundled into one named-field object so subclasses no longer pass a long positional argument list to {@code super}.
+     *
+     * @param category The navigator category whose folders/worlds are listed
+     * @param title The inventory title
+     * @param emptyMessage The message shown when nothing matches, or {@code null} to show nothing
+     * @param requiredVisibility The visibility a world must have to be listed
+     * @param validStatuses The statuses a world must have to be listed
+     */
+    public record Options(
+            NavigatorCategory category,
+            String title,
+            @Nullable String emptyMessage,
+            Visibility requiredVisibility,
+            Set<BuildWorldStatus> validStatuses) {
+
+        /**
+         * {@return a new {@link Builder}}
+         */
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Fluent builder for {@link Options}. {@code requiredVisibility} defaults to {@link Visibility#IGNORE} and
+         * {@code validStatuses} to all statuses; {@code category} and {@code title} are required.
+         */
+        public static final class Builder {
+
+            private @Nullable NavigatorCategory category;
+            private @Nullable String title;
+            private @Nullable String emptyMessage;
+            private Visibility requiredVisibility = Visibility.IGNORE;
+            private Set<BuildWorldStatus> validStatuses = EnumSet.allOf(BuildWorldStatus.class);
+
+            private Builder() {}
+
+            public Builder category(NavigatorCategory category) {
+                this.category = category;
+                return this;
+            }
+
+            public Builder title(String title) {
+                this.title = title;
+                return this;
+            }
+
+            public Builder emptyMessage(@Nullable String emptyMessage) {
+                this.emptyMessage = emptyMessage;
+                return this;
+            }
+
+            public Builder requiredVisibility(Visibility requiredVisibility) {
+                this.requiredVisibility = requiredVisibility;
+                return this;
+            }
+
+            public Builder validStatuses(Set<BuildWorldStatus> validStatuses) {
+                this.validStatuses = validStatuses;
+                return this;
+            }
+
+            public Options build() {
+                return new Options(
+                        Objects.requireNonNull(category, "category"),
+                        Objects.requireNonNull(title, "title"),
+                        emptyMessage,
+                        requiredVisibility,
+                        validStatuses);
+            }
+        }
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -31,8 +31,8 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.command.subcommand.worlds.SetPermissionSubCommand;
 import de.eintosti.buildsystem.command.subcommand.worlds.SetProjectSubCommand;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
 import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
 import java.util.*;
@@ -48,7 +48,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
-public class EditMenu extends Menu {
+public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
 
     private static final int SLOT_WORLD_INFO = 3;
     private static final int SLOT_PIN = 5;
@@ -193,7 +193,7 @@ public class EditMenu extends Menu {
      * classification, and the render/click behavior. Declaring each slot once here replaces the old parallel
      * {@code populate} calls and {@code handleClick} switch.
      */
-    private record EditButton(
+    record EditButton(
             @Nullable String permission,
             ClickOutcome outcome,
             BiConsumer<Player, Inventory> renderer,
@@ -201,7 +201,7 @@ public class EditMenu extends Menu {
             implements MenuButton {
 
         @Override
-        public void render(Player player, Inventory inventory) {
+        public void render(Player player, Inventory inventory, int slot) {
             renderer.accept(player, inventory);
         }
 
@@ -209,128 +209,204 @@ public class EditMenu extends Menu {
         public void onClick(Player player, InventoryClickEvent event) {
             clickHandler.accept(player, event);
         }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Fluent builder for an {@link EditButton}. {@code outcome} defaults to {@link ClickOutcome#NONE}; the
+         * {@code permission}, renderer, and click handler default to none/no-op until set. Editor slots render at fixed
+         * positions, so the renderer is a plain {@code (player, inventory)} consumer rather than a slot-aware one.
+         */
+        static final class Builder {
+
+            private @Nullable String permission;
+            private ClickOutcome outcome = ClickOutcome.NONE;
+            private BiConsumer<Player, Inventory> renderer = (player, inventory) -> {};
+            private BiConsumer<Player, InventoryClickEvent> clickHandler = (player, event) -> {};
+
+            private Builder() {}
+
+            Builder permission(@Nullable String permission) {
+                this.permission = permission;
+                return this;
+            }
+
+            Builder outcome(ClickOutcome outcome) {
+                this.outcome = outcome;
+                return this;
+            }
+
+            Builder render(BiConsumer<Player, Inventory> renderer) {
+                this.renderer = renderer;
+                return this;
+            }
+
+            Builder onClick(BiConsumer<Player, InventoryClickEvent> clickHandler) {
+                this.clickHandler = clickHandler;
+                return this;
+            }
+
+            EditButton build() {
+                return new EditButton(permission, outcome, renderer, clickHandler);
+            }
+        }
     }
 
     private final BuildSystemPlugin plugin;
     private final PlayerServiceImpl playerManager;
     private final BuildWorld buildWorld;
-    private final Map<Integer, EditButton> buttons;
 
     public EditMenu(BuildSystemPlugin plugin, BuildWorld buildWorld, Player player) {
         super(plugin.getMessages(), 54, plugin.getMessages().getString("worldeditor_title", player));
         this.plugin = plugin;
         this.playerManager = plugin.getPlayerService();
         this.buildWorld = buildWorld;
-        this.buttons = buildButtons();
+        buildButtons();
     }
 
-    private Map<Integer, EditButton> buildButtons() {
-        Map<Integer, EditButton> map = new LinkedHashMap<>();
+    private void buildButtons() {
+        register(
+                SLOT_WORLD_INFO,
+                EditButton.builder().render(this::renderWorldInfo).build());
 
-        map.put(SLOT_WORLD_INFO, new EditButton(null, ClickOutcome.NONE, this::renderWorldInfo, (player, event) -> {}));
-
-        TOGGLES.forEach((slot, toggle) -> map.put(
+        TOGGLES.forEach((slot, toggle) -> register(
                 slot,
-                new EditButton(
-                        toggle.permission(),
-                        ClickOutcome.REOPEN,
-                        (player, inventory) -> renderToggle(player, inventory, slot, toggle),
-                        (player, event) -> {
+                EditButton.builder()
+                        .permission(toggle.permission())
+                        .outcome(ClickOutcome.REOPEN)
+                        .render((player, inventory) -> renderToggle(player, inventory, slot, toggle))
+                        .onClick((player, event) -> {
                             if (requirePermission(player, toggle.permission())) {
                                 WorldData worldData = buildWorld.getData();
                                 toggle.setter()
                                         .accept(worldData, !toggle.getter().test(worldData));
                                 reopen(player);
                             }
-                        })));
+                        })
+                        .build()));
 
-        map.put(
+        register(
                 SLOT_TIME,
-                new EditButton("buildsystem.edit.time", ClickOutcome.REOPEN, this::renderTime, (player, event) -> {
-                    if (requirePermission(player, "buildsystem.edit.time")) {
-                        changeTime(player);
-                    }
-                    reopen(player);
-                }));
+                EditButton.builder()
+                        .permission("buildsystem.edit.time")
+                        .outcome(ClickOutcome.REOPEN)
+                        .render(this::renderTime)
+                        .onClick((player, event) -> {
+                            if (requirePermission(player, "buildsystem.edit.time")) {
+                                changeTime(player);
+                            }
+                            reopen(player);
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_BUTCHER,
-                new EditButton(
-                        "buildsystem.edit.entities", ClickOutcome.CLOSE, this::renderButcher, (player, event) -> {
+                EditButton.builder()
+                        .permission("buildsystem.edit.entities")
+                        .outcome(ClickOutcome.CLOSE)
+                        .render(this::renderButcher)
+                        .onClick((player, event) -> {
                             if (requirePermission(player, "buildsystem.edit.entities")) {
                                 removeEntities(player);
                             }
-                        }));
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_BUILDERS,
-                new EditButton(
-                        "buildsystem.edit.builders", ClickOutcome.REOPEN, this::renderBuilders, this::onBuildersClick));
+                EditButton.builder()
+                        .permission("buildsystem.edit.builders")
+                        .outcome(ClickOutcome.REOPEN)
+                        .render(this::renderBuilders)
+                        .onClick(this::onBuildersClick)
+                        .build());
 
-        map.put(
+        register(
                 SLOT_VISIBILITY,
-                new EditButton(
-                        "buildsystem.edit.visibility",
-                        ClickOutcome.REOPEN,
-                        this::renderVisibility,
-                        this::onVisibilityClick));
+                EditButton.builder()
+                        .permission("buildsystem.edit.visibility")
+                        .outcome(ClickOutcome.REOPEN)
+                        .render(this::renderVisibility)
+                        .onClick(this::onVisibilityClick)
+                        .build());
 
-        map.put(
+        register(
                 SLOT_GAMERULES,
-                new EditButton(
-                        "buildsystem.edit.gamerules", ClickOutcome.SUBMENU, this::renderGameRules, (player, event) -> {
+                EditButton.builder()
+                        .permission("buildsystem.edit.gamerules")
+                        .outcome(ClickOutcome.SUBMENU)
+                        .render(this::renderGameRules)
+                        .onClick((player, event) -> {
                             if (requirePermission(player, "buildsystem.edit.gamerules")) {
                                 XSound.BLOCK_CHEST_OPEN.play(player);
                                 new GameRulesMenu(plugin, buildWorld, player).open(player);
                             }
-                        }));
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_DIFFICULTY,
-                new EditButton(
-                        "buildsystem.edit.difficulty", ClickOutcome.REOPEN, this::renderDifficulty, (player, event) -> {
+                EditButton.builder()
+                        .permission("buildsystem.edit.difficulty")
+                        .outcome(ClickOutcome.REOPEN)
+                        .render(this::renderDifficulty)
+                        .onClick((player, event) -> {
                             if (requirePermission(player, "buildsystem.edit.difficulty")) {
                                 cycleDifficulty();
                             }
                             reopen(player);
-                        }));
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_STATUS,
-                new EditButton("buildsystem.edit.status", ClickOutcome.SUBMENU, this::renderStatus, (player, event) -> {
-                    if (requirePermission(player, "buildsystem.edit.status")) {
-                        XSound.ENTITY_CHICKEN_EGG.play(player);
-                        new StatusMenu(plugin, buildWorld, player).open(player);
-                    }
-                }));
+                EditButton.builder()
+                        .permission("buildsystem.edit.status")
+                        .outcome(ClickOutcome.SUBMENU)
+                        .render(this::renderStatus)
+                        .onClick((player, event) -> {
+                            if (requirePermission(player, "buildsystem.edit.status")) {
+                                XSound.ENTITY_CHICKEN_EGG.play(player);
+                                new StatusMenu(plugin, buildWorld, player).open(player);
+                            }
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_PROJECT,
-                new EditButton("buildsystem.edit.project", ClickOutcome.INPUT, this::renderProject, (player, event) -> {
-                    if (requirePermission(player, "buildsystem.edit.project")) {
-                        XSound.ENTITY_CHICKEN_EGG.play(player);
-                        new SetProjectSubCommand(plugin).getProjectInput(player, buildWorld, false);
-                    }
-                }));
+                EditButton.builder()
+                        .permission("buildsystem.edit.project")
+                        .outcome(ClickOutcome.INPUT)
+                        .render(this::renderProject)
+                        .onClick((player, event) -> {
+                            if (requirePermission(player, "buildsystem.edit.project")) {
+                                XSound.ENTITY_CHICKEN_EGG.play(player);
+                                new SetProjectSubCommand(plugin).getProjectInput(player, buildWorld, false);
+                            }
+                        })
+                        .build());
 
-        map.put(
+        register(
                 SLOT_PERMISSION,
-                new EditButton(
-                        "buildsystem.edit.permission", ClickOutcome.INPUT, this::renderPermission, (player, event) -> {
+                EditButton.builder()
+                        .permission("buildsystem.edit.permission")
+                        .outcome(ClickOutcome.INPUT)
+                        .render(this::renderPermission)
+                        .onClick((player, event) -> {
                             if (requirePermission(player, "buildsystem.edit.permission")) {
                                 XSound.ENTITY_CHICKEN_EGG.play(player);
                                 new SetPermissionSubCommand(plugin).getPermissionInput(player, buildWorld, false);
                             }
-                        }));
-
-        return map;
+                        })
+                        .build());
     }
 
     @Override
     protected void populate(Player player) {
-        Inventory inv = getInventory();
-        plugin.getMenuItems().fillAll(player, inv);
-        buttons.forEach((slot, button) -> button.render(player, inv));
+        plugin.getMenuItems().fillAll(player, getInventory());
+        renderButtons(player);
     }
 
     private void renderToggle(Player player, Inventory inventory, int slot, Toggle toggle) {
@@ -491,13 +567,7 @@ public class EditMenu extends Menu {
             return;
         }
 
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        MenuButton button = buttons.get(event.getSlot());
-        if (button != null) {
-            button.onClick(player, event);
-        }
+        super.handleClick(event);
     }
 
     /**
@@ -549,7 +619,7 @@ public class EditMenu extends Menu {
      */
     Map<Integer, String> permissionBySlot() {
         Map<Integer, String> permissions = new LinkedHashMap<>();
-        buttons.forEach((slot, button) -> {
+        buttons().forEach((slot, button) -> {
             String permission = button.permission();
             if (permission != null) {
                 permissions.put(slot, permission);
@@ -564,7 +634,7 @@ public class EditMenu extends Menu {
      */
     Map<Integer, ClickOutcome> outcomeBySlot() {
         Map<Integer, ClickOutcome> outcomes = new LinkedHashMap<>();
-        buttons.forEach((slot, button) -> outcomes.put(slot, button.outcome()));
+        buttons().forEach((slot, button) -> outcomes.put(slot, button.outcome()));
         return outcomes;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/FolderContentMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/FolderContentMenu.java
@@ -51,11 +51,13 @@ public class FolderContentMenu extends DisplayablesMenu {
         super(
                 plugin,
                 player,
-                category,
-                plugin.getMessages().getString("folder_title", player, new SimpleEntry<>("%folder%", folder.getName())),
-                null,
-                requiredVisibility,
-                validStatuses);
+                Options.builder()
+                        .category(category)
+                        .title(plugin.getMessages()
+                                .getString("folder_title", player, new SimpleEntry<>("%folder%", folder.getName())))
+                        .requiredVisibility(requiredVisibility)
+                        .validStatuses(validStatuses)
+                        .build());
         this.folder = folder;
         this.parentInventory = parentInventory;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/GameRulesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/GameRulesMenu.java
@@ -20,10 +20,10 @@ package de.eintosti.buildsystem.world.menu;
 import com.cryptomorin.xseries.XGameRule;
 import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
-import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.PaginatedMenu;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import java.util.Arrays;
@@ -31,12 +31,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.bukkit.ChatColor;
-import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -75,58 +72,57 @@ public class GameRulesMenu extends PaginatedMenu {
         }
         World world = optionalWorld.get();
 
+        clearButtons();
         for (int i = 0; i < MENU_SIZE; i++) {
             if (!isValidSlot(i)) {
                 plugin.getMenuItems().addGlassPane(player, getInventory(), i);
             }
         }
 
-        addPageNavItem(player, SLOT_PREVIOUS_PAGE, page() > 0, "gui_previous_page", SkullTextures.PREVIOUS_PAGE);
-        addPageNavItem(
-                player,
-                SLOT_NEXT_PAGE,
-                page() < totalPages(ITEMS_PER_PAGE) - 1,
-                "gui_next_page",
-                SkullTextures.NEXT_PAGE);
-
-        String[] allGameRules = world.getGameRules();
-        int startIndex = page() * ITEMS_PER_PAGE;
-        for (int i = 0; i < SLOTS.length && startIndex + i < allGameRules.length; i++) {
-            addGameRuleItem(SLOTS[i], world, allGameRules[startIndex + i], player);
+        // Page arrows render only when a page exists in that direction; otherwise the glass filler above stays.
+        if (totalPages(ITEMS_PER_PAGE) > 1 && page() > 0) {
+            register(SLOT_PREVIOUS_PAGE, previousPageButton(SkullTextures.PREVIOUS_PAGE, ITEMS_PER_PAGE));
         }
+        if (totalPages(ITEMS_PER_PAGE) > 1 && page() < totalPages(ITEMS_PER_PAGE) - 1) {
+            register(SLOT_NEXT_PAGE, nextPageButton(SkullTextures.NEXT_PAGE, ITEMS_PER_PAGE));
+        }
+
+        registerPageItems(SLOTS, Arrays.asList(world.getGameRules()), name -> gameRuleButton(world, name));
+
+        renderButtons(player);
     }
 
-    /**
-     * Renders a page-navigation skull when more pages exist in the given direction, otherwise a filler glass pane.
-     *
-     * @param player The viewing player
-     * @param slot The slot to render into
-     * @param hasMorePages Whether a page exists in this direction (and there is more than one page)
-     * @param nameKey The message key for the skull's display name
-     * @param skullTexture The skull texture to use
-     */
-    private void addPageNavItem(Player player, int slot, boolean hasMorePages, String nameKey, String skullTexture) {
-        if (totalPages(ITEMS_PER_PAGE) > 1 && hasMorePages) {
-            ItemBuilder.skull(Profileable.detect(skullTexture))
-                    .name(messages.getString(nameKey, player))
-                    .into(getInventory(), slot);
-        } else {
-            plugin.getMenuItems().addGlassPane(player, getInventory(), slot);
-        }
+    private MenuButton gameRuleButton(World world, String gameRuleName) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    XGameRule<?> gameRule = XGameRule.of(gameRuleName).orElse(null);
+                    if (gameRule == null || !gameRule.isSupported()) {
+                        plugin.getLogger()
+                                .severe("GameRule '%s' does not exist in world '%s'."
+                                        .formatted(gameRuleName, world.getName()));
+                        return;
+                    }
+                    ItemBuilder.of(isEnabled(world, gameRule) ? XMaterial.FILLED_MAP : XMaterial.MAP)
+                            .name(ChatColor.YELLOW + gameRule.name())
+                            .lore(getLore(world, gameRule, player))
+                            .into(inventory, slot);
+                })
+                .onClick((player, event) -> {
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                    modifyGameRule(world, gameRuleName, event);
+                    populate(player);
+                })
+                .build();
     }
 
-    private void addGameRuleItem(int slot, World world, String gameRuleName, Player player) {
-        XGameRule<?> gameRule = XGameRule.of(gameRuleName).orElse(null);
-        if (gameRule == null || !gameRule.isSupported()) {
-            plugin.getLogger()
-                    .severe("GameRule '" + gameRuleName + "' does not exist in world '" + world.getName() + "'.");
+    @Override
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        // Only the menu's own slots return to the editor; clicks in the player inventory are ignored.
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= getInventory().getSize()) {
             return;
         }
-
-        ItemBuilder.of(isEnabled(world, gameRule) ? XMaterial.FILLED_MAP : XMaterial.MAP)
-                .name(ChatColor.YELLOW + gameRule.name())
-                .lore(getLore(world, gameRule, player))
-                .into(getInventory(), slot);
+        XSound.BLOCK_CHEST_OPEN.play(player);
+        new EditMenu(plugin, buildWorld, player).open(player);
     }
 
     private List<String> getLore(World world, XGameRule<?> gameRule, Player player) {
@@ -147,69 +143,11 @@ public class GameRulesMenu extends PaginatedMenu {
         return Arrays.stream(SLOTS).anyMatch(i -> i == slot);
     }
 
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null || itemStack.getType() == Material.AIR || !itemStack.hasItemMeta()) {
-            return;
-        }
-
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        switch (XMaterial.matchXMaterial(event.getCurrentItem())) {
-            case PLAYER_HEAD:
-                boolean pageChanged = false;
-                int slot = event.getSlot();
-                if (slot == SLOT_PREVIOUS_PAGE) {
-                    pageChanged = previousPage(player, ITEMS_PER_PAGE);
-                } else if (slot == SLOT_NEXT_PAGE) {
-                    pageChanged = nextPage(player, ITEMS_PER_PAGE);
-                }
-                if (!pageChanged) {
-                    return;
-                }
-                populate(player);
-                return;
-
-            case FILLED_MAP:
-            case MAP:
-                XSound.ENTITY_CHICKEN_EGG.play(player);
-                modifyGameRule(event, buildWorld.getWorld().orElse(null));
-                populate(player);
-                return;
-
-            default:
-                XSound.BLOCK_CHEST_OPEN.play(player);
-                new EditMenu(plugin, buildWorld, player).open(player);
-        }
-    }
-
-    private void modifyGameRule(InventoryClickEvent event, @Nullable World world) {
-        if (world == null) {
-            return;
-        }
-
-        int slot = event.getSlot();
-        if (!isValidSlot(slot)) {
-            return;
-        }
-
-        ItemStack itemStack = event.getCurrentItem();
-        if (itemStack == null) {
-            return;
-        }
-
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        if (itemMeta == null || !itemMeta.hasDisplayName()) {
-            return;
-        }
-
-        String rawName = ChatColor.stripColor(itemMeta.getDisplayName());
-        XGameRule<?> gameRule = XGameRule.of(rawName).orElse(null);
+    private void modifyGameRule(World world, String gameRuleName, InventoryClickEvent event) {
+        XGameRule<?> gameRule = XGameRule.of(gameRuleName).orElse(null);
         if (gameRule == null || !gameRule.isSupported()) {
             plugin.getLogger()
-                    .warning("GameRule '%s' does not exist in world '%s'.".formatted(rawName, world.getName()));
+                    .warning("GameRule '%s' does not exist in world '%s'.".formatted(gameRuleName, world.getName()));
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
@@ -20,68 +20,82 @@ package de.eintosti.buildsystem.world.menu;
 import com.cryptomorin.xseries.XSound;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.player.menu.SettingsMenu;
+import java.util.function.Consumer;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class NavigatorMenu extends Menu {
+public class NavigatorMenu extends ButtonMenu<MenuButton> {
+
+    private static final int SLOT_WORLDS = 11;
+    private static final int SLOT_ARCHIVE = 12;
+    private static final int SLOT_PRIVATE = 13;
+    private static final int SLOT_SETTINGS = 15;
+
+    private static final String SETTINGS_SKULL_PROFILE =
+            "1cba7277fc895bf3b673694159864b83351a4d14717e476ebda1c3bf38fcf37";
 
     private final BuildSystemPlugin plugin;
 
     public NavigatorMenu(BuildSystemPlugin plugin, Player player) {
         super(plugin.getMessages(), 27, plugin.getMessages().getString("old_navigator_title", player));
         this.plugin = plugin;
+
+        register(
+                SLOT_WORLDS,
+                navButton(
+                        Profileable.detect(SkullTextures.WORLD_NAVIGATOR),
+                        "old_navigator_world_navigator",
+                        p -> new PublicWorldsMenu(plugin, p).open(p)));
+        register(
+                SLOT_ARCHIVE,
+                navButton(
+                        Profileable.detect(SkullTextures.WORLD_ARCHIVE),
+                        "old_navigator_world_archive",
+                        p -> new ArchivedWorldsMenu(plugin, p).open(p)));
+        register(
+                SLOT_PRIVATE,
+                navButton(
+                        Profileable.of(player),
+                        "old_navigator_private_worlds",
+                        p -> new PrivateWorldsMenu(plugin, p).open(p)));
+        register(
+                SLOT_SETTINGS,
+                MenuButton.builder()
+                        .render((p, inventory, slot) -> ItemBuilder.skull(Profileable.detect(SETTINGS_SKULL_PROFILE))
+                                .name(messages.getString("old_navigator_settings", p))
+                                .into(inventory, slot))
+                        .onClick((p, event) -> {
+                            if (!p.hasPermission("buildsystem.settings")) {
+                                XSound.ENTITY_ITEM_BREAK.play(p);
+                                return;
+                            }
+                            new SettingsMenu(plugin, p).open(p);
+                            XSound.ENTITY_CHICKEN_EGG.play(p);
+                        })
+                        .build());
+    }
+
+    private MenuButton navButton(Profileable icon, String nameKey, Consumer<Player> open) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> ItemBuilder.skull(icon)
+                        .name(messages.getString(nameKey, player))
+                        .into(inventory, slot))
+                .onClick((player, event) -> {
+                    open.accept(player);
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                })
+                .build();
     }
 
     @Override
     protected void populate(Player player) {
         plugin.getMenuItems().fillRange(player, getInventory(), 0, 27);
-
-        ItemBuilder.skull(Profileable.detect(SkullTextures.WORLD_NAVIGATOR))
-                .name(messages.getString("old_navigator_world_navigator", player))
-                .into(getInventory(), 11);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.WORLD_ARCHIVE))
-                .name(messages.getString("old_navigator_world_archive", player))
-                .into(getInventory(), 12);
-        ItemBuilder.skull(Profileable.of(player))
-                .name(messages.getString("old_navigator_private_worlds", player))
-                .into(getInventory(), 13);
-        ItemBuilder.skull(Profileable.detect("1cba7277fc895bf3b673694159864b83351a4d14717e476ebda1c3bf38fcf37"))
-                .name(messages.getString("old_navigator_settings", player))
-                .into(getInventory(), 15);
-    }
-
-    @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        switch (event.getSlot()) {
-            case 11:
-                new PublicWorldsMenu(plugin, player).open(player);
-                break;
-            case 12:
-                new ArchivedWorldsMenu(plugin, player).open(player);
-                break;
-            case 13:
-                new PrivateWorldsMenu(plugin, player).open(player);
-                break;
-            case 15:
-                if (!player.hasPermission("buildsystem.settings")) {
-                    XSound.ENTITY_ITEM_BREAK.play(player);
-                    return;
-                }
-                new SettingsMenu(plugin, player).open(player);
-                break;
-            default:
-                return;
-        }
-
-        XSound.ENTITY_CHICKEN_EGG.play(player);
+        renderButtons(player);
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/SetupMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/SetupMenu.java
@@ -31,6 +31,7 @@ import de.eintosti.buildsystem.world.display.CustomizableIcons;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -54,37 +55,30 @@ public class SetupMenu extends Menu {
     private static final int FIRST_PLAYER_SLOT = 36;
     private static final int LAST_PLAYER_SLOT = 80;
 
-    private static final Map<BuildWorldType, Integer> CREATE_ITEM_SLOTS = Map.ofEntries(
-            entry(BuildWorldType.NORMAL, 11),
-            entry(BuildWorldType.FLAT, 12),
-            entry(BuildWorldType.NETHER, 13),
-            entry(BuildWorldType.END, 14),
-            entry(BuildWorldType.VOID, 15),
-            entry(BuildWorldType.IMPORTED, 16));
+    /**
+     * Where a configurable icon sits and what message names it. Pairs the slot and message key that were previously held
+     * in two parallel maps per section.
+     *
+     * @param slot The inventory slot the icon occupies
+     * @param nameKey The message key for the icon's display name
+     */
+    private record IconDef(int slot, String nameKey) {}
 
-    private static final Map<BuildWorldType, String> CREATE_ITEM_KEYS = Map.ofEntries(
-            entry(BuildWorldType.NORMAL, "setup_normal_world"),
-            entry(BuildWorldType.FLAT, "setup_flat_world"),
-            entry(BuildWorldType.NETHER, "setup_nether_world"),
-            entry(BuildWorldType.END, "setup_end_world"),
-            entry(BuildWorldType.VOID, "setup_void_world"),
-            entry(BuildWorldType.IMPORTED, "setup_imported_world"));
+    private static final Map<BuildWorldType, IconDef> CREATE_ICONS = Map.ofEntries(
+            entry(BuildWorldType.NORMAL, new IconDef(11, "setup_normal_world")),
+            entry(BuildWorldType.FLAT, new IconDef(12, "setup_flat_world")),
+            entry(BuildWorldType.NETHER, new IconDef(13, "setup_nether_world")),
+            entry(BuildWorldType.END, new IconDef(14, "setup_end_world")),
+            entry(BuildWorldType.VOID, new IconDef(15, "setup_void_world")),
+            entry(BuildWorldType.IMPORTED, new IconDef(16, "setup_imported_world")));
 
-    private static final Map<BuildWorldStatus, Integer> STATUS_ITEM_SLOTS = Map.ofEntries(
-            entry(BuildWorldStatus.NOT_STARTED, 20),
-            entry(BuildWorldStatus.IN_PROGRESS, 21),
-            entry(BuildWorldStatus.ALMOST_FINISHED, 22),
-            entry(BuildWorldStatus.FINISHED, 23),
-            entry(BuildWorldStatus.ARCHIVE, 24),
-            entry(BuildWorldStatus.HIDDEN, 25));
-
-    private static final Map<BuildWorldStatus, String> STATUS_ITEM_KEYS = Map.ofEntries(
-            entry(BuildWorldStatus.NOT_STARTED, "status_not_started"),
-            entry(BuildWorldStatus.IN_PROGRESS, "status_in_progress"),
-            entry(BuildWorldStatus.ALMOST_FINISHED, "status_almost_finished"),
-            entry(BuildWorldStatus.FINISHED, "status_finished"),
-            entry(BuildWorldStatus.ARCHIVE, "status_archive"),
-            entry(BuildWorldStatus.HIDDEN, "status_hidden"));
+    private static final Map<BuildWorldStatus, IconDef> STATUS_ICONS = Map.ofEntries(
+            entry(BuildWorldStatus.NOT_STARTED, new IconDef(20, "status_not_started")),
+            entry(BuildWorldStatus.IN_PROGRESS, new IconDef(21, "status_in_progress")),
+            entry(BuildWorldStatus.ALMOST_FINISHED, new IconDef(22, "status_almost_finished")),
+            entry(BuildWorldStatus.FINISHED, new IconDef(23, "status_finished")),
+            entry(BuildWorldStatus.ARCHIVE, new IconDef(24, "status_archive")),
+            entry(BuildWorldStatus.HIDDEN, new IconDef(25, "status_hidden")));
 
     private final BuildSystemPlugin plugin;
     private final CustomizableIcons icons;
@@ -101,8 +95,8 @@ public class SetupMenu extends Menu {
         plugin.getMenuItems().fillAll(player, inv);
 
         addSectionHeaders(inv, player);
-        addIconItems(inv, player, CREATE_ITEM_SLOTS, CREATE_ITEM_KEYS);
-        addIconItems(inv, player, STATUS_ITEM_SLOTS, STATUS_ITEM_KEYS);
+        addIconItems(inv, player, CREATE_ICONS, icons::getIcon);
+        addIconItems(inv, player, STATUS_ICONS, icons::getIcon);
     }
 
     private void addSectionHeaders(Inventory inv, Player player) {
@@ -121,22 +115,15 @@ public class SetupMenu extends Menu {
      *
      * @param inv The inventory to populate
      * @param player The viewing player
-     * @param slots The slot each enum constant occupies
-     * @param keys The message key for each enum constant's display name
+     * @param iconDefs The slot and name key for each enum constant
+     * @param iconResolver Resolves an enum constant to its currently configured icon material
      * @param <T> The enum type (e.g. {@link BuildWorldType}, {@link BuildWorldStatus})
      */
     private <T extends Enum<T>> void addIconItems(
-            Inventory inv, Player player, Map<T, Integer> slots, Map<T, String> keys) {
-        slots.forEach((constant, slot) -> ItemBuilder.of(getIcon(constant))
-                .name(messages.getString(keys.get(constant), player))
-                .into(inv, slot));
-    }
-
-    private XMaterial getIcon(Enum<?> constant) {
-        if (constant instanceof BuildWorldType type) {
-            return icons.getIcon(type);
-        }
-        return icons.getIcon((BuildWorldStatus) constant);
+            Inventory inv, Player player, Map<T, IconDef> iconDefs, Function<T, XMaterial> iconResolver) {
+        iconDefs.forEach((constant, def) -> ItemBuilder.of(iconResolver.apply(constant))
+                .name(messages.getString(def.nameKey(), player))
+                .into(inv, def.slot()));
     }
 
     @Override
@@ -178,22 +165,23 @@ public class SetupMenu extends Menu {
     @Override
     public void handleClose(InventoryCloseEvent event) {
         Inventory inv = getInventory();
-        processIconMapping(inv, CREATE_ITEM_SLOTS, icons::setIcon);
-        processIconMapping(inv, STATUS_ITEM_SLOTS, icons::setIcon);
+        processIconMapping(inv, CREATE_ICONS, icons::setIcon);
+        processIconMapping(inv, STATUS_ICONS, icons::setIcon);
     }
 
     /**
-     * A generic helper method that iterates over a map of Enum-to-Slot, extracts the {@link ItemStack}, and sets the
-     * corresponding icon.
+     * A generic helper method that iterates over a map of Enum-to-{@link IconDef}, extracts the {@link ItemStack} at each
+     * icon's slot, and sets the corresponding icon.
      *
      * @param inventory The inventory to get items from
-     * @param slotMapping A map from an Enum constant to its inventory slot index
+     * @param iconDefs A map from an Enum constant to its {@link IconDef}
+     * @param setter Stores the chosen icon material for an enum constant
      * @param <T> The type of the Enum (e.g., {@link BuildWorldType}, {@link BuildWorldStatus})
      */
     private <T extends Enum<T>> void processIconMapping(
-            Inventory inventory, Map<T, Integer> slotMapping, BiConsumer<T, XMaterial> setter) {
-        slotMapping.forEach((enumConstant, slot) -> {
-            XMaterial material = Optional.ofNullable(inventory.getItem(slot))
+            Inventory inventory, Map<T, IconDef> iconDefs, BiConsumer<T, XMaterial> setter) {
+        iconDefs.forEach((enumConstant, def) -> {
+            XMaterial material = Optional.ofNullable(inventory.getItem(def.slot()))
                     .map(XMaterial::matchXMaterial)
                     .orElse(null);
             if (material == null) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -23,8 +23,9 @@ import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuButton;
 import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -34,7 +35,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-public class StatusMenu extends Menu {
+public class StatusMenu extends ButtonMenu<MenuButton> {
 
     /**
      * The single source of truth for the status selection grid: each interactive slot maps to the status it selects.
@@ -59,6 +60,8 @@ public class StatusMenu extends Menu {
                         .getString("status_title", player, Map.entry("%world%", formatWorldName(buildWorld))));
         this.plugin = plugin;
         this.buildWorld = buildWorld;
+
+        STATUS_BY_SLOT.forEach((slot, status) -> register(slot, statusButton(status)));
     }
 
     private static String formatWorldName(BuildWorld buildWorld) {
@@ -69,12 +72,48 @@ public class StatusMenu extends Menu {
         return worldName;
     }
 
+    private MenuButton statusButton(BuildWorldStatus status) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) -> {
+                    XMaterial material = plugin.getCustomizableIcons().getIcon(status);
+                    String displayName = messages.getString(Messages.getMessageKey(status), player);
+
+                    if (!player.hasPermission(status.getPermission())) {
+                        material = XMaterial.BARRIER;
+                        displayName = "§c§m" + ChatColor.stripColor(displayName);
+                    }
+
+                    ItemBuilder.of(material)
+                            .name(displayName)
+                            .glow(buildWorld.getData().getStatus() == status)
+                            .into(inventory, slot);
+                })
+                .onClick((player, event) -> {
+                    if (!player.hasPermission(status.getPermission())) {
+                        XSound.ENTITY_ITEM_BREAK.play(player);
+                        return;
+                    }
+
+                    player.closeInventory();
+                    buildWorld.getData().setStatus(status);
+                    plugin.getSettingsService().forceUpdateSidebar(buildWorld);
+
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                    messages.sendMessage(
+                            player,
+                            "worlds_setstatus_set",
+                            Map.entry("%world%", buildWorld.getName()),
+                            Map.entry("%status%", messages.getString(Messages.getMessageKey(status), player)));
+                })
+                .build();
+    }
+
     @Override
     protected void populate(Player player) {
         plugin.getMenuItems().fillRange(player, getInventory(), 0, 10);
         plugin.getMenuItems().fillRange(player, getInventory(), 17, 27);
 
-        STATUS_BY_SLOT.forEach((slot, status) -> addStatusItem(player, slot, status));
+        renderButtons(player);
     }
 
     /**
@@ -84,59 +123,19 @@ public class StatusMenu extends Menu {
         return STATUS_BY_SLOT;
     }
 
-    /**
-     * Adds a status item to the inventory at the specified position.
-     *
-     * @param player The player who will see the item
-     * @param position The position in the inventory to add the item
-     * @param status The status to represent with the item
-     */
-    private void addStatusItem(Player player, int position, BuildWorldStatus status) {
-        XMaterial material = plugin.getCustomizableIcons().getIcon(status);
-        String displayName = messages.getString(Messages.getMessageKey(status), player);
-
-        if (!player.hasPermission(status.getPermission())) {
-            material = XMaterial.BARRIER;
-            displayName = "§c§m" + ChatColor.stripColor(displayName);
-        }
-
-        ItemBuilder.of(material)
-                .name(displayName)
-                .glow(buildWorld.getData().getStatus() == status)
-                .into(getInventory(), position);
-    }
-
     @Override
-    public void handleClick(InventoryClickEvent event) {
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        // Only react to clicks inside this menu (not the player's own inventory).
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= getInventory().getSize()) {
+            return;
+        }
         ItemStack itemStack = event.getCurrentItem();
         if (itemStack == null || itemStack.getType() == Material.AIR || !itemStack.hasItemMeta()) {
             return;
         }
 
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        BuildWorldStatus status = STATUS_BY_SLOT.get(event.getSlot());
-        if (status == null) {
-            XSound.BLOCK_CHEST_OPEN.play(player);
-            new EditMenu(plugin, buildWorld, player).open(player);
-            return;
-        }
-
-        if (!player.hasPermission(status.getPermission())) {
-            XSound.ENTITY_ITEM_BREAK.play(player);
-            return;
-        }
-
-        player.closeInventory();
-        buildWorld.getData().setStatus(status);
-        plugin.getSettingsService().forceUpdateSidebar(buildWorld);
-
-        XSound.ENTITY_CHICKEN_EGG.play(player);
-        messages.sendMessage(
-                player,
-                "worlds_setstatus_set",
-                Map.entry("%world%", buildWorld.getName()),
-                Map.entry("%status%", messages.getString(Messages.getMessageKey(status), player)));
+        // A click on any non-status slot (e.g. the filler) returns to the editor.
+        XSound.BLOCK_CHEST_OPEN.play(player);
+        new EditMenu(plugin, buildWorld, player).open(player);
     }
 }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/FolderStorageImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/FolderStorageImplTest.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.event.folder.FolderCreatedEvent;
 import de.eintosti.buildsystem.api.event.folder.FolderDeletedEvent;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.builder.Builder;
+import de.eintosti.buildsystem.api.world.display.Displayable.DisplayableType;
 import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import java.util.ArrayList;
@@ -286,6 +287,11 @@ class FolderStorageImplTest {
         @Override
         public List<String> getLore(org.bukkit.entity.Player player) {
             return List.of();
+        }
+
+        @Override
+        public DisplayableType getDisplayableType() {
+            return DisplayableType.FOLDER;
         }
     }
 

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/FolderStorageImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/FolderStorageImplTest.java
@@ -23,7 +23,6 @@ import de.eintosti.buildsystem.api.event.folder.FolderCreatedEvent;
 import de.eintosti.buildsystem.api.event.folder.FolderDeletedEvent;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.builder.Builder;
-import de.eintosti.buildsystem.api.world.display.Displayable.DisplayableType;
 import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import java.util.ArrayList;
@@ -287,11 +286,6 @@ class FolderStorageImplTest {
         @Override
         public List<String> getLore(org.bukkit.entity.Player player) {
             return List.of();
-        }
-
-        @Override
-        public DisplayableType getDisplayableType() {
-            return DisplayableType.FOLDER;
         }
     }
 


### PR DESCRIPTION
**Frozen API (_buildsystem-api_):**
- Displayable: add polymorphic `getDisplayableType()` replacing the closed instanceof switch; expose documented PDC key constants; drop the per-call reflective JavaPlugin lookup
- rename `BuildWorld.asProfilable` -> `asProfileable`
- document Storage async/threading contract and `BuildWorldManipulationEvent`

**Menu framework (_buildsystem-core_):**
- add `ButtonMenu<B>`: shared button registry, base click dispatch with raw-slot bounded lookup (no bottom-inventory misfire), and `onUnhandledClick` hook for filler/back behaviour
- `MenuButton` gains a slot-aware render and a fluent builder; `EditButton` and `SettingsButton` gain builders
- `PaginatedMenu extends ButtonMenu`
- migrate Edit, Settings, Status, Speed, Delete, Design, CustomBlock, Navigator, Backups and BackupsConfirmation menus to the registry
- `DisplayablesMenu.Options` named-parameter construction across the family
- generalize `SetupMenu` icon maps; keep it a plain `Menu` (drag-and-drop editor)