### PR TITLE
polish(api): finalize 4.0.0 public API + navigator/status fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Changelog
+
+All notable changes to **BuildSystem** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 4.0.0
+
+Major release. Breaking changes for `buildsystem-api` consumers and for two
+config toggles. `config.yml` and `messages.yml` migrate automatically.
+
+### Requirements
+
+- Java 25. Older runtimes will not start the plugin.
+- Minecraft 1.21 minimum.
+
+### Added
+
+- **Custom world statuses.** Statuses are no longer a fixed enum — admins create,
+  restyle, reorder, and delete them in-game (`/setup` → World Statuses). Each
+  status has its own name, colour, icon, ordering, a building-allowed flag, and an
+  optional auto-progress target; whether a status appears in the navigator is
+  decided by category membership, not a per-status flag. The six built-ins
+  (`not_started`, `in_progress`, `almost_finished`, `finished`, `archive`,
+  `hidden`) are seeded and can be restyled or deleted (never the last remaining
+  status). Assign with `buildsystem.setstatus.<id>` — built-in ids drop
+  underscores for backwards compatibility, custom ids are used verbatim.
+- **Navigator categories.** The fixed public/archive/private navigator sections
+  become fully customizable categories. A category groups worlds by visibility +
+  a set of statuses, with its own name/colour/icon. A world is shown in *every*
+  category that groups it, so overlapping categories each list it. Create with
+  `buildsystem.create.<categoryId>`; admins with the create-permission bypass may
+  create in any category.
+- **In-game `/setup` GUI.** A redesigned hub branching to editors for the default
+  world-type icons, world statuses, and the navigator layout — with a 16-colour
+  dye picker, a scrollable/filterable item picker, optional player-head skull
+  textures, and confirm/reset controls. "Reset to defaults" restores the
+  built-ins (world statuses, navigator categories, and default world-type icons);
+  deleting the storage file does too.
+- **Navigator layout editor** (`/setup` → Navigator Layout). One menu both manages
+  categories and arranges where each category and the settings button appear in
+  the inventory navigator: pick a category (or the settings button) up and place
+  it into a navigator slot, drop it outside to remove it, drop it on the delete
+  target to delete the category, right-click to edit it, and create new categories
+  from within the same screen. The editor temporarily takes over the player's
+  inventory for its controls and restores it on close, quit, or shutdown.
+- **Per-world, per-folder, per-category skull-texture icons.** When an icon is a
+  player head, a custom texture (or the `%viewer%` sentinel for the viewing
+  player's own head) can be configured.
+- World-editor toggles now show their current value (`Currently: Enabled/Disabled`)
+  in the lore, in addition to the enchant glint.
+- Pinned worlds (#319). Pinned worlds sort above all others in every navigator
+  list regardless of the active sort and show a configurable prefix. Toggle via
+  the edit menu; permission `buildsystem.edit.pin`.
+- `/worlds saveTemplate <world> [templateName]` (#449). Copies a world into
+  `templates/` at runtime. Permission `buildsystem.savetemplate`.
+- Per-option `/settings` permissions: `buildsystem.setting.<option>` (#250).
+- Per-template and per-generator create permissions:
+  `buildsystem.create.template.<name>`, `buildsystem.create.generator.<name>`
+  (#322, #323). All default to granted; deny a node to restrict it.
+- `settings.world-permission-whitelist`: restrict the values `/worlds
+  setPermission` may assign to a configured list.
+
+### Changed
+
+- `config.yml`/`messages.yml` are versioned and migrated on load.
+- API: `BuildWorldManipulationEvent` moved to
+  `de.eintosti.buildsystem.api.event.world`.
+- API: world creation/import is now fluent — `WorldService.newWorld(name)` /
+  `importWorld(name)`, terminated with `build()`.
+- API: `Type<T>` renamed to `Property<T>`.
+- API: `BuildWorld.getWorld()` returns `Optional<World>` (was nullable `World`).
+- API: `BuildWorldStatus` is now an interface resolved through the new
+  `WorldStatusRegistry`, not an enum. `BuildWorldStatusChangeEvent` carries
+  interface instances.
+- API: the `NavigatorCategory` enum becomes an interface backed by the new
+  `NavigatorCategoryRegistry`; `Folder.getCategory()` returns it.
+- API: world public/private is replaced by a `Visibility`
+  (`EVERYONE`/`ADDED_PLAYERS`) on `WorldData`
+  (`getVisibility()`/`setVisibility()`); `isPrivateWorld()`/`setPrivateWorld()`
+  are gone.
+- API: the instance is registered through Bukkit's `ServicesManager`; obtain it
+  via `BuildSystemProvider.get()`.
+
+### Added (API)
+
+- World lifecycle events in `event.world`: `BuildWorldCreateEvent` (cancellable),
+  `BuildWorldPostCreateEvent`, `BuildWorldDeleteEvent` (cancellable),
+  `BuildWorldPostDeleteEvent`, `BuildWorldUnimportEvent`, `BuildWorldRenameEvent`,
+  `BuildWorldStatusChangeEvent`.
+- Backup and folder events in `event.backup` and `event.folder`.
+- `WorldService.importWorlds()` for bulk import, spread across ticks.
+- Direct `WorldData` accessors (`getStatus()`/`setStatus()`,
+  `isPhysics()`/`setPhysics()`, …) in addition to the property objects.
+- `WorldStatusRegistry` and `NavigatorCategoryRegistry`, exposed via
+  `BuildSystem.getStatusRegistry()` / `getNavigatorCategoryRegistry()`.
+- `Displayable.getIconSkullTexture()` and `getHeadProfile()` for custom head
+  icons.
+
+### Removed
+
+- API: `BuildWorld.setLoaded(boolean)` (`isLoaded()` remains).
+- API: `WorldData.getConfigFormat()` and `WorldData.getAllData()`.
+- API: `BuildSystemProvider.register()` / `unregister()` are no longer public.
+- API: `BuildWorld.asProfileable()` — head icons are now resolved through
+  `Displayable.getHeadProfile()` / `getIconSkullTexture()`.
+
+### Fixed
+
+- Paper 26.1: `IncompatibleClassChangeError` on `org.bukkit.GameRule` (a class on
+  spigot-api, an interface on Paper). Game-rule access goes through XSeries
+  `XGameRule` so the plugin runs on both (#457).
+- Game-rule names updated to the current API.
+- Main-thread safety: NoClip block check, world-rename registry mutation (spawn
+  captured before unload), and post-async-skull inventory updates now run on the
+  main thread; async menu callbacks hardened.
+- Backups: bounded `BackupService` thread pool; storage credentials validated
+  before use; SFTP connection failures raised as `IOException` instead of `null`.
+- World rename persistence and unload-time parsing.
+- Duplicate listener registration on reload.
+- Placeholder substitution is literal, not regex-based.
+- Inventory clicks are matched against the menu inventory only; a click in the
+  player's own inventory no longer triggers the menu button in the same slot.
+
+### Security
+
+- Path-traversal guards on template and world directory resolution.
+
+### Performance
+
+- Navigator armor stands cached, removing a per-tick entity scan.
+- NoClip check no longer allocates a `Location` per tick.
+- Reduced allocation/work in scoreboard rendering, color processing, and the
+  template menu.
+
+### Migration (server admins)
+
+The following happen automatically on the first 4.0.0 boot — no manual steps
+required for a working server:
+
+- **World statuses** — stored enum names (`IN_PROGRESS`) are lowercased to the
+  new id format (`in_progress`). Unknown values fall back to `not_started`.
+- **World visibility** — the per-world `private: true/false` boolean is converted
+  to `ADDED_PLAYERS`/`EVERYONE`. Nothing is lost.
+- **Folder categories** — stored upper-case enum values (`PUBLIC`, `ARCHIVE`,
+  `PRIVATE`) are lowercased to the matching built-in category id. Unknown values
+  fall back to `public`.
+- **Status display names** — if `statuses.yml` does not yet exist, each built-in
+  status is seeded from the server's existing `status_<id>` key in `messages.yml`
+  (colour code split off into `color`, remainder becomes `displayName`). After
+  that first boot, `statuses.yml` is authoritative; the `status_*` keys in
+  `messages.yml` are unused and can be deleted manually.
+- **`config.yml` / `messages.yml`** — both files are versioned and missing keys
+  are added on load; existing customisations are preserved.
+
+Two config flags removed in 4.0.0 — if present they are silently ignored:
+
+- `settings.per-option-permissions` (superseded by the always-on
+  `buildsystem.setting.<option>` nodes).
+- `settings.restrict-template-access` (superseded by the deny-to-restrict
+  `buildsystem.create.template.<name>` model).
+
+### Upgrade notes (API consumers)
+
+Recompile against `buildsystem-api` 4.0.0. Update `BuildWorldManipulationEvent`
+imports to `api.event.world`, migrate to `newWorld`/`importWorld` + `build()`, and
+adapt to `Property<T>` and `Optional<World>`. `BuildWorldStatus` and
+`NavigatorCategory` are now interfaces — compare them by id (`equals()` /
+`getId()`), never with `==` or `switch`. Replace `BuildWorld.asProfileable()` with
+the `Displayable` head-profile hooks.
+
+**Full changelog**: https://github.com/thomasmny/BuildSystem/compare/3.0.2...4.0.0

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/BuildSystem.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/BuildSystem.java
@@ -81,7 +81,7 @@ public interface BuildSystem {
      * Returns the service for listing, creating, and restoring world backups via per-world {@link BackupProfile}s.
      *
      * @return The backup service, never {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     BackupService getBackupService();
 
@@ -90,7 +90,7 @@ public interface BuildSystem {
      * built-in defaults plus any custom statuses created by administrators.
      *
      * @return The status registry, never {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     WorldStatusRegistry getStatusRegistry();
 
@@ -99,7 +99,7 @@ public interface BuildSystem {
      * visibility and navigator grouping.
      *
      * @return The navigator category registry, never {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     NavigatorCategoryRegistry getNavigatorCategoryRegistry();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupCreatedEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupCreatedEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Called after a {@link Backup} of a {@link BuildWorld} has been created and stored.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BackupCreatedEvent extends BackupEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupDeletedEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupDeletedEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Called after a {@link Backup} has been deleted, for example when pruning the oldest backups over the configured per-world limit.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BackupDeletedEvent extends BackupEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Represents a {@link Backup} related event.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public abstract class BackupEvent extends Event {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupRestoredEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/backup/BackupRestoredEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Called after a {@link BuildWorld} has been restored from a {@link Backup}.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BackupRestoredEvent extends BackupEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldCreateEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldCreateEvent.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.Nullable;
  * <p>Because the {@link BuildWorld} does not exist yet, this event exposes the prospective world's properties directly
  * rather than a {@link BuildWorld} instance.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldCreateEvent extends Event implements Cancellable {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldDeleteEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldDeleteEvent.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.NullMarked;
  * <p>Cancelling this event prevents the deletion. The cancelling listener is responsible for informing the initiating
  * player.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldDeleteEvent extends BuildWorldEvent implements Cancellable {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldManipulationEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldManipulationEvent.java
@@ -40,7 +40,7 @@ import org.jspecify.annotations.NullMarked;
  * <p>BuildSystem itself cancels this event at {@link org.bukkit.event.EventPriority#LOW} when the player is not allowed
  * to modify the world; listeners running at a later priority can observe or override that decision.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldManipulationEvent extends BuildWorldEvent implements Cancellable {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldPostCreateEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldPostCreateEvent.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Called after a {@link BuildWorld} has been created or imported and registered.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldPostCreateEvent extends BuildWorldEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldPostDeleteEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldPostDeleteEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>At this point the {@link BuildWorld} object is no longer registered and must only be used for reading.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldPostDeleteEvent extends BuildWorldEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldRenameEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldRenameEvent.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.NullMarked;
  * <p>By the time this event fires the rename has completed, so {@link BuildWorld#getName()} already returns the new
  * name.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldRenameEvent extends BuildWorldEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldStatusChangeEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldStatusChangeEvent.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.NullMarked;
  * <p>This event is fired synchronously from whichever thread mutates the status, and only when the value actually
  * changes.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldStatusChangeEvent extends BuildWorldEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldUnimportEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/BuildWorldUnimportEvent.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
  *
  * <p>This event is also fired as the first stage of a deletion, followed by {@link BuildWorldPostDeleteEvent}.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class BuildWorldUnimportEvent extends BuildWorldEvent {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/PlayerBuildModeToggleEvent.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/event/world/PlayerBuildModeToggleEvent.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.NullMarked;
  * Called when a player's build mode is toggled. This event can be triggered by the player themselves or by another
  * plugin/player.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public class PlayerBuildModeToggleEvent extends PlayerEvent implements Cancellable {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/exception/WorldDeletionCancelledException.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/exception/WorldDeletionCancelledException.java
@@ -22,7 +22,7 @@ import de.eintosti.buildsystem.api.event.world.BuildWorldDeleteEvent;
 /**
  * Thrown when a {@link BuildWorldDeleteEvent} listener cancelled the deletion of a world.
  *
- * @since TODO
+ * @since 4.0.0
  */
 public class WorldDeletionCancelledException extends WorldDeletionException {
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/exception/WorldDeletionException.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/exception/WorldDeletionException.java
@@ -28,7 +28,7 @@ public class WorldDeletionException extends WorldException {
      * Constructs a new {@link WorldDeletionException} with the specified message.
      *
      * @param message The detail message
-     * @since TODO
+     * @since 4.0.0
      */
     public WorldDeletionException(String message) {
         super(message);

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/BuildWorld.java
@@ -47,7 +47,7 @@ public interface BuildWorld extends Displayable {
      * Gets the Bukkit {@link World} associated with this {@link BuildWorld}.
      *
      * @return An {@link Optional} containing the Bukkit world, or {@link Optional#empty()} if not loaded
-     * @since TODO
+     * @since 4.0.0
      */
     Optional<World> getWorld();
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/WorldService.java
@@ -61,7 +61,7 @@ public interface WorldService {
      *
      * @param name The name of the world to create
      * @return A new {@link WorldBuilder} for the specified world name
-     * @since TODO
+     * @since 4.0.0
      */
     WorldBuilder newWorld(String name);
 
@@ -71,7 +71,7 @@ public interface WorldService {
      *
      * @param name The name of the existing world directory to import
      * @return A new {@link WorldImporter} for the specified world name
-     * @since TODO
+     * @since 4.0.0
      */
     WorldImporter importWorld(String name);
 
@@ -89,7 +89,7 @@ public interface WorldService {
      *     an {@link IllegalStateException} if a bulk import is already running
      * @apiNote Each individual import goes through Bukkit's main-thread world machinery; the spreading is handled
      *     internally. Safe to call from the main thread.
-     * @since TODO
+     * @since 4.0.0
      */
     CompletableFuture<Integer> importWorlds();
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldPermissions.java
@@ -77,7 +77,7 @@ public interface WorldPermissions {
      *
      * @param player The player attempting to modify the world
      * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
-     * @since TODO
+     * @since 4.0.0
      */
     boolean canModify(Player player);
 
@@ -90,7 +90,7 @@ public interface WorldPermissions {
      * @param player The player attempting to modify the world
      * @param setting The world setting gating the modification
      * @return {@code true} if the player is allowed to modify the world, {@code false} otherwise
-     * @since TODO
+     * @since 4.0.0
      */
     boolean canModify(Player player, WorldSetting setting);
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldSetting.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/access/WorldSetting.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * A protectable boolean world setting that gates whether a player may modify the world in a particular way.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public enum WorldSetting {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/Backup.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/Backup.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Represents a single backup of a {@link de.eintosti.buildsystem.api.world.BuildWorld}.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface Backup {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupProfile.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupProfile.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.NullMarked;
  * Represents a profile for managing backups of a specific {@link BuildWorld}. This interface defines operations related
  * to listing, creating, restoring, and destroying backups.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface BackupProfile {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupService.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupService.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.NullMarked;
  * through which backups can be listed, created and restored. The concrete storage backend (local disk, SFTP or S3) is
  * configured by the server owner and is transparent to API consumers.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface BackupService {
@@ -37,7 +37,7 @@ public interface BackupService {
      *
      * @param buildWorld The world whose backup profile is requested
      * @return The backup profile for {@code buildWorld}, never {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     BackupProfile getProfile(BuildWorld buildWorld);
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupStorage.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/backup/BackupStorage.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Represents a storage mechanism for managing world backups.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface BackupStorage {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/WorldBuilder.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/WorldBuilder.java
@@ -48,7 +48,7 @@ import org.jspecify.annotations.Nullable;
  * <p>Not to be confused with {@link Builder}, which represents a player trusted to modify a world rather than a tool for
  * <em>creating</em> one.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface WorldBuilder {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/WorldImporter.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/creation/WorldImporter.java
@@ -42,7 +42,7 @@ import org.jspecify.annotations.Nullable;
  * <p>To generate a fresh world instead, use {@link de.eintosti.buildsystem.api.world.WorldService#newWorld(String)} and
  * its {@link WorldBuilder}.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface WorldImporter {

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
@@ -25,15 +25,22 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Represents a building status a {@link BuildWorld} can have, indicating the progression and accessibility of a world.
  *
- * <p>Statuses are dynamic; server administrators can create, restyle, and delete custom statuses at runtime through
- * the in-game setup menu. Instances are obtained and resolved through the {@link WorldStatusRegistry}. Six built-in
- * statuses are always present and {@link #isBuiltIn() protected from deletion}: {@code not_started}, {@code in_progress},
- * {@code almost_finished}, {@code finished}, {@code archive}, and {@code hidden}.
+ * <p>Statuses are dynamic; server administrators can create, restyle, and delete them at runtime through the in-game
+ * setup menu. Instances are obtained and resolved through the {@link WorldStatusRegistry}. Six statuses are
+ * {@link #isBuiltIn() built in} and seeded by default — {@code not_started}, {@code in_progress},
+ * {@code almost_finished}, {@code finished}, {@code archive}, and {@code hidden} — and can be restored after deletion
+ * by resetting to defaults. The registry always keeps at least one status so a {@link WorldStatusRegistry#getDefaultStatus()
+ * default} fallback always exists.
  *
  * <p>Behavioral traits are data-driven and defined by individual properties, such as whether building is permitted,
  * visibility flags, and automatic progression rules.
  *
- * @since TODO
+ * <p>Two statuses are equal if and only if they share the same {@link #getId() id}. Compare statuses with
+ * {@link Object#equals(Object) equals}, never with {@code ==}: this type is no longer an enum, so reference identity is
+ * not guaranteed even for the same logical status. Implementations must define {@code equals} and {@code hashCode}
+ * consistently with the id.
+ *
+ * @since 4.0.0
  */
 @NullMarked
 public interface BuildWorldStatus {
@@ -102,13 +109,6 @@ public interface BuildWorldStatus {
     boolean isBuildingAllowed();
 
     /**
-     * Gets whether worlds with this status are shown in the navigator.
-     *
-     * @return {@code true} if visible in the navigator, otherwise {@code false}
-     */
-    boolean isVisibleInNavigator();
-
-    /**
      * Gets the id of the status a world is automatically advanced to the first time it is modified.
      *
      * @return The target status id, or {@link Optional#empty()} if this status does not auto-advance
@@ -116,8 +116,9 @@ public interface BuildWorldStatus {
     Optional<String> getProgressesTo();
 
     /**
-     * Gets whether this is a built-in status. Built-in statuses can be restyled but never deleted, guaranteeing a valid
-     * fallback always exists.
+     * Gets whether this status is one of the plugin's built-in defaults, as opposed to an administrator-created custom
+     * status. Built-in statuses can be restyled and deleted like any other; deleting one only removes it until the
+     * statuses are reset to their defaults.
      *
      * @return {@code true} if built-in, otherwise {@code false}
      */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldData.java
@@ -38,7 +38,7 @@ public interface WorldData {
      * Gets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
      *
      * @return The custom spawn string
-     * @since TODO
+     * @since 4.0.0
      */
     String getCustomSpawn();
 
@@ -46,7 +46,7 @@ public interface WorldData {
      * Sets the custom spawn of the {@link BuildWorld} as a string in the format {@code x;y;z;yaw;pitch}.
      *
      * @param customSpawn The custom spawn string
-     * @since TODO
+     * @since 4.0.0
      */
     void setCustomSpawn(String customSpawn);
 
@@ -61,7 +61,7 @@ public interface WorldData {
      * Gets the permission required to enter the {@link BuildWorld}. Returns "-" if no specific permission is required.
      *
      * @return The permission string
-     * @since TODO
+     * @since 4.0.0
      */
     String getPermission();
 
@@ -69,7 +69,7 @@ public interface WorldData {
      * Sets the permission required to enter the {@link BuildWorld}.
      *
      * @param permission The permission string
-     * @since TODO
+     * @since 4.0.0
      */
     void setPermission(String permission);
 
@@ -77,7 +77,7 @@ public interface WorldData {
      * Gets the project description of the {@link BuildWorld}.
      *
      * @return The project description string
-     * @since TODO
+     * @since 4.0.0
      */
     String getProject();
 
@@ -85,7 +85,7 @@ public interface WorldData {
      * Sets the project description of the {@link BuildWorld}.
      *
      * @param project The project description string
-     * @since TODO
+     * @since 4.0.0
      */
     void setProject(String project);
 
@@ -93,7 +93,7 @@ public interface WorldData {
      * Gets the {@link Difficulty} of the {@link BuildWorld}.
      *
      * @return The world's difficulty setting
-     * @since TODO
+     * @since 4.0.0
      */
     Difficulty getDifficulty();
 
@@ -101,7 +101,7 @@ public interface WorldData {
      * Sets the {@link Difficulty} of the {@link BuildWorld}.
      *
      * @param difficulty The world's difficulty setting
-     * @since TODO
+     * @since 4.0.0
      */
     void setDifficulty(Difficulty difficulty);
 
@@ -109,7 +109,7 @@ public interface WorldData {
      * Gets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
      *
      * @return The material used for display
-     * @since TODO
+     * @since 4.0.0
      */
     XMaterial getMaterial();
 
@@ -117,7 +117,7 @@ public interface WorldData {
      * Sets the {@link XMaterial} used to display the {@link BuildWorld} in the navigator menus.
      *
      * @param material The material used for display
-     * @since TODO
+     * @since 4.0.0
      */
     void setMaterial(XMaterial material);
 
@@ -126,7 +126,7 @@ public interface WorldData {
      * when none is set; the literal {@code "%viewer%"} means the viewing player's own head.
      *
      * @return The skull texture, {@code "%viewer%"}, or {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     @Nullable String getIconSkullTexture();
 
@@ -135,7 +135,7 @@ public interface WorldData {
      * clear it, or the literal {@code "%viewer%"} to render the viewing player's own head.
      *
      * @param skullTexture The skull texture, {@code "%viewer%"}, or {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     void setIconSkullTexture(@Nullable String skullTexture);
 
@@ -143,7 +143,7 @@ public interface WorldData {
      * Gets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
      *
      * @return The current build status
-     * @since TODO
+     * @since 4.0.0
      */
     BuildWorldStatus getStatus();
 
@@ -151,7 +151,7 @@ public interface WorldData {
      * Sets the current {@link BuildWorldStatus} of the {@link BuildWorld}.
      *
      * @param status The current build status
-     * @since TODO
+     * @since 4.0.0
      */
     void setStatus(BuildWorldStatus status);
 
@@ -159,7 +159,7 @@ public interface WorldData {
      * Gets whether block breaking is allowed in the {@link BuildWorld}.
      *
      * @return {@code true} if allowed, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isBlockBreaking();
 
@@ -167,7 +167,7 @@ public interface WorldData {
      * Sets whether block breaking is allowed in the {@link BuildWorld}.
      *
      * @param blockBreaking {@code true} if allowed, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setBlockBreaking(boolean blockBreaking);
 
@@ -175,7 +175,7 @@ public interface WorldData {
      * Gets whether block interactions (e.g., opening doors, chests) are enabled in the {@link BuildWorld}.
      *
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isBlockInteractions();
 
@@ -183,7 +183,7 @@ public interface WorldData {
      * Sets whether block interactions are enabled in the {@link BuildWorld}.
      *
      * @param blockInteractions {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setBlockInteractions(boolean blockInteractions);
 
@@ -191,7 +191,7 @@ public interface WorldData {
      * Gets whether block placement is allowed in the {@link BuildWorld}.
      *
      * @return {@code true} if allowed, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isBlockPlacement();
 
@@ -199,7 +199,7 @@ public interface WorldData {
      * Sets whether block placement is allowed in the {@link BuildWorld}.
      *
      * @param blockPlacement {@code true} if allowed, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setBlockPlacement(boolean blockPlacement);
 
@@ -208,7 +208,7 @@ public interface WorldData {
      * can modify the world.
      *
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isBuildersEnabled();
 
@@ -216,7 +216,7 @@ public interface WorldData {
      * Sets whether the "builders feature" is enabled in the {@link BuildWorld}.
      *
      * @param buildersEnabled {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setBuildersEnabled(boolean buildersEnabled);
 
@@ -224,7 +224,7 @@ public interface WorldData {
      * Gets whether explosions are enabled in the {@link BuildWorld}.
      *
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isExplosions();
 
@@ -232,7 +232,7 @@ public interface WorldData {
      * Sets whether explosions are enabled in the {@link BuildWorld}.
      *
      * @param explosions {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setExplosions(boolean explosions);
 
@@ -240,7 +240,7 @@ public interface WorldData {
      * Gets whether entities in the {@link BuildWorld} have artificial intelligence.
      *
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isMobAi();
 
@@ -248,7 +248,7 @@ public interface WorldData {
      * Sets whether entities in the {@link BuildWorld} have artificial intelligence.
      *
      * @param mobAi {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setMobAi(boolean mobAi);
 
@@ -256,7 +256,7 @@ public interface WorldData {
      * Gets whether physics (e.g., gravity, fluid flow) is applied to blocks in the {@link BuildWorld}.
      *
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isPhysics();
 
@@ -264,7 +264,7 @@ public interface WorldData {
      * Sets whether physics is applied to blocks in the {@link BuildWorld}.
      *
      * @param physics {@code true} if enabled, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setPhysics(boolean physics);
 
@@ -273,7 +273,7 @@ public interface WorldData {
      * sort order.
      *
      * @return {@code true} if pinned, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     boolean isPinned();
 
@@ -281,7 +281,7 @@ public interface WorldData {
      * Sets whether this world is pinned to the top of the navigator.
      *
      * @param pinned {@code true} if pinned, otherwise {@code false}
-     * @since TODO
+     * @since 4.0.0
      */
     void setPinned(boolean pinned);
 
@@ -290,7 +290,7 @@ public interface WorldData {
      * for a world's visibility, replacing the legacy private boolean.
      *
      * @return The access rule
-     * @since TODO
+     * @since 4.0.0
      */
     Visibility getVisibility();
 
@@ -298,7 +298,7 @@ public interface WorldData {
      * Sets the {@link Visibility} governing who may see and enter the {@link BuildWorld}.
      *
      * @param visibility The access rule
-     * @since TODO
+     * @since 4.0.0
      */
     void setVisibility(Visibility visibility);
 
@@ -306,7 +306,7 @@ public interface WorldData {
      * Gets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
      *
      * @return The number of seconds since the last backup
-     * @since TODO
+     * @since 4.0.0
      */
     int getTimeSinceBackup();
 
@@ -314,7 +314,7 @@ public interface WorldData {
      * Sets the number of seconds that have passed since the last {@link Backup} of the {@link BuildWorld} was created.
      *
      * @param timeSinceBackup The number of seconds since the last backup
-     * @since TODO
+     * @since 4.0.0
      */
     void setTimeSinceBackup(int timeSinceBackup);
 
@@ -322,7 +322,7 @@ public interface WorldData {
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
      *
      * @return The last edited timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     long getLastEdited();
 
@@ -330,7 +330,7 @@ public interface WorldData {
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was edited.
      *
      * @param lastEdited The last edited timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     void setLastEdited(long lastEdited);
 
@@ -338,7 +338,7 @@ public interface WorldData {
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
      *
      * @return The last loaded timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     long getLastLoaded();
 
@@ -346,7 +346,7 @@ public interface WorldData {
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was loaded.
      *
      * @param lastLoaded The last loaded timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     void setLastLoaded(long lastLoaded);
 
@@ -354,7 +354,7 @@ public interface WorldData {
      * Gets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
      *
      * @return The last unloaded timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     long getLastUnloaded();
 
@@ -362,7 +362,7 @@ public interface WorldData {
      * Sets the timestamp (in milliseconds since epoch) of the last time the {@link BuildWorld} was unloaded.
      *
      * @param lastUnloaded The last unloaded timestamp
-     * @since TODO
+     * @since 4.0.0
      */
     void setLastUnloaded(long lastUnloaded);
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldStatusRegistry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldStatusRegistry.java
@@ -21,12 +21,13 @@ import java.util.Collection;
 import java.util.Optional;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The registry of all {@link BuildWorldStatus statuses} known to the server, both the built-in defaults and any custom
  * statuses created by administrators. Statuses are resolved from their persisted id through this registry.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface WorldStatusRegistry {
@@ -72,10 +73,11 @@ public interface WorldStatusRegistry {
     /**
      * Resolves a status by its {@link BuildWorldStatus#getId() id}.
      *
-     * @param id The status id
-     * @return The matching status, or {@link Optional#empty()} if none is registered with that id
+     * @param id The status id, or {@code null}
+     * @return The matching status, or {@link Optional#empty()} if {@code id} is {@code null} or no status is registered
+     *     with that id
      */
-    Optional<BuildWorldStatus> getStatus(String id);
+    Optional<BuildWorldStatus> getStatus(@Nullable String id);
 
     /**
      * Gets the global default status worlds fall back to (the built-in {@code not_started}). Always present.

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Displayable.java
@@ -89,7 +89,7 @@ public interface Displayable {
      * when no custom texture is set; the literal {@code "%viewer%"} means the viewing player's own head.
      *
      * @return The skull texture, {@code "%viewer%"} for the viewer's head, or {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     @Nullable String getIconSkullTexture();
 
@@ -98,7 +98,7 @@ public interface Displayable {
      * clear it, or the literal {@code "%viewer%"} to render the viewing player's own head.
      *
      * @param skullTexture The skull texture, {@code "%viewer%"}, or {@code null}
-     * @since TODO
+     * @since 4.0.0
      */
     void setIconSkullTexture(@Nullable String skullTexture);
 
@@ -109,7 +109,7 @@ public interface Displayable {
      * profiles (e.g. a world's creator) without blocking the inventory from opening.
      *
      * @return The default head profile, or {@code null} for a plain head
-     * @since TODO
+     * @since 4.0.0
      */
     @Nullable default Profileable getHeadProfile() {
         return null;
@@ -121,7 +121,7 @@ public interface Displayable {
      * to leave a plain head when resolution fails. Like the head profile, this is resolved asynchronously.
      *
      * @return The fallback head profile, or {@code null} for none
-     * @since TODO
+     * @since 4.0.0
      */
     @Nullable default Profileable getHeadFallbackProfile() {
         return null;

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Folder.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Folder.java
@@ -46,7 +46,7 @@ public interface Folder extends Displayable {
      * Gets the {@link NavigatorCategory} in which this folder is displayed.
      *
      * @return The {@link NavigatorCategory} of the folder
-     * @since TODO
+     * @since 4.0.0
      */
     NavigatorCategory getCategory();
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
@@ -35,11 +35,17 @@ import org.jspecify.annotations.Nullable;
  * shared and may appear in several categories (e.g. {@code in_progress} lives in both the public and private
  * categories, distinguished by visibility).
  *
- * <p>Server administrators can create, restyle, and delete categories at runtime through the in-game setup menu.
- * Built-in categories ({@code public}, {@code private}, {@code archive}) are {@link #isBuiltIn() protected from
- * deletion}.
+ * <p>Server administrators can create, restyle, and delete categories at runtime through the in-game setup menu. Three
+ * categories are {@link #isBuiltIn() built in} and seeded by default ({@code public}, {@code private},
+ * {@code archive}) and can be restored after deletion by resetting to defaults. The registry always keeps at least one
+ * category so a {@link NavigatorCategoryRegistry#getDefaultCategory() default} fallback always exists.
  *
- * @since TODO
+ * <p>Two categories are equal if and only if they share the same {@link #getId() id}. Compare categories with
+ * {@link Object#equals(Object) equals}, never with {@code ==}: this type is no longer an enum, so reference identity is
+ * not guaranteed even for the same logical category. Implementations must define {@code equals} and {@code hashCode}
+ * consistently with the id.
+ *
+ * @since 4.0.0
  */
 @NullMarked
 public interface NavigatorCategory {
@@ -65,6 +71,17 @@ public interface NavigatorCategory {
      * @return The colour token
      */
     String getColor();
+
+    /**
+     * Gets the display name prefixed with this category's {@link #getColor() colour}, with legacy colour codes still
+     * unresolved. Callers translate the codes when rendering.
+     *
+     * @return The colour-prefixed display name
+     * @since 4.0.0
+     */
+    default String getStyledName() {
+        return getColor() + getDisplayName();
+    }
 
     /**
      * Gets the material used to represent this category in the navigator and setup menus.
@@ -122,7 +139,7 @@ public interface NavigatorCategory {
      * @param visibility The world's visibility
      * @param statusId The world's status id
      * @return {@code true} if this category groups such a world
-     * @since TODO
+     * @since 4.0.0
      */
     default boolean groups(Visibility visibility, String statusId) {
         return getVisibilities().contains(visibility) && getStatusIds().contains(statusId);
@@ -144,7 +161,9 @@ public interface NavigatorCategory {
     int getNavigatorSlot();
 
     /**
-     * Gets whether this is a built-in category. Built-in categories can be restyled but never deleted.
+     * Gets whether this category is one of the plugin's built-in defaults, as opposed to an administrator-created
+     * custom category. Built-in categories can be restyled and deleted like any other; deleting one only removes it
+     * until the categories are reset to their defaults.
      *
      * @return {@code true} if built-in, otherwise {@code false}
      */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
  * The registry of all {@link NavigatorCategory navigator categories} known to the server, both the built-in defaults
  * and any custom categories created by administrators.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public interface NavigatorCategoryRegistry {
@@ -65,12 +65,15 @@ public interface NavigatorCategoryRegistry {
     Optional<NavigatorCategory> getCategory(@Nullable String id);
 
     /**
-     * Resolves the category a world is displayed in by matching both the world's visibility and its status: the world
-     * belongs to the first category whose {@link NavigatorCategory#getVisibilities() visibilities} contain the world's
-     * and whose {@link NavigatorCategory#getStatusIds() statuses} contain the world's status.
+     * Resolves a world's primary ("home") category — the first category whose
+     * {@link NavigatorCategory#getVisibilities() visibilities} contain the world's visibility and whose
+     * {@link NavigatorCategory#getStatusIds() statuses} contain the world's status. A world may additionally appear in
+     * other overlapping categories; whether any single category lists a world is tested with
+     * {@link NavigatorCategory#groups}. This method only picks the single representative category (e.g. for a world's
+     * default folder), falling back to the {@link #getDefaultCategory() default} when nothing matches.
      *
-     * @param world The world whose category to resolve
-     * @return The resolved category, or the {@link #getDefaultCategory() default} when nothing matches
+     * @param world The world whose primary category to resolve
+     * @return The resolved primary category, or the {@link #getDefaultCategory() default} when nothing matches
      */
     NavigatorCategory getCategoryForWorld(BuildWorld world);
 

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/SaveBehavior.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/lifecycle/SaveBehavior.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.NullMarked;
 /**
  * Whether a world's state should be written to disk before it is unloaded.
  *
- * @since TODO
+ * @since 4.0.0
  */
 @NullMarked
 public enum SaveBehavior {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/FolderSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/FolderSubCommand.java
@@ -132,9 +132,15 @@ public class FolderSubCommand extends AbstractSubCommand {
                     return;
                 }
 
-                NavigatorCategory worldCategory =
-                        plugin.getNavigatorCategoryRegistry().getCategoryForWorld(buildWorld);
-                if (!folder.getCategory().equals(worldCategory)) {
+                // A world can be filed in any folder whose category groups it, matching exactly where the world is
+                // listed in the navigator (overlapping categories each list it). Using groups() rather than the single
+                // "home" category from getCategoryForWorld keeps "can I see it here" and "can I file it here" in sync.
+                if (!folder.getCategory()
+                        .groups(
+                                buildWorld.getData().getVisibility(),
+                                buildWorld.getData().getStatus().getId())) {
+                    NavigatorCategory worldCategory =
+                            plugin.getNavigatorCategoryRegistry().getCategoryForWorld(buildWorld);
                     messages.sendMessage(
                             player,
                             "worlds_folder_world_category_mismatch",
@@ -262,9 +268,10 @@ public class FolderSubCommand extends AbstractSubCommand {
                 return result;
             }
             worldService.getWorldStorage().getBuildWorlds().stream()
-                    .filter(bw -> plugin.getNavigatorCategoryRegistry()
-                            .getCategoryForWorld(bw)
-                            .equals(folder.getCategory()))
+                    .filter(bw -> folder.getCategory()
+                            .groups(
+                                    bw.getData().getVisibility(),
+                                    bw.getData().getStatus().getId()))
                     .filter(bw -> op.equals("add") ? !bw.isAssignedToFolder() : folder.containsWorld(bw))
                     .forEach(bw -> WorldsCompletions.addIfStartsWith(args[3], bw.getName(), result));
             return result;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ItemBuilder.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ItemBuilder.java
@@ -151,22 +151,35 @@ public final class ItemBuilder {
     }
 
     /**
-     * Starts a builder for a {@link NavigatorCategory navigator category} icon. An explicitly configured skull texture
-     * wins; otherwise a player-head icon defaults to the viewing player's own skin for added-players categories (the
-     * "private" style) and the navigator texture for everyone-visible categories.
+     * Resolves the skull texture a {@link NavigatorCategory} icon should use: its explicitly configured texture wins;
+     * otherwise a blank-textured player head falls back to the viewing player's own skin for added-players categories
+     * (the "private" style) and the navigator texture for everyone-visible categories. Returns {@code null} for a
+     * non-head icon or an explicitly textureless head. Shared by the synchronous {@link #icon(NavigatorCategory, Player)}
+     * and the asynchronous {@code MenuItems.renderCategoryIcon} so the two paths cannot diverge.
+     *
+     * @param category The category whose icon texture is resolved
+     * @return The skull texture, the {@link #VIEWER_HEAD} sentinel, or {@code null}
+     */
+    public static @Nullable String categoryTexture(NavigatorCategory category) {
+        String texture = category.getIconSkullTexture();
+        if (category.getIcon() == XMaterial.PLAYER_HEAD && (texture == null || texture.isBlank())) {
+            return category.getPrimaryVisibility() == Visibility.ADDED_PLAYERS
+                    ? VIEWER_HEAD
+                    : SkullTextures.WORLD_NAVIGATOR;
+        }
+        return texture;
+    }
+
+    /**
+     * Starts a builder for a {@link NavigatorCategory navigator category} icon, applying the texture chosen by
+     * {@link #categoryTexture(NavigatorCategory)}.
      *
      * @param category The category whose icon is rendered
      * @param viewer The viewing player, used to resolve the viewer-head default
      * @return A new builder wrapping the resolved icon
      */
     public static ItemBuilder icon(NavigatorCategory category, Player viewer) {
-        String texture = category.getIconSkullTexture();
-        if (category.getIcon() == XMaterial.PLAYER_HEAD && (texture == null || texture.isBlank())) {
-            texture = category.getPrimaryVisibility() == Visibility.ADDED_PLAYERS
-                    ? VIEWER_HEAD
-                    : SkullTextures.WORLD_NAVIGATOR;
-        }
-        return icon(category.getIcon(), texture, viewer);
+        return icon(category.getIcon(), categoryTexture(category), viewer);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -22,7 +22,6 @@ import com.cryptomorin.xseries.profiles.builder.XSkull;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.Settings;
-import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.display.Displayable;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import de.eintosti.buildsystem.config.ConfigService;
@@ -173,17 +172,12 @@ public final class MenuItems {
     public void renderCategoryIcon(
             Inventory inventory, int slot, NavigatorCategory category, Player viewer, String name, List<String> lore) {
         XMaterial icon = category.getIcon();
-        if (icon != XMaterial.PLAYER_HEAD) {
-            ItemBuilder.of(icon).name(name).lore(lore).into(inventory, slot);
+        String texture = ItemBuilder.categoryTexture(category);
+        if (icon != XMaterial.PLAYER_HEAD || texture == null || texture.isBlank()) {
+            ItemBuilder.icon(icon, texture, viewer).name(name).lore(lore).into(inventory, slot);
             return;
         }
 
-        String texture = category.getIconSkullTexture();
-        if (texture == null || texture.isBlank()) {
-            texture = category.getPrimaryVisibility() == Visibility.ADDED_PLAYERS
-                    ? ItemBuilder.VIEWER_HEAD
-                    : SkullTextures.WORLD_NAVIGATOR;
-        }
         Profileable profile = ItemBuilder.VIEWER_HEAD.equals(texture)
                 ? Profileable.detect(viewer.getName())
                 : Profileable.detect(texture);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuItems.java
@@ -22,7 +22,9 @@ import com.cryptomorin.xseries.profiles.builder.XSkull;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.player.settings.DesignColor;
 import de.eintosti.buildsystem.api.player.settings.Settings;
+import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.display.Displayable;
+import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.player.settings.SettingsService;
@@ -153,6 +155,39 @@ public final class MenuItems {
                             .log(Level.WARNING, "Failed to resolve head profile for menu item: " + name, throwable);
                     return null;
                 });
+    }
+
+    /**
+     * Renders a {@link NavigatorCategory}'s icon into a menu slot, resolving any player-head skin asynchronously so the
+     * live navigator never blocks the main thread on a profile lookup (an admin-configured username texture, or the
+     * viewer's own head used by the {@code private}-style categories). Non-head icons render synchronously. Mirrors
+     * {@link ItemBuilder#icon(NavigatorCategory, Player)}'s default-texture choice.
+     *
+     * @param inventory The inventory to add the item to
+     * @param slot The slot to add the item at
+     * @param category The category whose icon is rendered
+     * @param viewer The player viewing the inventory
+     * @param name The already-styled display name to apply
+     * @param lore The lore to apply
+     */
+    public void renderCategoryIcon(
+            Inventory inventory, int slot, NavigatorCategory category, Player viewer, String name, List<String> lore) {
+        XMaterial icon = category.getIcon();
+        if (icon != XMaterial.PLAYER_HEAD) {
+            ItemBuilder.of(icon).name(name).lore(lore).into(inventory, slot);
+            return;
+        }
+
+        String texture = category.getIconSkullTexture();
+        if (texture == null || texture.isBlank()) {
+            texture = category.getPrimaryVisibility() == Visibility.ADDED_PLAYERS
+                    ? ItemBuilder.VIEWER_HEAD
+                    : SkullTextures.WORLD_NAVIGATOR;
+        }
+        Profileable profile = ItemBuilder.VIEWER_HEAD.equals(texture)
+                ? Profileable.detect(viewer.getName())
+                : Profileable.detect(texture);
+        applyHeadProfileAsync(inventory, slot, profile, null, name, lore);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
@@ -263,7 +263,7 @@ public class NavigatorService {
             XSound.ENTITY_CHICKEN_EGG.play(player);
         }
 
-        displayActionBarMessage(player, ColorAPI.process(category.getColor() + category.getDisplayName()));
+        displayActionBarMessage(player, ColorAPI.process(category.getStyledName()));
     }
 
     private void displayActionBarMessage(Player player, String message) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlStatusStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlStatusStorage.java
@@ -75,7 +75,6 @@ public class YamlStatusStorage extends AbstractYamlStorage {
                 .icon(icon)
                 .order(section.getInt("order", 0))
                 .buildingAllowed(section.getBoolean("building-allowed", true))
-                .visibleInNavigator(section.getBoolean("visible-in-navigator", true))
                 .progressesTo(progressesTo != null && !progressesTo.isBlank() ? progressesTo : null)
                 .builtIn(section.getBoolean("built-in", false))
                 .build();
@@ -118,7 +117,6 @@ public class YamlStatusStorage extends AbstractYamlStorage {
         config.set(path + ".icon", status.getIcon().name());
         config.set(path + ".order", status.getOrder());
         config.set(path + ".building-allowed", status.isBuildingAllowed());
-        config.set(path + ".visible-in-navigator", status.isVisibleInNavigator());
         config.set(path + ".progresses-to", status.getProgressesTo().orElse(null));
         config.set(path + ".built-in", status.isBuiltIn());
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/StringUtils.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/StringUtils.java
@@ -20,12 +20,41 @@ package de.eintosti.buildsystem.util;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+import java.util.function.Predicate;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public final class StringUtils {
 
     private StringUtils() {}
+
+    /**
+     * Derives a stable, unique lower-case id from a human-entered display name: lower-cased, runs of non-alphanumeric
+     * characters collapsed to single underscores, and leading/trailing underscores trimmed, falling back to
+     * {@code fallback} when nothing usable remains. A numeric suffix ({@code _2}, {@code _3}, ...) is appended until
+     * {@code taken} reports the candidate is free, so two display names can never collapse onto the same id.
+     *
+     * @param displayName The human-entered name to slugify
+     * @param fallback The base id to use when {@code displayName} has no usable characters
+     * @param taken Tests whether a candidate id is already in use
+     * @return A unique id not reported as taken by {@code taken}
+     */
+    public static String uniqueId(String displayName, String fallback, Predicate<String> taken) {
+        String base = displayName
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "_")
+                .replaceAll("^_+|_+$", "");
+        if (base.isEmpty()) {
+            base = fallback;
+        }
+        String id = base;
+        int suffix = 2;
+        while (taken.test(id)) {
+            id = base + "_" + suffix++;
+        }
+        return id;
+    }
 
     /**
      * Formats a given time in milliseconds to a human-readable string.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
@@ -40,7 +40,6 @@ public final class WorldStatusImpl implements BuildWorldStatus {
     private XMaterial icon;
     private int order;
     private boolean buildingAllowed;
-    private boolean visibleInNavigator;
     private @Nullable String progressesTo;
 
     private WorldStatusImpl(Builder builder) {
@@ -50,7 +49,6 @@ public final class WorldStatusImpl implements BuildWorldStatus {
         this.icon = builder.icon;
         this.order = builder.order;
         this.buildingAllowed = builder.buildingAllowed;
-        this.visibleInNavigator = builder.visibleInNavigator;
         this.progressesTo = builder.progressesTo;
         this.builtIn = builder.builtIn;
     }
@@ -108,7 +106,13 @@ public final class WorldStatusImpl implements BuildWorldStatus {
 
     @Override
     public String getPermission() {
-        return "buildsystem.setstatus." + id.toLowerCase(Locale.ROOT).replace("_", "");
+        // Built-in statuses keep the legacy underscore-stripped node (e.g. not_started -> "...notstarted") so
+        // permission
+        // setups from before custom statuses keep working. Custom statuses use their full id, so two distinct ids
+        // cannot
+        // collapse onto the same permission node.
+        String node = builtIn ? id.replace("_", "") : id;
+        return "buildsystem.setstatus." + node.toLowerCase(Locale.ROOT);
     }
 
     @Override
@@ -118,15 +122,6 @@ public final class WorldStatusImpl implements BuildWorldStatus {
 
     public void setBuildingAllowed(boolean buildingAllowed) {
         this.buildingAllowed = buildingAllowed;
-    }
-
-    @Override
-    public boolean isVisibleInNavigator() {
-        return visibleInNavigator;
-    }
-
-    public void setVisibleInNavigator(boolean visibleInNavigator) {
-        this.visibleInNavigator = visibleInNavigator;
     }
 
     @Override
@@ -171,7 +166,6 @@ public final class WorldStatusImpl implements BuildWorldStatus {
         private XMaterial icon = XMaterial.WHITE_DYE;
         private int order = 0;
         private boolean buildingAllowed = true;
-        private boolean visibleInNavigator = true;
         private @Nullable String progressesTo = null;
         private boolean builtIn = false;
 
@@ -202,11 +196,6 @@ public final class WorldStatusImpl implements BuildWorldStatus {
 
         public Builder buildingAllowed(boolean buildingAllowed) {
             this.buildingAllowed = buildingAllowed;
-            return this;
-        }
-
-        public Builder visibleInNavigator(boolean visibleInNavigator) {
-            this.visibleInNavigator = visibleInNavigator;
             return this;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldStatusRegistry;
 import de.eintosti.buildsystem.storage.yaml.YamlStatusStorage;
+import de.eintosti.buildsystem.util.StringUtils;
 import de.eintosti.buildsystem.world.display.NavigatorCategoryRegistryImpl;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +31,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -38,8 +38,9 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Owns every {@link BuildWorldStatus}, seeding the built-in defaults on first run and persisting all administrator
- * changes. Deleting a custom status cascades: every world that used it is reset to the {@link #getDefaultStatus()
- * default} status and the id is removed from every category that grouped it. Built-in statuses are protected.
+ * changes. Deleting a status cascades: every world that used it is reset to the {@link #getDefaultStatus() default}
+ * status and the id is removed from every category that grouped it. The last remaining status can never be deleted, so
+ * a valid default always exists.
  */
 @NullMarked
 public class WorldStatusRegistryImpl implements WorldStatusRegistry {
@@ -62,12 +63,12 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
     }
 
     private void seedDefaults() {
-        put("not_started", "Not Started", "&c", XMaterial.RED_DYE, 1, true, true, "in_progress");
-        put("in_progress", "In Progress", "&6", XMaterial.ORANGE_DYE, 2, true, true, null);
-        put("almost_finished", "Almost Finished", "&a", XMaterial.LIME_DYE, 3, true, true, null);
-        put("finished", "Finished", "&2", XMaterial.GREEN_DYE, 4, true, true, null);
-        put("archive", "Archive", "&3", XMaterial.CYAN_DYE, 5, false, true, null);
-        put("hidden", "Hidden", "&7", XMaterial.BONE_MEAL, 6, true, false, null);
+        put("not_started", "Not Started", "&c", XMaterial.RED_DYE, 1, true, "in_progress");
+        put("in_progress", "In Progress", "&6", XMaterial.ORANGE_DYE, 2, true, null);
+        put("almost_finished", "Almost Finished", "&a", XMaterial.LIME_DYE, 3, true, null);
+        put("finished", "Finished", "&2", XMaterial.GREEN_DYE, 4, true, null);
+        put("archive", "Archive", "&3", XMaterial.CYAN_DYE, 5, false, null);
+        put("hidden", "Hidden", "&7", XMaterial.BONE_MEAL, 6, true, null);
     }
 
     private void put(
@@ -77,7 +78,6 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
             XMaterial icon,
             int order,
             boolean buildingAllowed,
-            boolean visibleInNavigator,
             @Nullable String progressesTo) {
         // One-time migration: a server upgrading from pre-4.0 carries the customised status name in the legacy
         // "status_<id>" message key (the message store never prunes user keys). When present, adopt it so the
@@ -91,7 +91,6 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
                         .icon(icon)
                         .order(order)
                         .buildingAllowed(buildingAllowed)
-                        .visibleInNavigator(visibleInNavigator)
                         .progressesTo(progressesTo)
                         .builtIn(true)
                         .build());
@@ -110,13 +109,35 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
         }
 
         String raw = legacy.get().strip();
-        if (raw.startsWith("&#") && raw.length() >= 8) {
-            return new String[] {raw.substring(0, 8), raw.substring(8).strip()};
-        }
-        if (raw.startsWith("&") && raw.length() >= 2) {
-            return new String[] {raw.substring(0, 2), raw.substring(2).strip()};
+        int colorLength = leadingColorLength(raw);
+        if (colorLength > 0) {
+            return new String[] {
+                raw.substring(0, colorLength), raw.substring(colorLength).strip()
+            };
         }
         return new String[] {defaultColor, raw};
+    }
+
+    /**
+     * Returns the length of the colour token at the start of a legacy styled string, covering the formats a pre-4.0
+     * server could have stored in a {@code status_<id>} message: the Spigot hex form {@code &x&R&R&G&G&B&B}, the
+     * {@code &#RRGGBB} and bare {@code #RRGGBB} hex forms, and a single legacy code such as {@code &c}. Returns 0 when
+     * the string does not start with a recognised colour token.
+     */
+    private static int leadingColorLength(String raw) {
+        if (raw.length() >= 2 && (raw.charAt(0) == '&' || raw.charAt(0) == '§')) {
+            if (Character.toLowerCase(raw.charAt(1)) == 'x' && raw.length() >= 14) {
+                return 14; // &x&R&R&G&G&B&B
+            }
+            if (raw.charAt(1) == '#' && raw.length() >= 8) {
+                return 8; // &#RRGGBB
+            }
+            return 2; // &c, &a, ...
+        }
+        if (raw.startsWith("#") && raw.length() >= 7) {
+            return 7; // #RRGGBB
+        }
+        return 0;
     }
 
     @Override
@@ -127,7 +148,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
     }
 
     @Override
-    public Optional<BuildWorldStatus> getStatus(String id) {
+    public Optional<BuildWorldStatus> getStatus(@Nullable String id) {
         return Optional.ofNullable(this.statuses.get(id));
     }
 
@@ -153,7 +174,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
     }
 
     public WorldStatusImpl createStatus(String displayName) {
-        String id = uniqueId(displayName);
+        String id = StringUtils.uniqueId(displayName, "status", this.statuses::containsKey);
         int order = this.statuses.values().stream()
                         .mapToInt(WorldStatusImpl::getOrder)
                         .max()
@@ -219,21 +240,5 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
                 persist(status);
             }
         }
-    }
-
-    private String uniqueId(String displayName) {
-        String base = displayName
-                .toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]+", "_")
-                .replaceAll("^_+|_+$", "");
-        if (base.isEmpty()) {
-            base = "status";
-        }
-        String id = base;
-        int suffix = 2;
-        while (this.statuses.containsKey(id)) {
-            id = base + "_" + suffix++;
-        }
-        return id;
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
@@ -22,11 +22,14 @@ import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
+import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategoryRegistry;
 import de.eintosti.buildsystem.menu.ItemBuilder;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.storage.yaml.YamlCategoryStorage;
+import de.eintosti.buildsystem.util.StringUtils;
+import de.eintosti.buildsystem.world.folder.FolderImpl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +37,6 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.NullMarked;
@@ -53,11 +55,13 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     /** Slot the settings button occupies in a freshly seeded navigator (matches the historical fixed slot). */
     public static final int DEFAULT_SETTINGS_SLOT = 15;
 
+    private final BuildSystemPlugin plugin;
     private final YamlCategoryStorage storage;
     private final Map<String, NavigatorCategoryImpl> categories = new LinkedHashMap<>();
     private int settingsSlot;
 
     public NavigatorCategoryRegistryImpl(BuildSystemPlugin plugin) {
+        this.plugin = plugin;
         this.storage = new YamlCategoryStorage(plugin);
 
         this.categories.putAll(storage.load());
@@ -214,7 +218,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     }
 
     public NavigatorCategoryImpl createCategory(String displayName) {
-        String id = uniqueId(displayName);
+        String id = StringUtils.uniqueId(displayName, "category", this.categories::containsKey);
         int slot = this.categories.values().stream()
                         .mapToInt(NavigatorCategory::getNavigatorSlot)
                         .max()
@@ -259,7 +263,8 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
      * Removes a category (built-in or custom). The last remaining category is never deleted, so a valid default always
      * exists; an admin can restore the built-ins with {@link #resetToDefaults()}. Worlds previously displayed in the
      * category simply resolve to another matching category (or the {@link #getDefaultCategory() default}) on the next
-     * render; no status is orphaned because statuses are shared rather than owned by a category.
+     * render; no status is orphaned because statuses are shared rather than owned by a category. Folders, which hold a
+     * fixed category, are re-homed to the default so they (and the worlds they contain) stay reachable.
      *
      * @return {@code true} if the category was deleted, {@code false} if it was unknown or the last remaining category
      */
@@ -269,22 +274,23 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         }
         this.categories.remove(id);
         storage.delete(id);
+        rehomeFolders(id);
         return true;
     }
 
-    private String uniqueId(String displayName) {
-        String base = displayName
-                .toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]+", "_")
-                .replaceAll("^_+|_+$", "");
-        if (base.isEmpty()) {
-            base = "category";
+    /**
+     * Re-homes every folder that belonged to the just-deleted category to the {@link #getDefaultCategory() default}, so
+     * the folders (and the worlds they contain) stay reachable in the navigator instead of vanishing until the next
+     * reload. Mirrors how deleting a status resets the worlds that used it. Whole subtrees move together because a
+     * subfolder shares its parent's category.
+     */
+    private void rehomeFolders(String deletedId) {
+        NavigatorCategory fallback = getDefaultCategory();
+        for (Folder folder : plugin.getWorldService().getFolderStorage().getFolders()) {
+            if (folder.getCategory().getId().equals(deletedId)) {
+                ((FolderImpl) folder).setCategory(fallback);
+                plugin.getWorldService().getFolderStorage().save(folder);
+            }
         }
-        String id = base;
-        int suffix = 2;
-        while (this.categories.containsKey(id)) {
-            id = base + "_" + suffix++;
-        }
-        return id;
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
@@ -286,11 +286,16 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
      */
     private void rehomeFolders(String deletedId) {
         NavigatorCategory fallback = getDefaultCategory();
-        for (Folder folder : plugin.getWorldService().getFolderStorage().getFolders()) {
+        var folderStorage = plugin.getWorldService().getFolderStorage();
+        List<Folder> rehomed = new ArrayList<>();
+        for (Folder folder : folderStorage.getFolders()) {
             if (folder.getCategory().getId().equals(deletedId)) {
                 ((FolderImpl) folder).setCategory(fallback);
-                plugin.getWorldService().getFolderStorage().save(folder);
+                rehomed.add(folder);
             }
+        }
+        if (!rehomed.isEmpty()) {
+            folderStorage.save(rehomed);
         }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/folder/FolderImpl.java
@@ -40,7 +40,7 @@ public class FolderImpl implements Folder {
     private String name;
     private final Builder creator;
     private final long creation;
-    private final NavigatorCategory category;
+    private NavigatorCategory category;
     private final List<UUID> worlds;
     private final List<Folder> subfolders;
 
@@ -167,6 +167,15 @@ public class FolderImpl implements Folder {
     @Override
     public NavigatorCategory getCategory() {
         return this.category;
+    }
+
+    /**
+     * Reassigns this folder to another {@link NavigatorCategory}. Not part of the public {@link Folder} API; used by the
+     * category registry to re-home folders when their category is deleted. Subfolders share their parent's category, so
+     * the whole subtree must be moved together to keep the parent-category invariant enforced by {@link #setParent}.
+     */
+    public void setCategory(NavigatorCategory category) {
+        this.category = category;
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/DisplayablesMenu.java
@@ -94,8 +94,9 @@ public abstract class DisplayablesMenu extends PaginatedMenu {
 
     /**
      * The configuration of a {@link DisplayablesMenu}: the {@link NavigatorCategory category} whose folders and worlds it lists,
-     * its title and "no worlds" message. A world is listed when {@link NavigatorCategoryRegistry#getCategoryForWorld(BuildWorld)}
-     * resolves to this category, so visibility and status filtering are derived from the category rather than passed separately.
+     * its title and "no worlds" message. A world is listed in this category when the category
+     * {@link NavigatorCategory#groups groups} the world's visibility and status, so a world shown by several overlapping
+     * categories appears in each; the filtering is derived from the category rather than passed separately.
      *
      * @param category The navigator category whose folders/worlds are listed
      * @param title The inventory title

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
@@ -27,6 +27,7 @@ import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.player.menu.SettingsMenu;
 import de.eintosti.buildsystem.util.color.ColorAPI;
+import java.util.List;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -62,9 +63,14 @@ public class NavigatorMenu extends ButtonMenu<MenuButton> {
 
     private MenuButton categoryButton(NavigatorCategory category) {
         return MenuButton.builder()
-                .render((player, inventory, slot) -> ItemBuilder.icon(category, player)
-                        .name(ColorAPI.process(category.getColor() + category.getDisplayName()))
-                        .into(inventory, slot))
+                .render((player, inventory, slot) -> plugin.getMenuItems()
+                        .renderCategoryIcon(
+                                inventory,
+                                slot,
+                                category,
+                                player,
+                                ColorAPI.process(category.getStyledName()),
+                                List.of()))
                 .onClick((player, event) -> {
                     new CategoryWorldsMenu(plugin, player, category).open(player);
                     XSound.ENTITY_CHICKEN_EGG.play(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -43,7 +43,9 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class StatusMenu extends ButtonMenu<MenuButton> {
 
-    private static final int FIRST_STATUS_SLOT = 10;
+    private static final int STATUSES_PER_ROW = 7;
+    private static final int MIN_ROWS = 3;
+    private static final int MAX_ROWS = 6;
 
     private final BuildSystemPlugin plugin;
     private final BuildWorld buildWorld;
@@ -59,9 +61,19 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
 
         List<BuildWorldStatus> statuses =
                 List.copyOf(plugin.getWorldStatusRegistry().getStatuses());
-        int slot = FIRST_STATUS_SLOT;
-        for (BuildWorldStatus status : statuses) {
-            register(slot++, statusButton(status));
+        // Lay the grid out row by row, keeping a one-slot border on every side. The six-row chest bounds capacity, so
+        // guard against placing a button outside the inventory (which would throw) when an admin has created a very
+        // large number of statuses.
+        int capacity = (rowCount(statuses.size()) - 2) * STATUSES_PER_ROW;
+        for (int index = 0; index < statuses.size() && index < capacity; index++) {
+            int slot = (index / STATUSES_PER_ROW + 1) * 9 + 1 + index % STATUSES_PER_ROW;
+            register(slot, statusButton(statuses.get(index)));
+        }
+        if (statuses.size() > capacity) {
+            plugin.getLogger()
+                    .warning(
+                            "StatusMenu can display at most %d statuses; %d are hidden. Reduce the number of statuses to reach them all."
+                                    .formatted(capacity, statuses.size() - capacity));
         }
     }
 
@@ -70,9 +82,16 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
      * side, clamped to the chest maximum of six rows.
      */
     private static int computeSize(BuildSystemPlugin plugin) {
-        int count = plugin.getWorldStatusRegistry().getStatuses().size();
-        int rows = Math.min(6, Math.max(3, 2 + (int) Math.ceil((count + 1) / 7.0)));
-        return rows * 9;
+        return rowCount(plugin.getWorldStatusRegistry().getStatuses().size()) * 9;
+    }
+
+    /**
+     * The inventory row count: one content row per {@value #STATUSES_PER_ROW} statuses plus a top and bottom border row,
+     * clamped between {@value #MIN_ROWS} and the six-row chest maximum.
+     */
+    private static int rowCount(int statusCount) {
+        int contentRows = Math.max(1, (int) Math.ceil(statusCount / (double) STATUSES_PER_ROW));
+        return Math.clamp(contentRows + 2, MIN_ROWS, MAX_ROWS);
     }
 
     private static String formatWorldName(BuildWorld buildWorld) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -44,8 +44,8 @@ import org.jspecify.annotations.NullMarked;
 public class StatusMenu extends ButtonMenu<MenuButton> {
 
     private static final int STATUSES_PER_ROW = 7;
-    private static final int MIN_ROWS = 3;
-    private static final int MAX_ROWS = 6;
+    private static final int BORDER_ROWS = 2; // one filler row above and below the grid
+    private static final int MAX_CONTENT_ROWS = 4; // the six-row chest minus the two border rows
 
     private final BuildSystemPlugin plugin;
     private final BuildWorld buildWorld;
@@ -64,7 +64,7 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
         // Lay the grid out row by row, keeping a one-slot border on every side. The six-row chest bounds capacity, so
         // guard against placing a button outside the inventory (which would throw) when an admin has created a very
         // large number of statuses.
-        int capacity = (rowCount(statuses.size()) - 2) * STATUSES_PER_ROW;
+        int capacity = contentRows(statuses.size()) * STATUSES_PER_ROW;
         for (int index = 0; index < statuses.size() && index < capacity; index++) {
             int slot = (index / STATUSES_PER_ROW + 1) * 9 + 1 + index % STATUSES_PER_ROW;
             register(slot, statusButton(statuses.get(index)));
@@ -82,16 +82,18 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
      * side, clamped to the chest maximum of six rows.
      */
     private static int computeSize(BuildSystemPlugin plugin) {
-        return rowCount(plugin.getWorldStatusRegistry().getStatuses().size()) * 9;
+        int rows = contentRows(plugin.getWorldStatusRegistry().getStatuses().size()) + BORDER_ROWS;
+        return rows * 9;
     }
 
     /**
-     * The inventory row count: one content row per {@value #STATUSES_PER_ROW} statuses plus a top and bottom border row,
-     * clamped between {@value #MIN_ROWS} and the six-row chest maximum.
+     * The number of grid rows the statuses occupy — one row per {@value #STATUSES_PER_ROW} statuses, at least one and
+     * clamped to {@value #MAX_CONTENT_ROWS} (the six-row chest minus the top and bottom border rows). Statuses beyond
+     * the resulting capacity are not shown.
      */
-    private static int rowCount(int statusCount) {
-        int contentRows = Math.max(1, (int) Math.ceil(statusCount / (double) STATUSES_PER_ROW));
-        return Math.clamp(contentRows + 2, MIN_ROWS, MAX_ROWS);
+    private static int contentRows(int statusCount) {
+        int rows = (int) Math.ceil(statusCount / (double) STATUSES_PER_ROW);
+        return Math.clamp(rows, 1, MAX_CONTENT_ROWS);
     }
 
     private static String formatWorldName(BuildWorld buildWorld) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryEditorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryEditorMenu.java
@@ -57,9 +57,7 @@ public class CategoryEditorMenu extends RegistryEditorMenu {
                         .getString(
                                 "setup_category_editor_title",
                                 player,
-                                Map.entry(
-                                        "%category%",
-                                        ColorAPI.process(category.getColor() + category.getDisplayName()))));
+                                Map.entry("%category%", ColorAPI.process(category.getStyledName()))));
 
         this.registry = plugin.getNavigatorCategoryRegistry();
         this.category = (NavigatorCategoryImpl) category;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
@@ -105,7 +105,7 @@ public class NavigatorLayoutMenu extends Menu {
                 continue;
             }
             ItemBuilder.icon(category, player)
-                    .name(ColorAPI.process(category.getColor() + category.getDisplayName()))
+                    .name(ColorAPI.process(category.getStyledName()))
                     .lore(messages.getStringList("setup_navigator_placed_lore", player))
                     .into(inventory, slot);
         }
@@ -140,7 +140,7 @@ public class NavigatorLayoutMenu extends Menu {
                 continue;
             }
             ItemBuilder.icon(category, player)
-                    .name(ColorAPI.process(category.getColor() + category.getDisplayName()))
+                    .name(ColorAPI.process(category.getStyledName()))
                     .lore(messages.getStringList("setup_navigator_palette_lore", player))
                     .into(playerInventory, slot);
         }
@@ -246,7 +246,15 @@ public class NavigatorLayoutMenu extends Menu {
     private void placeSettings(Player player, int slot) {
         NavigatorCategoryImpl occupant = categoryAtSlot(slot);
         if (occupant != null) {
-            occupant.setNavigatorSlot(registry.getSettingsSlot());
+            int previousSettingsSlot = registry.getSettingsSlot();
+            if (isSlotValid(previousSettingsSlot)) {
+                // Swap: the displaced category takes the slot the settings button just vacated.
+                occupant.setNavigatorSlot(previousSettingsSlot);
+            } else {
+                // Settings came from the palette (no slot to swap into); send the occupant to the palette rather than
+                // an invalid slot, which would hide it from the navigator entirely.
+                occupant.setShownInNavigator(false);
+            }
             registry.persist(occupant);
         }
         registry.setSettingsSlot(slot);
@@ -371,7 +379,7 @@ public class NavigatorLayoutMenu extends Menu {
         ItemStack cursor = category == null
                 ? null
                 : ItemBuilder.icon(category, player)
-                        .name(ColorAPI.process(category.getColor() + category.getDisplayName()))
+                        .name(ColorAPI.process(category.getStyledName()))
                         .build();
 
         setCursorNextTick(player, cursor);
@@ -427,8 +435,11 @@ public class NavigatorLayoutMenu extends Menu {
                 .filter(NavigatorCategory::isShownInNavigator)
                 .map(NavigatorCategory::getNavigatorSlot)
                 .collect(Collectors.toSet());
+        // The settings button holds a navigator slot too; never hand its slot out, or the category placed there is
+        // skipped by populate() and silently vanishes from the navigator.
+        int settingsSlot = registry.getSettingsSlot();
         for (int slot = 0; slot < NAVIGATOR_SIZE; slot++) {
-            if (!occupied.contains(slot)) {
+            if (slot != settingsSlot && !occupied.contains(slot)) {
                 return slot;
             }
         }

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
@@ -46,13 +46,13 @@ import org.jspecify.annotations.NullMarked;
 public final class TestData {
 
     public static final WorldStatusImpl NOT_STARTED =
-            status("not_started", "Not Started", "&c", 1, true, true, "in_progress");
-    public static final WorldStatusImpl IN_PROGRESS = status("in_progress", "In Progress", "&6", 2, true, true, null);
+            status("not_started", "Not Started", "&c", 1, true, "in_progress");
+    public static final WorldStatusImpl IN_PROGRESS = status("in_progress", "In Progress", "&6", 2, true, null);
     public static final WorldStatusImpl ALMOST_FINISHED =
-            status("almost_finished", "Almost Finished", "&a", 3, true, true, null);
-    public static final WorldStatusImpl FINISHED = status("finished", "Finished", "&2", 4, true, true, null);
-    public static final WorldStatusImpl ARCHIVE_STATUS = status("archive", "Archive", "&3", 5, false, true, null);
-    public static final WorldStatusImpl HIDDEN = status("hidden", "Hidden", "&7", 6, true, false, null);
+            status("almost_finished", "Almost Finished", "&a", 3, true, null);
+    public static final WorldStatusImpl FINISHED = status("finished", "Finished", "&2", 4, true, null);
+    public static final WorldStatusImpl ARCHIVE_STATUS = status("archive", "Archive", "&3", 5, false, null);
+    public static final WorldStatusImpl HIDDEN = status("hidden", "Hidden", "&7", 6, true, null);
 
     public static final List<WorldStatusImpl> STATUSES =
             List.of(NOT_STARTED, IN_PROGRESS, ALMOST_FINISHED, FINISHED, ARCHIVE_STATUS, HIDDEN);
@@ -84,13 +84,12 @@ public final class TestData {
     private TestData() {}
 
     private static WorldStatusImpl status(
-            String id, String name, String color, int order, boolean building, boolean nav, String progressesTo) {
+            String id, String name, String color, int order, boolean building, String progressesTo) {
         return WorldStatusImpl.builder(id)
                 .displayName(name)
                 .color(color)
                 .order(order)
                 .buildingAllowed(building)
-                .visibleInNavigator(nav)
                 .progressesTo(progressesTo)
                 .builtIn(true)
                 .build();


### PR DESCRIPTION
Follow-up to #474 (the dynamic world statuses & navigator categories feature, already on `master`). This is the 4.0.0 API-freeze polish plus the bug fixes and cleanup found while reviewing that work. It is exactly the delta on top of `master`, so it merges cleanly.

## Public API (freezing in 4.0.0)
- Stamp every `@since TODO` as `@since 4.0.0`.
- Document the compare-by-id equality contract on `BuildWorldStatus` / `NavigatorCategory` (they are interfaces now, so the enum-era `==` no longer holds).
- Add `NavigatorCategory#getStyledName()` to match `BuildWorldStatus`.
- `WorldStatusRegistry#getStatus` accepts `@Nullable`, matching `getCategory`.
- Remove the unused `BuildWorldStatus#isVisibleInNavigator()` — navigator visibility is decided by category membership.
- Record the `BuildWorld#asProfileable()` removal and correct the `isBuiltIn` / `getCategoryForWorld` docs.

## Fixes
- `StatusMenu`: lay the grid out row by row so a large status count can't overflow the inventory and throw.
- `NavigatorLayoutMenu`: never hand out the settings slot as free; don't strand a displaced category at slot -1.
- Re-home a deleted category's folders to the default so they (and the worlds inside them) stay reachable.
- Resolve navigator category heads off-thread instead of blocking the main thread on profile lookups.
- `PlaceholderAPI` `%status%` keeps its colour again.
- Derive custom-status permissions from the full id so two distinct ids can't collide.
- Handle legacy hex colour formats when migrating status display names.

## Cleanup
- Extract `StringUtils#uniqueId` (shared slug generator) and `ItemBuilder#categoryTexture` (shared default-texture rule).
- Batch the folder re-home into a single write; make content rows the single source for the `StatusMenu` grid math.

Adds the 4.0.0 `CHANGELOG.md`. Build + core tests pass.
