### PR TITLE
feat: per-world physics exceptions with fine-control menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ config toggles. `config.yml` and `messages.yml` migrate automatically.
 
 ### Added
 
+- **Per-world physics exceptions.** Physics control is no longer all-or-nothing:
+  while a world's physics are disabled, nine behavior categories (block updates,
+  connections, falling blocks, fluid flow, leaf decay, growth, spreading, block
+  forming, block fading) can individually be re-allowed. Right-click the physics
+  toggle in `/worlds edit` to open the exceptions menu (gated by the existing
+  `buildsystem.edit.physics`); values persist per world. The global
+  `world.disabled-physics` section is replaced by per-category defaults under
+  `world.defaults.physics-exceptions` (`true` = still runs while physics are
+  off); existing configs migrate automatically.
 - **Custom world statuses.** Statuses are no longer a fixed enum — admins create,
   restyle, reorder, and delete them in-game (`/setup` → World Statuses). Each
   status has its own name, colour, icon, ordering, a building-allowed flag, and an

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/PhysicsCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/PhysicsCategory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.api.world.data;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A group of world behavior that can individually be re-allowed while {@link WorldDataKey#PHYSICS} is disabled.
+ * Each category owns the {@link #key() key} storing its per-world value: {@code true} means the behavior still runs
+ * with physics disabled, {@code false} (the default) means it is blocked. While physics is enabled, the values are
+ * ignored and vanilla behavior applies.
+ *
+ * @since 4.0.0
+ */
+@NullMarked
+public enum PhysicsCategory {
+
+    /**
+     * Neighbor updates: attached blocks (torches, rails, …) popping off and block shape updates.
+     */
+    BLOCK_UPDATES("block-updates"),
+
+    /**
+     * Fences, gates, glass panes, stairs and walls connecting to adjacent blocks.
+     */
+    CONNECTIONS("connections"),
+
+    /**
+     * Gravity blocks (sand, gravel, …) falling.
+     */
+    FALLING_BLOCKS("falling-blocks"),
+
+    /**
+     * Water and lava flow.
+     */
+    FLUID_FLOW("fluid-flow"),
+
+    /**
+     * Leaves decaying.
+     */
+    LEAF_DECAY("leaf-decay"),
+
+    /**
+     * Crops and plants growing in place.
+     */
+    GROWTH("growth"),
+
+    /**
+     * Grass, vines, fire and similar blocks spreading to other blocks.
+     */
+    SPREADING("spreading"),
+
+    /**
+     * Snow, ice and similar blocks forming.
+     */
+    BLOCK_FORMING("block-forming"),
+
+    /**
+     * Ice and snow melting, corals dying and fire burning out.
+     */
+    BLOCK_FADING("block-fading");
+
+    private final WorldDataKey<Boolean> key;
+
+    PhysicsCategory(String id) {
+        this.key = WorldDataKey.of("physics-exceptions." + id, Boolean.class);
+    }
+
+    /**
+     * {@return the key storing whether this category still runs while physics is disabled}
+     */
+    public WorldDataKey<Boolean> key() {
+        return key;
+    }
+}

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldDataKey.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldDataKey.java
@@ -100,7 +100,8 @@ public final class WorldDataKey<T> {
     public static final WorldDataKey<Boolean> MOB_AI = of("mob-ai", Boolean.class);
 
     /**
-     * Whether block physics (gravity, fluid flow, …) is applied.
+     * Whether block physics (gravity, fluid flow, …) is applied. While disabled, individual behaviors can be
+     * re-allowed per {@link PhysicsCategory}.
      */
     public static final WorldDataKey<Boolean> PHYSICS = of("physics", Boolean.class);
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.config;
 import com.cryptomorin.xseries.XGameRule;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.world.menu.GameRuleEntry;
 import java.util.*;
 import java.util.logging.Logger;
@@ -146,11 +147,6 @@ public class ConfigService {
     }
 
     private static PluginConfig.World parseWorld(FileConfiguration config, Logger logger) {
-        PluginConfig.World.DisabledPhysics disabledPhysics = new PluginConfig.World.DisabledPhysics(
-                config.getBoolean("world.disabled-physics.prevent-connections", true),
-                config.getBoolean("world.disabled-physics.prevent-fluid-flow", true),
-                config.getBoolean("world.disabled-physics.prevent-falling-blocks", true));
-
         PluginConfig.World.Limits limits = new PluginConfig.World.Limits(
                 config.getInt("world.limits.public", -1), config.getInt("world.limits.private", -1));
 
@@ -169,6 +165,13 @@ public class ConfigService {
 
         List<GameRuleEntry<?>> gameRules = parseGameRules(config, logger);
 
+        Map<PhysicsCategory, Boolean> physicsExceptions = new EnumMap<>(PhysicsCategory.class);
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            physicsExceptions.put(
+                    category,
+                    config.getBoolean("world.defaults." + category.key().id(), false));
+        }
+
         PluginConfig.World.Defaults defaults = new PluginConfig.World.Defaults(
                 config.getInt("world.defaults.worldborder-size", 6000000),
                 Difficulty.valueOf(Objects.requireNonNullElse(config.getString("world.defaults.difficulty"), "PEACEFUL")
@@ -177,6 +180,7 @@ public class ConfigService {
                 permission,
                 time,
                 config.getBoolean("world.defaults.physics", true),
+                physicsExceptions,
                 config.getBoolean("world.defaults.explosions", true),
                 config.getBoolean("world.defaults.mob-ai", true),
                 config.getBoolean("world.defaults.block-breaking", true),
@@ -208,7 +212,6 @@ public class ConfigService {
                 Objects.requireNonNullElse(config.getString("world.invalid-characters"), "^\b$"),
                 config.getInt("world.import-all-delay", 30),
                 deletionBlacklist,
-                disabledPhysics,
                 limits,
                 defaults,
                 unload,

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -18,8 +18,10 @@
 package de.eintosti.buildsystem.config;
 
 import com.cryptomorin.xseries.XMaterial;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.world.menu.GameRuleEntry;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
@@ -58,7 +60,6 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
             String invalidCharacters,
             int importAllDelay,
             Set<String> deletionBlacklist,
-            DisabledPhysics disabledPhysics,
             Limits limits,
             Defaults defaults,
             Unload unload,
@@ -67,9 +68,6 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
         public World {
             deletionBlacklist = Set.copyOf(deletionBlacklist);
         }
-
-        public record DisabledPhysics(
-                boolean preventConnections, boolean preventFluidFlow, boolean preventFallingBlocks) {}
 
         public record Limits(int publicWorlds, int privateWorlds) {}
 
@@ -80,12 +78,26 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
                 Permission permission,
                 Time time,
                 boolean physics,
+                Map<PhysicsCategory, Boolean> physicsExceptions,
                 boolean explosions,
                 boolean mobAi,
                 boolean blockBreaking,
                 boolean blockPlacement,
                 boolean blockInteractions,
                 BuildersEnabled buildersEnabled) {
+
+            public Defaults {
+                physicsExceptions = Map.copyOf(physicsExceptions);
+            }
+
+            /**
+             * The default for a {@link PhysicsCategory} on worlds that have never stored their own value:
+             * {@code true} means the behavior still runs while the world's physics are disabled. Unlisted categories
+             * default to blocked, matching vanilla physics-off behavior.
+             */
+            public boolean physicsException(PhysicsCategory category) {
+                return physicsExceptions.getOrDefault(category, false);
+            }
 
             public record Permission(String publicPermission, String privatePermission) {}
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/ConfigMigrationManager.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/ConfigMigrationManager.java
@@ -31,7 +31,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class ConfigMigrationManager {
 
-    public static final int LATEST_VERSION = 3;
+    public static final int LATEST_VERSION = 4;
 
     private final BuildSystemPlugin plugin;
     private final Map<Integer, Migration> migrations;
@@ -47,6 +47,7 @@ public class ConfigMigrationManager {
 
         registerMigration(1, new MigrationV1ToV2());
         registerMigration(2, new MigrationV2ToV3());
+        registerMigration(3, new MigrationV3ToV4());
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.config.migration;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Migrates config from v3 to v4: {@code world.disabled-physics.prevent-*} becomes
+ * {@code world.defaults.physics-exceptions.*} with inverted sense — {@code prevent-x: true} meant the behavior was
+ * blocked while physics were disabled, {@code physics-exceptions.x: true} means it still runs. The values are now
+ * per-world defaults seeding the physics-exceptions world data, not live global switches.
+ */
+@NullMarked
+public class MigrationV3ToV4 implements Migration {
+
+    @Override
+    public void migrate(FileConfiguration config) {
+        invertIfPresent(
+                config, "world.disabled-physics.prevent-connections", "world.defaults.physics-exceptions.connections");
+        invertIfPresent(
+                config, "world.disabled-physics.prevent-fluid-flow", "world.defaults.physics-exceptions.fluid-flow");
+        invertIfPresent(
+                config,
+                "world.disabled-physics.prevent-falling-blocks",
+                "world.defaults.physics-exceptions.falling-blocks");
+        config.set("world.disabled-physics", null);
+    }
+
+    private static void invertIfPresent(FileConfiguration config, String from, String to) {
+        if (config.contains(from)) {
+            config.set(to, !config.getBoolean(from, true));
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/ListenerRegistrar.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/ListenerRegistrar.java
@@ -83,7 +83,7 @@ public final class ListenerRegistrar {
         register(new AsyncPlayerChatListener());
         register(new AsyncPlayerPreLoginListener(
                 playerService.getPlayerStorage(), spawnService, worldStorage, scheduler));
-        register(new BlockPhysicsListener(worldStorage, configService));
+        register(new BlockPhysicsListener(worldStorage));
         register(new BuildModePreventationListener(playerService, configService));
         register(new BuildWorldResetUnloadListener(worldStorage));
         register(new DisabledInteractionsListener(settingsService, worldStorage, configService));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListener.java
@@ -17,199 +17,138 @@
  */
 package de.eintosti.buildsystem.listener.world;
 
-import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
+import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
-import de.eintosti.buildsystem.config.ConfigService;
-import de.eintosti.buildsystem.util.DirectionUtil;
-import java.util.List;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.type.*;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.*;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.metadata.MetadataValue;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+/**
+ * Cancels physics-driven events in worlds whose {@link WorldDataKey#PHYSICS} setting is disabled, unless the world
+ * re-allows the event's {@link PhysicsCategory}. Explosions are only gated by the master setting; they are owned by
+ * {@link WorldDataKey#EXPLOSIONS} and have no category.
+ */
 @NullMarked
 public class BlockPhysicsListener implements Listener {
 
     private final WorldStorage worldStorage;
-    private final ConfigService configService;
 
-    public BlockPhysicsListener(WorldStorage worldStorage, ConfigService configService) {
+    public BlockPhysicsListener(WorldStorage worldStorage) {
         this.worldStorage = worldStorage;
-        this.configService = configService;
     }
 
-    private boolean physicsAllowed(World world) {
+    /**
+     * {@return the world's data when physics is disabled there, or {@code null} when physics applies normally}
+     */
+    private @Nullable WorldData physicsDisabledData(World world) {
         BuildWorld buildWorld = worldStorage.getBuildWorld(world);
-        return buildWorld == null || buildWorld.getData().get(WorldDataKey.PHYSICS);
+        if (buildWorld == null) {
+            return null;
+        }
+        WorldData data = buildWorld.getData();
+        return data.get(WorldDataKey.PHYSICS) ? null : data;
+    }
+
+    private boolean allows(World world, PhysicsCategory category) {
+        WorldData data = physicsDisabledData(world);
+        return data == null || data.get(category.key());
+    }
+
+    private <E extends BlockEvent & Cancellable> void cancelUnlessAllowed(E event, PhysicsCategory category) {
+        if (!allows(event.getBlock().getWorld(), category)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onLeavesDecay(LeavesDecayEvent event) {
+        cancelUnlessAllowed(event, PhysicsCategory.LEAF_DECAY);
+    }
+
+    @EventHandler
+    public void onBlockFade(BlockFadeEvent event) {
+        cancelUnlessAllowed(event, PhysicsCategory.BLOCK_FADING);
+    }
+
+    @EventHandler
+    public void onBlockForm(BlockFormEvent event) {
+        cancelUnlessAllowed(event, PhysicsCategory.BLOCK_FORMING);
+    }
+
+    @EventHandler
+    public void onBlockGrow(BlockGrowEvent event) {
+        cancelUnlessAllowed(event, PhysicsCategory.GROWTH);
+    }
+
+    @EventHandler
+    public void onBlockSpread(BlockSpreadEvent event) {
+        cancelUnlessAllowed(event, PhysicsCategory.SPREADING);
     }
 
     @EventHandler
     public void onBlockPhysics(BlockPhysicsEvent event) {
         Block block = event.getBlock();
-        if (physicsAllowed(block.getWorld())) {
+        WorldData data = physicsDisabledData(block.getWorld());
+        if (data == null || data.get(PhysicsCategory.BLOCK_UPDATES.key())) {
             return;
         }
 
-        if (!configService.current().world().disabledPhysics().preventConnections()) {
-            boolean canConnect =
-                    switch (block.getBlockData()) {
-                        case Fence fence -> true;
-                        case Gate gate -> true;
-                        case GlassPane glassPane -> true;
-                        case Stairs stairs -> true;
-                        case Wall wall -> true;
-                        default -> false;
-                    };
-            if (canConnect) {
-                event.setCancelled(false);
-                return;
-            }
-        }
-
-        switch (XMaterial.matchXMaterial(block.getType())) {
-            case REDSTONE_BLOCK -> {
-                for (BlockFace blockFace : DirectionUtil.BLOCK_SIDES) {
-                    if (isCustomRedstoneLamp(block.getRelative(blockFace))) {
-                        event.setCancelled(false);
-                        return;
-                    }
-                }
-            }
-            case REDSTONE_LAMP -> {
-                for (BlockFace blockFace : DirectionUtil.BLOCK_SIDES) {
-                    if (block.getRelative(blockFace).getType() == XMaterial.REDSTONE_BLOCK.get()) {
-                        event.setCancelled(false);
-                        return;
-                    }
-                }
-            }
-        }
-
-        event.setCancelled(true);
+        boolean connects = data.get(PhysicsCategory.CONNECTIONS.key()) && canConnect(block);
+        event.setCancelled(!connects);
     }
 
-    @EventHandler
-    public void onLeavesDecay(LeavesDecayEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
-        }
-        event.setCancelled(true);
-    }
-
-    @EventHandler
-    public void onBlockFade(BlockFadeEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
-        }
-        event.setCancelled(true);
-    }
-
-    @EventHandler
-    public void onBlockForm(BlockFormEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
-        }
-        event.setCancelled(true);
+    private static boolean canConnect(Block block) {
+        return switch (block.getBlockData()) {
+            case Fence _, Gate _, GlassPane _, Stairs _, Wall _ -> true;
+            default -> false;
+        };
     }
 
     @EventHandler
     public void onBlockFromTo(BlockFromToEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
+        WorldData data = physicsDisabledData(event.getBlock().getWorld());
+        if (data == null) {
             return;
         }
 
-        if (event.getBlock().isLiquid()
-                && !configService.current().world().disabledPhysics().preventFluidFlow()) {
-            event.setCancelled(false);
-            return;
-        }
-
-        event.setCancelled(true);
-    }
-
-    @EventHandler
-    public void onBlockGrow(BlockGrowEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
-        }
-        event.setCancelled(true);
-    }
-
-    @EventHandler
-    public void onBlockSpread(BlockSpreadEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
-        }
-        event.setCancelled(true);
+        boolean flows = event.getBlock().isLiquid() && data.get(PhysicsCategory.FLUID_FLOW.key());
+        event.setCancelled(!flows);
     }
 
     @EventHandler
     public void onEntityChangeBlock(EntityChangeBlockEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
+        if (event.getEntityType() != EntityType.FALLING_BLOCK
+                || allows(event.getBlock().getWorld(), PhysicsCategory.FALLING_BLOCKS)) {
             return;
         }
-
-        if (event.getEntityType() == EntityType.FALLING_BLOCK
-                && configService.current().world().disabledPhysics().preventFallingBlocks()) {
-            event.setCancelled(true);
-            event.getBlock().getState().update(false, false);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST)
-    public void onBlockRedstone(BlockRedstoneEvent event) {
-        Block block = event.getBlock();
-        if (isCustomRedstoneLamp(block)) {
-            event.setNewCurrent(15);
-        }
-
-        XMaterial xMaterial = XMaterial.matchXMaterial(block.getType());
-        if (xMaterial != XMaterial.REDSTONE_BLOCK) {
-            return;
-        }
-
-        for (BlockFace blockFace : DirectionUtil.BLOCK_SIDES) {
-            if (isCustomRedstoneLamp(block.getRelative(blockFace))) {
-                event.setNewCurrent(15);
-            }
-        }
+        event.setCancelled(true);
+        event.getBlock().getState().update(false, false);
     }
 
     @EventHandler
     public void onBlockExplode(BlockExplodeEvent event) {
-        if (physicsAllowed(event.getBlock().getWorld())) {
-            return;
+        if (physicsDisabledData(event.getBlock().getWorld()) != null) {
+            event.setCancelled(true);
         }
-        event.setCancelled(true);
     }
 
     @EventHandler
     public void onEntityExplode(EntityExplodeEvent event) {
         World world = event.getLocation().getWorld();
-        if (world == null || physicsAllowed(world)) {
-            return;
+        if (world != null && physicsDisabledData(world) != null) {
+            event.setCancelled(true);
         }
-        event.setCancelled(true);
-    }
-
-    private boolean isCustomRedstoneLamp(Block block) {
-        List<MetadataValue> metadataValues = block.getMetadata("CustomRedstoneLamp");
-        for (MetadataValue value : metadataValues) {
-            if (value.asBoolean()) {
-                return true;
-            }
-        }
-        return block.getType().name().equals("REDSTONE_LAMP_ON");
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/Menus.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/Menus.java
@@ -46,6 +46,7 @@ import de.eintosti.buildsystem.world.menu.EditMenu;
 import de.eintosti.buildsystem.world.menu.FolderContentMenu;
 import de.eintosti.buildsystem.world.menu.GameRulesMenu;
 import de.eintosti.buildsystem.world.menu.NavigatorMenu;
+import de.eintosti.buildsystem.world.menu.PhysicsMenu;
 import de.eintosti.buildsystem.world.menu.SetupMenu;
 import de.eintosti.buildsystem.world.menu.StatusMenu;
 import de.eintosti.buildsystem.world.menu.setup.CategoryEditorMenu;
@@ -237,6 +238,10 @@ public final class Menus {
     public void openGameRules(BuildWorld buildWorld, Player player) {
         new GameRulesMenu(services.messages(), services.menuItems(), plugin.getLogger(), this, buildWorld, player)
                 .open(player);
+    }
+
+    public void openPhysics(BuildWorld buildWorld, Player player) {
+        new PhysicsMenu(services.messages(), services.menuItems(), this, buildWorld, player).open(player);
     }
 
     public void openMaterialPicker(Player player, Consumer<XMaterial> onPick, Runnable onBack) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
@@ -23,9 +23,11 @@ import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.api.world.data.WorldStatusRegistry;
+import de.eintosti.buildsystem.config.PluginConfig;
 import de.eintosti.buildsystem.player.PlayerLookupService;
 import de.eintosti.buildsystem.world.BuildWorldImpl;
 import de.eintosti.buildsystem.world.WorldContext;
@@ -38,7 +40,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.bukkit.Difficulty;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jspecify.annotations.NullMarked;
@@ -103,10 +104,26 @@ public final class WorldCodec implements Codec<BuildWorld> {
         return world;
     }
 
-    private Map<String, Object> serializeWorldData(WorldDataImpl worldData) {
-        return worldData.getAllData().entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, entry -> entry.getValue().getConfigFormat()));
+    /**
+     * Serializes the property map, splitting dotted key ids (e.g. {@code physics-exceptions.fluid-flow}) into nested
+     * maps. The storage writes this map verbatim via {@code config.set}, which does not interpret dots inside map
+     * keys, so the nesting has to happen here for the file to gain real sections. Ids nest one section level deep,
+     * which is all the catalog uses.
+     */
+    private Map<String, @Nullable Object> serializeWorldData(WorldDataImpl worldData) {
+        Map<String, @Nullable Object> data = new HashMap<>();
+        Map<String, Map<String, @Nullable Object>> sections = new HashMap<>();
+        worldData.getAllData().forEach((id, property) -> {
+            int dot = id.indexOf('.');
+            if (dot < 0) {
+                data.put(id, property.getConfigFormat());
+                return;
+            }
+            sections.computeIfAbsent(id.substring(0, dot), section -> new HashMap<>())
+                    .put(id.substring(dot + 1), property.getConfigFormat());
+        });
+        data.putAll(sections);
+        return data;
     }
 
     @Override
@@ -138,7 +155,7 @@ public final class WorldCodec implements Codec<BuildWorld> {
     }
 
     private WorldDataImpl parseWorldData(String worldName, ConfigurationSection section) {
-        return new WorldDataBuilder(worldName)
+        WorldDataBuilder builder = new WorldDataBuilder(worldName)
                 .withCustomSpawn(parseCustomSpawn(section))
                 .withPermission(section.getString(dataPath(WorldDataKey.PERMISSION), "-"))
                 .withProject(section.getString(dataPath(WorldDataKey.PROJECT), "-"))
@@ -168,8 +185,14 @@ public final class WorldCodec implements Codec<BuildWorld> {
                 .withPermissionOverrideEnabled(
                         () -> context.configService().current().folder().overridePermissions())
                 .withProjectOverrideEnabled(
-                        () -> context.configService().current().folder().overrideProjects())
-                .build();
+                        () -> context.configService().current().folder().overrideProjects());
+        PluginConfig.World.Defaults defaults =
+                context.configService().current().world().defaults();
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            builder.withPhysicsCategory(
+                    category, section.getBoolean(dataPath(category.key()), defaults.physicsException(category)));
+        }
+        return builder.build();
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -26,6 +26,7 @@ import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
@@ -108,7 +109,7 @@ public final class BuildWorldImpl implements BuildWorld {
         boolean buildersEnabled = privateWorld
                 ? defaults.buildersEnabled().privateBuilders()
                 : defaults.buildersEnabled().publicBuilders();
-        return new WorldDataBuilder(name)
+        WorldDataBuilder builder = new WorldDataBuilder(name)
                 .withVisibility(Visibility.matchVisibility(privateWorld))
                 .withStatus(context.statusRegistry().getDefaultStatus())
                 .withMaterial(
@@ -127,8 +128,11 @@ public final class BuildWorldImpl implements BuildWorld {
                 .withPermissionOverrideEnabled(
                         () -> context.configService().current().folder().overridePermissions())
                 .withProjectOverrideEnabled(
-                        () -> context.configService().current().folder().overrideProjects())
-                .build();
+                        () -> context.configService().current().folder().overrideProjects());
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            builder.withPhysicsCategory(category, defaults.physicsException(category));
+        }
+        return builder.build();
     }
 
     public BuildWorldImpl(

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.world.data;
 
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
@@ -28,6 +29,7 @@ import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import de.eintosti.buildsystem.world.data.type.Overridable;
 import de.eintosti.buildsystem.world.data.type.PersistentProperty;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -58,6 +60,14 @@ public class WorldDataImpl implements WorldData {
     public static final boolean DEFAULT_EXPLOSIONS = true;
     public static final boolean DEFAULT_MOB_AI = true;
     public static final boolean DEFAULT_PHYSICS = true;
+
+    /**
+     * Unlike the other defaults, the {@link PhysicsCategory} values are seeded from the
+     * {@code world.defaults.physics-exceptions} config section at both creation and deserialization; this constant is
+     * only the fallback for builders that were never seeded.
+     */
+    public static final boolean DEFAULT_PHYSICS_CATEGORY = false;
+
     public static final boolean DEFAULT_PINNED = false;
     public static final int DEFAULT_TIME_SINCE_BACKUP = 0;
 
@@ -106,6 +116,12 @@ public class WorldDataImpl implements WorldData {
         register(WorldDataKey.EXPLOSIONS, new ConfigurableProperty<>(builder.explosions));
         register(WorldDataKey.MOB_AI, new ConfigurableProperty<>(builder.mobAi));
         register(WorldDataKey.PHYSICS, new ConfigurableProperty<>(builder.physics));
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            register(
+                    category.key(),
+                    new ConfigurableProperty<>(
+                            builder.physicsCategories.getOrDefault(category, DEFAULT_PHYSICS_CATEGORY)));
+        }
         register(WorldDataKey.PINNED, new ConfigurableProperty<>(builder.pinned));
         register(
                 WorldDataKey.VISIBILITY,
@@ -204,6 +220,7 @@ public class WorldDataImpl implements WorldData {
         private boolean explosions = DEFAULT_EXPLOSIONS;
         private boolean mobAi = DEFAULT_MOB_AI;
         private boolean physics = DEFAULT_PHYSICS;
+        private final Map<PhysicsCategory, Boolean> physicsCategories = new EnumMap<>(PhysicsCategory.class);
         private boolean pinned = DEFAULT_PINNED;
         private Visibility visibility = Visibility.EVERYONE;
         private int timeSinceBackup = DEFAULT_TIME_SINCE_BACKUP;
@@ -299,6 +316,11 @@ public class WorldDataImpl implements WorldData {
 
         public WorldDataBuilder withPhysics(boolean physics) {
             this.physics = physics;
+            return this;
+        }
+
+        public WorldDataBuilder withPhysicsCategory(PhysicsCategory category, boolean allowed) {
+            this.physicsCategories.put(category, allowed);
             return this;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -52,6 +52,7 @@ import org.jspecify.annotations.Nullable;
 public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
 
     private static final int SLOT_WORLD_INFO = 3;
+    private static final int SLOT_PHYSICS = 22;
     private static final int SLOT_TIME = 23;
     private static final int SLOT_BUTCHER = 29;
     private static final int SLOT_BUILDERS = 30;
@@ -233,6 +234,22 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                                 removeEntities(player);
                             }
                         })
+                        .build());
+
+        register(
+                SLOT_PHYSICS,
+                EditButton.builder()
+                        .permission("buildsystem.edit.physics")
+                        .outcome(ClickOutcome.REOPEN)
+                        .render((player, inventory) -> menuItems.addToggleItem(
+                                player,
+                                inventory,
+                                SLOT_PHYSICS,
+                                XMaterial.SAND,
+                                buildWorld.getData().get(WorldDataKey.PHYSICS),
+                                "worldeditor_physics_item",
+                                "worldeditor_physics_lore"))
+                        .onClick(this::onPhysicsClick)
                         .build());
 
         register(
@@ -534,6 +551,25 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         }
 
         super.handleClick(event);
+    }
+
+    /**
+     * The physics button is dual-action: a left-click flips the master physics flag and re-opens, a right-click opens
+     * the {@link PhysicsMenu} with the per-category exceptions.
+     */
+    private void onPhysicsClick(Player player, InventoryClickEvent event) {
+        if (!requirePermission(player, "buildsystem.edit.physics")) {
+            return;
+        }
+        if (event.isRightClick()) {
+            XSound.BLOCK_CHEST_OPEN.play(player);
+            menus.openPhysics(buildWorld, player);
+            return;
+        }
+
+        WorldData worldData = buildWorld.getData();
+        worldData.set(WorldDataKey.PHYSICS, !worldData.get(WorldDataKey.PHYSICS));
+        reopen(player);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenuToggles.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenuToggles.java
@@ -66,14 +66,6 @@ final class EditMenuToggles {
                             "worldeditor_blockplacement_lore",
                             WorldDataKey.BLOCK_PLACEMENT)),
             entry(
-                    22,
-                    new Toggle(
-                            XMaterial.SAND,
-                            "buildsystem.edit.physics",
-                            "worldeditor_physics_item",
-                            "worldeditor_physics_lore",
-                            WorldDataKey.PHYSICS)),
-            entry(
                     24,
                     new Toggle(
                             XMaterial.TNT,

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.menu;
+
+import static java.util.Map.entry;
+
+import com.cryptomorin.xseries.XMaterial;
+import com.cryptomorin.xseries.XSound;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
+import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.ButtonMenu;
+import de.eintosti.buildsystem.menu.MenuButton;
+import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.world.menu.EditMenuToggles.Toggle;
+import java.util.HashMap;
+import java.util.Map;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The physics fine-control menu, reached by right-clicking the physics toggle in the {@link EditMenu}: the master
+ * physics switch plus one toggle per {@link PhysicsCategory} exception that still runs while physics is disabled.
+ * Every toggle is gated by the same {@code buildsystem.edit.physics} permission as the editor's physics button.
+ */
+@NullMarked
+public class PhysicsMenu extends ButtonMenu<MenuButton> {
+
+    private static final String PERMISSION = "buildsystem.edit.physics";
+
+    private static final int MENU_SIZE = 45;
+    private static final int SLOT_MASTER = 4;
+
+    private static final Toggle MASTER_TOGGLE = new Toggle(
+            XMaterial.SAND,
+            PERMISSION,
+            "worldeditor_physics_master_item",
+            "worldeditor_physics_master_lore",
+            WorldDataKey.PHYSICS);
+
+    private static final Map<Integer, Toggle> CATEGORY_TOGGLES = Map.ofEntries(
+            entry(12, categoryToggle(XMaterial.OBSERVER, "blockupdates", PhysicsCategory.BLOCK_UPDATES)),
+            entry(13, categoryToggle(XMaterial.OAK_FENCE, "connections", PhysicsCategory.CONNECTIONS)),
+            entry(14, categoryToggle(XMaterial.GRAVEL, "fallingblocks", PhysicsCategory.FALLING_BLOCKS)),
+            entry(21, categoryToggle(XMaterial.WATER_BUCKET, "fluidflow", PhysicsCategory.FLUID_FLOW)),
+            entry(22, categoryToggle(XMaterial.OAK_LEAVES, "leafdecay", PhysicsCategory.LEAF_DECAY)),
+            entry(23, categoryToggle(XMaterial.WHEAT, "growth", PhysicsCategory.GROWTH)),
+            entry(30, categoryToggle(XMaterial.VINE, "spreading", PhysicsCategory.SPREADING)),
+            entry(31, categoryToggle(XMaterial.SNOW_BLOCK, "blockforming", PhysicsCategory.BLOCK_FORMING)),
+            entry(32, categoryToggle(XMaterial.ICE, "blockfading", PhysicsCategory.BLOCK_FADING)));
+
+    private final MenuItems menuItems;
+    private final Menus menus;
+    private final BuildWorld buildWorld;
+
+    public PhysicsMenu(Messages messages, MenuItems menuItems, Menus menus, BuildWorld buildWorld, Player player) {
+        super(messages, MENU_SIZE, messages.getString("worldeditor_physics_title", player));
+        this.menuItems = menuItems;
+        this.menus = menus;
+        this.buildWorld = buildWorld;
+
+        register(SLOT_MASTER, toggleButton(MASTER_TOGGLE));
+        CATEGORY_TOGGLES.forEach((slot, toggle) -> register(slot, toggleButton(toggle)));
+    }
+
+    private static Toggle categoryToggle(XMaterial material, String messageName, PhysicsCategory category) {
+        return new Toggle(
+                material,
+                PERMISSION,
+                "worldeditor_physics_" + messageName + "_item",
+                "worldeditor_physics_" + messageName + "_lore",
+                category.key());
+    }
+
+    private MenuButton toggleButton(Toggle toggle) {
+        return MenuButton.builder()
+                .render((player, inventory, slot) ->
+                        toggle.render(menuItems, buildWorld.getData(), player, inventory, slot))
+                .onClick((player, event) -> {
+                    if (requirePermission(player, PERMISSION)) {
+                        toggle.flip(buildWorld.getData());
+                        XSound.ENTITY_CHICKEN_EGG.play(player);
+                    }
+                    populate(player);
+                })
+                .build();
+    }
+
+    @Override
+    protected void populate(Player player) {
+        for (int i = 0; i < MENU_SIZE; i++) {
+            if (i != SLOT_MASTER && !CATEGORY_TOGGLES.containsKey(i)) {
+                menuItems.addGlassPane(player, getInventory(), i);
+            }
+        }
+        renderButtons(player);
+    }
+
+    @Override
+    protected void onUnhandledClick(Player player, InventoryClickEvent event) {
+        // Only the menu's own slots return to the editor; clicks in the player inventory are ignored.
+        if (event.getRawSlot() < 0 || event.getRawSlot() >= getInventory().getSize()) {
+            return;
+        }
+        XSound.BLOCK_CHEST_OPEN.play(player);
+        menus.openEdit(buildWorld, player);
+    }
+
+    /**
+     * {@return the slot &rarr; world-data key mapping this menu toggles} Exposed for the golden layout test.
+     */
+    Map<Integer, WorldDataKey<Boolean>> keyBySlot() {
+        Map<Integer, WorldDataKey<Boolean>> keys = new HashMap<>();
+        keys.put(SLOT_MASTER, MASTER_TOGGLE.key());
+        CATEGORY_TOGGLES.forEach((slot, toggle) -> keys.put(slot, toggle.key()));
+        return keys;
+    }
+}

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -33,10 +33,6 @@ world:
     - world
     - world_nether
     - world_the_end
-  disabled-physics:
-    prevent-connections: true
-    prevent-fluid-flow: true
-    prevent-falling-blocks: true
   limits:
     public: -1
     private: -1
@@ -58,6 +54,17 @@ world:
       public: false
       private: true
     physics: true
+    # Behaviors that still run while a world's physics are disabled.
+    physics-exceptions:
+      block-updates: false
+      connections: false
+      falling-blocks: false
+      fluid-flow: false
+      leaf-decay: false
+      growth: false
+      spreading: false
+      block-forming: false
+      block-fading: false
     explosions: true
     mob-ai: true
     block-breaking: true

--- a/buildsystem-core/src/main/resources/messages.yml
+++ b/buildsystem-core/src/main/resources/messages.yml
@@ -841,6 +841,52 @@ worldeditor_physics_item: "&bBlock Physics"
 worldeditor_physics_lore:
   - "&7Toggle whether or not block"
   - "&7physics are activated."
+  - "&8» &7&oRight-click to manage exceptions"
+
+worldeditor_physics_title: "&3Physics Exceptions"
+worldeditor_physics_master_item: "&bBlock Physics"
+worldeditor_physics_master_lore:
+  - "&7The master switch. While disabled,"
+  - "&7only the exceptions below still run."
+worldeditor_physics_blockupdates_item: "&bBlock Updates"
+worldeditor_physics_blockupdates_lore:
+  - "&7Neighbor updates, e.g. torches"
+  - "&7and rails popping off, while"
+  - "&7physics are deactivated."
+worldeditor_physics_connections_item: "&bConnections"
+worldeditor_physics_connections_lore:
+  - "&7Fences, panes, stairs and walls"
+  - "&7connecting to adjacent blocks while"
+  - "&7physics are deactivated."
+worldeditor_physics_fallingblocks_item: "&bFalling Blocks"
+worldeditor_physics_fallingblocks_lore:
+  - "&7Sand, gravel and other gravity"
+  - "&7blocks falling while physics"
+  - "&7are deactivated."
+worldeditor_physics_fluidflow_item: "&bFluid Flow"
+worldeditor_physics_fluidflow_lore:
+  - "&7Water and lava flowing while"
+  - "&7physics are deactivated."
+worldeditor_physics_leafdecay_item: "&bLeaf Decay"
+worldeditor_physics_leafdecay_lore:
+  - "&7Leaves decaying while physics"
+  - "&7are deactivated."
+worldeditor_physics_growth_item: "&bGrowth"
+worldeditor_physics_growth_lore:
+  - "&7Crops and plants growing while"
+  - "&7physics are deactivated."
+worldeditor_physics_spreading_item: "&bSpreading"
+worldeditor_physics_spreading_lore:
+  - "&7Grass, vines and fire spreading"
+  - "&7while physics are deactivated."
+worldeditor_physics_blockforming_item: "&bBlock Forming"
+worldeditor_physics_blockforming_lore:
+  - "&7Snow and ice forming while"
+  - "&7physics are deactivated."
+worldeditor_physics_blockfading_item: "&bBlock Fading"
+worldeditor_physics_blockfading_lore:
+  - "&7Ice and snow melting and corals"
+  - "&7dying while physics are deactivated."
 
 worldeditor_pin_item: "&bPinned"
 worldeditor_pin_lore:

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.config;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.cryptomorin.xseries.XMaterial;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import java.util.logging.Logger;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,30 @@ class PluginConfigTest {
         assertFalse(cfg.folder().overrideProjects());
     }
 
+    @Test
+    void physicsExceptions_default_toAllBlocked() {
+        PluginConfig cfg = parse("");
+
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            assertFalse(cfg.world().defaults().physicsException(category), category + " should default to blocked");
+        }
+    }
+
+    @Test
+    void physicsExceptions_configuredValues_areParsed() {
+        PluginConfig cfg = parse("""
+                world:
+                  defaults:
+                    physics-exceptions:
+                      fluid-flow: true
+                      leaf-decay: true
+                """);
+
+        assertTrue(cfg.world().defaults().physicsException(PhysicsCategory.FLUID_FLOW));
+        assertTrue(cfg.world().defaults().physicsException(PhysicsCategory.LEAF_DECAY));
+        assertFalse(cfg.world().defaults().physicsException(PhysicsCategory.CONNECTIONS));
+    }
+
     // -----------------------------------------------------------------------
     // 2. Full parse: representative config produces expected record values
     // -----------------------------------------------------------------------
@@ -113,10 +138,6 @@ class PluginConfigTest {
                   import-all-delay: 60
                   deletion-blacklist:
                     - world
-                  disabled-physics:
-                    prevent-connections: false
-                    prevent-fluid-flow: false
-                    prevent-falling-blocks: false
                   limits:
                     public: 5
                     private: 3
@@ -129,6 +150,8 @@ class PluginConfigTest {
                       night: 18100
                     gamerules: {}
                     physics: false
+                    physics-exceptions:
+                      fluid-flow: true
                     explosions: false
                     mob-ai: false
                     block-breaking: false
@@ -183,6 +206,8 @@ class PluginConfigTest {
         assertEquals(6100, cfg.world().defaults().time().noon());
         assertEquals(18100, cfg.world().defaults().time().night());
         assertFalse(cfg.world().defaults().physics());
+        assertTrue(cfg.world().defaults().physicsException(PhysicsCategory.FLUID_FLOW));
+        assertFalse(cfg.world().defaults().physicsException(PhysicsCategory.LEAF_DECAY));
         assertFalse(cfg.world().defaults().explosions());
         assertFalse(cfg.world().defaults().mobAi());
         assertFalse(cfg.world().defaults().blockBreaking());

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/migration/MigrationV3ToV4Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.config.migration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+
+class MigrationV3ToV4Test {
+
+    @Test
+    void migrate_disabledPhysics_becomesInvertedPhysicsExceptions() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("world.disabled-physics.prevent-connections", true);
+        config.set("world.disabled-physics.prevent-fluid-flow", false);
+        config.set("world.disabled-physics.prevent-falling-blocks", true);
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertFalse(config.getBoolean("world.defaults.physics-exceptions.connections"));
+        assertTrue(config.getBoolean("world.defaults.physics-exceptions.fluid-flow"));
+        assertFalse(config.getBoolean("world.defaults.physics-exceptions.falling-blocks"));
+        assertNull(config.get("world.disabled-physics"));
+    }
+
+    @Test
+    void migrate_missingSection_writesNothing() {
+        YamlConfiguration config = new YamlConfiguration();
+
+        new MigrationV3ToV4().migrate(config);
+
+        assertNull(config.get("world.defaults.physics-exceptions"));
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListenerTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/listener/world/BlockPhysicsListenerTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.listener.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.eintosti.buildsystem.api.storage.WorldStorage;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
+import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.test.TestData;
+import de.eintosti.buildsystem.world.data.WorldDataImpl;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Fence;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.block.BlockFadeEvent;
+import org.bukkit.event.block.BlockFormEvent;
+import org.bukkit.event.block.BlockFromToEvent;
+import org.bukkit.event.block.BlockGrowEvent;
+import org.bukkit.event.block.BlockPhysicsEvent;
+import org.bukkit.event.block.BlockSpreadEvent;
+import org.bukkit.event.block.LeavesDecayEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the master-and-exceptions gate of {@link BlockPhysicsListener}: physics enabled leaves events alone,
+ * physics disabled cancels them, and a re-allowed {@link PhysicsCategory} exempts exactly its event family.
+ */
+@NullMarked
+class BlockPhysicsListenerTest {
+
+    private final World world = mock(World.class);
+
+    private WorldDataImpl data;
+    private BlockPhysicsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        data = new WorldDataImpl.WorldDataBuilder("world")
+                .withStatus(TestData.NOT_STARTED)
+                .build();
+        BuildWorld buildWorld = mock(BuildWorld.class);
+        when(buildWorld.getData()).thenReturn(data);
+        WorldStorage worldStorage = mock(WorldStorage.class);
+        when(worldStorage.getBuildWorld(world)).thenReturn(buildWorld);
+        listener = new BlockPhysicsListener(worldStorage);
+    }
+
+    private Block block() {
+        Block block = mock(Block.class);
+        when(block.getWorld()).thenReturn(world);
+        return block;
+    }
+
+    /**
+     * Runs the three gate states against fresh events: physics on (not cancelled), physics off (cancelled), physics
+     * off with the category re-allowed (not cancelled).
+     */
+    private <E extends Cancellable> void assertCategoryGate(
+            Supplier<E> eventFactory, Consumer<E> handler, PhysicsCategory category) {
+        E event = eventFactory.get();
+        handler.accept(event);
+        assertFalse(event.isCancelled(), category + ": enabled physics must not cancel");
+
+        data.set(WorldDataKey.PHYSICS, false);
+        event = eventFactory.get();
+        handler.accept(event);
+        assertTrue(event.isCancelled(), category + ": disabled physics must cancel");
+
+        data.set(category.key(), true);
+        event = eventFactory.get();
+        handler.accept(event);
+        assertFalse(event.isCancelled(), category + ": re-allowed category must not cancel");
+    }
+
+    @Test
+    void leavesDecay_gatedByLeafDecayCategory() {
+        assertCategoryGate(() -> new LeavesDecayEvent(block()), listener::onLeavesDecay, PhysicsCategory.LEAF_DECAY);
+    }
+
+    @Test
+    void blockFade_gatedByBlockFadingCategory() {
+        assertCategoryGate(
+                () -> new BlockFadeEvent(block(), mock(BlockState.class)),
+                listener::onBlockFade,
+                PhysicsCategory.BLOCK_FADING);
+    }
+
+    @Test
+    void blockForm_gatedByBlockFormingCategory() {
+        assertCategoryGate(
+                () -> new BlockFormEvent(block(), mock(BlockState.class)),
+                listener::onBlockForm,
+                PhysicsCategory.BLOCK_FORMING);
+    }
+
+    @Test
+    void blockGrow_gatedByGrowthCategory() {
+        assertCategoryGate(
+                () -> new BlockGrowEvent(block(), mock(BlockState.class)),
+                listener::onBlockGrow,
+                PhysicsCategory.GROWTH);
+    }
+
+    @Test
+    void blockSpread_gatedBySpreadingCategory() {
+        assertCategoryGate(
+                () -> new BlockSpreadEvent(block(), block(), mock(BlockState.class)),
+                listener::onBlockSpread,
+                PhysicsCategory.SPREADING);
+    }
+
+    @Test
+    void blockPhysics_gatedByBlockUpdatesCategory() {
+        assertCategoryGate(
+                () -> {
+                    Block block = block();
+                    when(block.getBlockData()).thenReturn(mock(BlockData.class));
+                    return new BlockPhysicsEvent(block, mock(BlockData.class));
+                },
+                listener::onBlockPhysics,
+                PhysicsCategory.BLOCK_UPDATES);
+    }
+
+    @Test
+    void blockPhysics_connectionsCategoryKeepsConnectableBlocksUpdating() {
+        data.set(WorldDataKey.PHYSICS, false);
+        Block fence = block();
+        when(fence.getBlockData()).thenReturn(mock(Fence.class));
+
+        BlockPhysicsEvent event = new BlockPhysicsEvent(fence, mock(BlockData.class));
+        listener.onBlockPhysics(event);
+        assertTrue(event.isCancelled(), "connections blocked must cancel fence updates");
+
+        data.set(PhysicsCategory.CONNECTIONS.key(), true);
+        event = new BlockPhysicsEvent(fence, mock(BlockData.class));
+        listener.onBlockPhysics(event);
+        assertFalse(event.isCancelled(), "re-allowed connections must keep fence updates");
+    }
+
+    @Test
+    void blockFromTo_fluidFlowOnlyAppliesToLiquids() {
+        data.set(WorldDataKey.PHYSICS, false);
+        data.set(PhysicsCategory.FLUID_FLOW.key(), true);
+
+        Block liquid = block();
+        when(liquid.isLiquid()).thenReturn(true);
+        BlockFromToEvent event = new BlockFromToEvent(liquid, BlockFace.DOWN);
+        listener.onBlockFromTo(event);
+        assertFalse(event.isCancelled(), "liquid flow must be allowed");
+
+        // A non-liquid FromTo (e.g. a teleporting dragon egg) stays blocked even with fluid flow allowed.
+        BlockFromToEvent solidEvent = new BlockFromToEvent(block(), BlockFace.DOWN);
+        listener.onBlockFromTo(solidEvent);
+        assertTrue(solidEvent.isCancelled(), "non-liquid FromTo must stay cancelled");
+    }
+
+    @Test
+    void entityChangeBlock_gatedByFallingBlocksCategory() {
+        data.set(WorldDataKey.PHYSICS, false);
+        FallingBlock fallingBlock = mock(FallingBlock.class);
+        when(fallingBlock.getType()).thenReturn(EntityType.FALLING_BLOCK);
+        Block block = block();
+        BlockState state = mock(BlockState.class);
+        when(block.getState()).thenReturn(state);
+
+        EntityChangeBlockEvent event = new EntityChangeBlockEvent(fallingBlock, block, mock(BlockData.class));
+        listener.onEntityChangeBlock(event);
+        assertTrue(event.isCancelled(), "falling blocks must be cancelled");
+        verify(state).update(false, false);
+
+        data.set(PhysicsCategory.FALLING_BLOCKS.key(), true);
+        event = new EntityChangeBlockEvent(fallingBlock, block, mock(BlockData.class));
+        listener.onEntityChangeBlock(event);
+        assertFalse(event.isCancelled(), "re-allowed falling blocks must not be cancelled");
+    }
+
+    @Test
+    void unmanagedWorld_isNeverTouched() {
+        World unmanaged = mock(World.class);
+        Block block = mock(Block.class);
+        when(block.getWorld()).thenReturn(unmanaged);
+
+        LeavesDecayEvent event = new LeavesDecayEvent(block);
+        listener.onLeavesDecay(event);
+        assertFalse(event.isCancelled());
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorageRoundTripTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorageRoundTripTest.java
@@ -26,6 +26,7 @@ import de.eintosti.buildsystem.Services;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.builder.Builder;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.test.TestData;
@@ -145,6 +146,49 @@ class YamlWorldStorageRoundTripTest {
 
         BuildWorld loaded = newStorage().load().join().iterator().next();
         assertEquals("1.0;64.0;2.0;90.0;0.0", loaded.getData().get(WorldDataKey.CUSTOM_SPAWN));
+    }
+
+    @Test
+    void roundTrip_preservesPhysicsCategories() {
+        BuildWorldImpl world = sampleWorld(UUID.randomUUID(), "PhysicsWorld");
+        world.getData().set(PhysicsCategory.FLUID_FLOW.key(), true);
+        newStorage().save(world).join();
+
+        BuildWorld loaded = newStorage().load().join().iterator().next();
+        assertTrue(loaded.getData().get(PhysicsCategory.FLUID_FLOW.key()));
+        assertFalse(loaded.getData().get(PhysicsCategory.LEAF_DECAY.key()));
+    }
+
+    @Test
+    void save_nestsPhysicsCategoriesUnderOneSection() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        newStorage().save(sampleWorld(uuid, "NestedWorld")).join();
+
+        // The dotted key ids must land as a real nested section, not as literal "physics-exceptions.x" keys.
+        YamlConfiguration yaml = new YamlConfiguration();
+        yaml.load(new File(dataFolder, "worlds.yml"));
+        assertTrue(yaml.isConfigurationSection("worlds." + uuid + ".data.physics-exceptions"));
+        assertTrue(yaml.isBoolean("worlds." + uuid + ".data.physics-exceptions.fluid-flow"));
+    }
+
+    @Test
+    void load_missingPhysicsCategories_seedsFromConfigDefaults() throws Exception {
+        // A world without stored physics-exceptions must inherit the config-default exceptions.
+        when(context.configService().current().world().defaults().physicsException(any(PhysicsCategory.class)))
+                .thenAnswer(invocation -> invocation.<PhysicsCategory>getArgument(0) == PhysicsCategory.FLUID_FLOW);
+
+        YamlConfiguration yaml = new YamlConfiguration();
+        yaml.set("worlds.Legacy.uuid", UUID.randomUUID().toString());
+        yaml.set("worlds.Legacy.type", "NORMAL");
+        yaml.set("worlds.Legacy.date", 1L);
+        yaml.set("worlds.Legacy.data.status", "FINISHED");
+        yaml.save(new File(dataFolder, "worlds.yml"));
+
+        BuildWorld world = newStorage().load().join().iterator().next();
+        assertTrue(world.getData().get(PhysicsCategory.FLUID_FLOW.key()));
+        assertFalse(world.getData().get(PhysicsCategory.CONNECTIONS.key()));
+        assertFalse(world.getData().get(PhysicsCategory.FALLING_BLOCKS.key()));
+        assertFalse(world.getData().get(PhysicsCategory.LEAF_DECAY.key()));
     }
 
     @Test

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
@@ -174,6 +174,8 @@ public final class TestData {
         lenient()
                 .when(configService.current().world().unload().timeUntilUnload())
                 .thenReturn("06:00:00");
+        // The deep-stubbed defaults().physicsException(...) returns false, which matches the production default
+        // (all physics exceptions blocked).
         return new WorldContext(
                 mock(Messages.class, RETURNS_DEEP_STUBS),
                 mock(MenuItems.class),

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldDataAccessorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.test.TestData;
 import org.jspecify.annotations.NullMarked;
@@ -56,6 +57,30 @@ class WorldDataAccessorTest {
 
         data.set(WorldDataKey.PHYSICS, true);
         assertTrue(data.get(WorldDataKey.PHYSICS));
+    }
+
+    @Test
+    void physicsCategories_defaultToBlockedAndRoundTrip() {
+        WorldDataImpl data = worldData();
+
+        for (PhysicsCategory category : PhysicsCategory.values()) {
+            assertFalse(data.get(category.key()), category + " should default to blocked");
+        }
+
+        data.set(PhysicsCategory.FLUID_FLOW.key(), true);
+        assertTrue(data.get(PhysicsCategory.FLUID_FLOW.key()));
+        assertFalse(data.get(PhysicsCategory.LEAF_DECAY.key()));
+    }
+
+    @Test
+    void physicsCategories_builderSeedsIndividualValues() {
+        WorldDataImpl data = new WorldDataImpl.WorldDataBuilder("test")
+                .withStatus(TestData.NOT_STARTED)
+                .withPhysicsCategory(PhysicsCategory.CONNECTIONS, true)
+                .build();
+
+        assertTrue(data.get(PhysicsCategory.CONNECTIONS.key()));
+        assertFalse(data.get(PhysicsCategory.BLOCK_UPDATES.key()));
     }
 
     @Test

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/menu/PhysicsMenuTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/menu/PhysicsMenuTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.menu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
+import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.menu.Menus;
+import java.util.Map;
+import org.bukkit.entity.Player;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+/**
+ * Golden test pinning the {@link PhysicsMenu} slot &rarr; {@link WorldDataKey} contract: the master physics switch and
+ * one toggle per {@link PhysicsCategory}.
+ */
+@NullMarked
+class PhysicsMenuTest {
+
+    private ServerMock server;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    private PhysicsMenu menu() {
+        Messages messages = mock(Messages.class);
+        when(messages.getString(anyString(), any())).thenReturn("Title");
+        BuildWorld buildWorld = mock(BuildWorld.class);
+        Player player = server.addPlayer();
+        return new PhysicsMenu(messages, mock(MenuItems.class), mock(Menus.class), buildWorld, player);
+    }
+
+    @Test
+    void keyBySlot_mapsMasterAndEveryCategory() {
+        Map<Integer, WorldDataKey<Boolean>> keys = menu().keyBySlot();
+
+        assertEquals(WorldDataKey.PHYSICS, keys.get(4));
+
+        assertEquals(PhysicsCategory.BLOCK_UPDATES.key(), keys.get(12));
+        assertEquals(PhysicsCategory.CONNECTIONS.key(), keys.get(13));
+        assertEquals(PhysicsCategory.FALLING_BLOCKS.key(), keys.get(14));
+        assertEquals(PhysicsCategory.FLUID_FLOW.key(), keys.get(21));
+        assertEquals(PhysicsCategory.LEAF_DECAY.key(), keys.get(22));
+        assertEquals(PhysicsCategory.GROWTH.key(), keys.get(23));
+        assertEquals(PhysicsCategory.SPREADING.key(), keys.get(30));
+        assertEquals(PhysicsCategory.BLOCK_FORMING.key(), keys.get(31));
+        assertEquals(PhysicsCategory.BLOCK_FADING.key(), keys.get(32));
+
+        // Master + one slot per category; a new PhysicsCategory constant must be given a slot here.
+        assertEquals(1 + PhysicsCategory.values().length, keys.size());
+    }
+}


### PR DESCRIPTION
Disabling physics in a world used to be all-or-nothing, with three global
config switches (`world.disabled-physics.prevent-*`) deciding which parts
leaked through for *every* world at once.

This replaces that with nine per-world categories that can each be re-allowed
while the world's physics stay off:

block updates, connections, falling blocks, fluid flow, leaf decay, growth,
spreading, block forming, block fading

Right-click the physics toggle in `/worlds edit` to open the new exceptions
menu; left-click still flips the master switch. Both are gated by the existing
`buildsystem.edit.physics`, so no new permission.

Values are stored per world in `worlds.yml` as `physics-exceptions.<category>`.
New worlds seed from `world.defaults.physics-exceptions` in `config.yml`.

### Migration

`world.disabled-physics` is gone; config v3 -> v4 rewrites the three old keys
into the new section with inverted sense (`prevent-fluid-flow: true` becomes
`fluid-flow: false`, both meaning "blocked"). Defaults are unchanged, so
existing servers behave exactly as before until someone opts a category in.

### Also

Drops the `CustomRedstoneLamp` metadata handling in `BlockPhysicsListener`.
Its setter went away with BuildSystem v3, so nothing has written that metadata
in a long time - the read side was keeping a `BlockRedstoneEvent` handler and a
redstone special-case in the physics path alive for no reason.

### Testing

New tests cover the listener's per-category cancellation, the v3 -> v4 config
migration, the menu layout and permission, `worlds.yml` round-tripping of the
nested keys, and the config defaults.
