### PR TITLE
feat: configurable void-world block, placed only on initial generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ config toggles. `config.yml` and `messages.yml` migrate automatically.
 
 ### Added
 
+<<<<<<< HEAD
 - **Per-world physics exceptions.** Physics control is no longer all-or-nothing:
   while a world's physics are disabled, nine behavior categories (block updates,
   connections, falling blocks, fluid flow, leaf decay, growth, spreading, block
@@ -26,6 +27,14 @@ config toggles. `config.yml` and `messages.yml` migrate automatically.
   `world.disabled-physics` section is replaced by per-category defaults under
   `world.defaults.physics-exceptions` (`true` = still runs while physics are
   off); existing configs migrate automatically.
+=======
+- **Configurable void-world block.** The block placed at the spawn of newly
+  generated void worlds is configurable: `world.void-block.enabled` turns the
+  placement off entirely and `world.void-block.material` picks the block
+  (default `GOLD_BLOCK`). The block is now placed only when the world is first
+  generated — never on later loads, imports, or renames — and never overwrites
+  an existing block.
+>>>>>>> f6315827 (feat: configurable void-world block, placed only on initial generation)
 - **Custom world statuses.** Statuses are no longer a fixed enum — admins create,
   restyle, reorder, and delete them in-game (`/setup` → World Statuses). Each
   status has its own name, colour, icon, ordering, a building-allowed flag, and an

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/ConfigService.java
@@ -21,12 +21,14 @@ import com.cryptomorin.xseries.XGameRule;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
+import de.eintosti.buildsystem.util.MaterialUtils;
 import de.eintosti.buildsystem.world.menu.GameRuleEntry;
 import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -147,6 +149,8 @@ public class ConfigService {
     }
 
     private static PluginConfig.World parseWorld(FileConfiguration config, Logger logger) {
+        PluginConfig.World.VoidBlock voidBlock = parseVoidBlock(config, logger);
+
         PluginConfig.World.Limits limits = new PluginConfig.World.Limits(
                 config.getInt("world.limits.public", -1), config.getInt("world.limits.private", -1));
 
@@ -212,10 +216,23 @@ public class ConfigService {
                 Objects.requireNonNullElse(config.getString("world.invalid-characters"), "^\b$"),
                 config.getInt("world.import-all-delay", 30),
                 deletionBlacklist,
+                voidBlock,
                 limits,
                 defaults,
                 unload,
                 backup);
+    }
+
+    private static PluginConfig.World.VoidBlock parseVoidBlock(FileConfiguration config, Logger logger) {
+        boolean enabled = config.getBoolean("world.void-block.enabled", true);
+        String raw = Objects.requireNonNullElse(config.getString("world.void-block.material"), "GOLD_BLOCK");
+        Material material = Optional.ofNullable(MaterialUtils.match(raw))
+                .filter(Material::isBlock)
+                .orElseGet(() -> {
+                    logger.warning("Invalid void-block material \"" + raw + "\". Defaulting to GOLD_BLOCK.");
+                    return Material.GOLD_BLOCK;
+                });
+        return new PluginConfig.World.VoidBlock(enabled, material);
     }
 
     private static List<GameRuleEntry<?>> parseGameRules(FileConfiguration config, Logger logger) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -60,6 +61,7 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
             String invalidCharacters,
             int importAllDelay,
             Set<String> deletionBlacklist,
+            VoidBlock voidBlock,
             Limits limits,
             Defaults defaults,
             Unload unload,
@@ -68,6 +70,12 @@ public record PluginConfig(Settings settings, World world, Folder folder) {
         public World {
             deletionBlacklist = Set.copyOf(deletionBlacklist);
         }
+
+        /**
+         * The block placed at the spawn of newly generated void worlds, so players do not fall on first join. The
+         * material is resolved and validated at parse time, so it is always a placeable block.
+         */
+        public record VoidBlock(boolean enabled, Material material) {}
 
         public record Limits(int publicWorlds, int privateWorlds) {}
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
@@ -22,9 +22,7 @@ import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.api.player.PlayerService;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
-import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
-import de.eintosti.buildsystem.api.world.data.WorldStatusRegistry;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.navigator.NavigatorService;
@@ -33,8 +31,6 @@ import de.eintosti.buildsystem.player.CachedValues;
 import de.eintosti.buildsystem.player.settings.SettingsService;
 import java.util.Map;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -42,7 +38,6 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.potion.PotionEffect;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public class PlayerChangedWorldListener implements Listener {
@@ -90,7 +85,6 @@ public class PlayerChangedWorldListener implements Listener {
 
         removeOldNavigator(player);
         removeBuildMode(player);
-        setGoldBlock(newWorld);
         checkWorldStatus(player);
 
         if (settingsManager.getSettings(player).isScoreboard()) {
@@ -115,21 +109,6 @@ public class PlayerChangedWorldListener implements Listener {
         cachedValues.resetInventoryIfPresent(player);
         XSound.ENTITY_EXPERIENCE_ORB_PICKUP.play(player);
         messages.sendMessage(player, "build_deactivated_self");
-    }
-
-    private void setGoldBlock(@Nullable BuildWorld buildWorld) {
-        if (buildWorld == null
-                || buildWorld.getType() != BuildWorldType.VOID
-                || !buildWorld.getData().get(WorldDataKey.STATUS).getId().equals(WorldStatusRegistry.NOT_STARTED_ID)) {
-            return;
-        }
-
-        World bukkitWorld = Bukkit.getWorld(buildWorld.getName());
-        if (bukkitWorld == null) {
-            return;
-        }
-
-        bukkitWorld.getBlockAt(0, 64, 0).setType(Material.GOLD_BLOCK);
     }
 
     @SuppressWarnings("deprecation")

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/AbstractWorldCreator.java
@@ -119,7 +119,8 @@ abstract class AbstractWorldCreator {
                         difficulty,
                         time,
                         worldBorderSize,
-                        seed)
+                        seed,
+                        !isImport())
                 .generate(
                         checkVersion ? BukkitWorldFactory.VersionCheck.REQUIRED : BukkitWorldFactory.VersionCheck.SKIP);
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/BukkitWorldFactory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/BukkitWorldFactory.java
@@ -17,17 +17,18 @@
  */
 package de.eintosti.buildsystem.world.creation;
 
-import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.creation.generator.CustomGenerator;
 import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.config.ConfigService;
+import de.eintosti.buildsystem.config.PluginConfig;
 import de.eintosti.buildsystem.world.creation.GenerationDataStore.WorldGenerationData;
 import de.eintosti.buildsystem.world.creation.generator.VoidGenerator;
 import de.eintosti.buildsystem.world.menu.GameRuleEntry;
 import java.util.Locale;
 import java.util.logging.Logger;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -49,6 +50,7 @@ public class BukkitWorldFactory {
     private final @Nullable Integer time;
     private final @Nullable Integer worldBorderSize;
     private final @Nullable Long seed;
+    private final boolean initialGeneration;
 
     private final WorldDataVersionGuard versionGuard;
     private final GenerationDataStore generationDataStore;
@@ -66,12 +68,15 @@ public class BukkitWorldFactory {
         this.time = null;
         this.worldBorderSize = null;
         this.seed = null;
+        this.initialGeneration = false;
         this.versionGuard = new WorldDataVersionGuard(logger, worldName);
         this.generationDataStore = new GenerationDataStore(logger);
     }
 
     /**
-     * Used when creating a new world with defaults from plugin config.
+     * Used when creating or importing a new world with defaults from plugin config. {@code initialGeneration} is
+     * {@code true} only when the world is generated from scratch (not imported), enabling one-time setup like the
+     * void-block placement.
      */
     BukkitWorldFactory(
             ConfigService configService,
@@ -82,7 +87,8 @@ public class BukkitWorldFactory {
             @Nullable Difficulty difficulty,
             @Nullable Integer time,
             @Nullable Integer worldBorderSize,
-            @Nullable Long seed) {
+            @Nullable Long seed,
+            boolean initialGeneration) {
         this.configService = configService;
         this.logger = logger;
         this.worldName = worldName;
@@ -92,6 +98,7 @@ public class BukkitWorldFactory {
         this.time = time;
         this.worldBorderSize = worldBorderSize;
         this.seed = seed;
+        this.initialGeneration = initialGeneration;
         this.versionGuard = new WorldDataVersionGuard(logger, worldName);
         this.generationDataStore = new GenerationDataStore(logger);
     }
@@ -204,11 +211,13 @@ public class BukkitWorldFactory {
         entry.rule().setValue(world, entry.value());
     }
 
-    private static void applyPostGenerationSettings(World bukkitWorld, BuildWorldType worldType) {
+    void applyPostGenerationSettings(World bukkitWorld, BuildWorldType worldType) {
         switch (worldType) {
             case VOID -> {
                 int voidBlockY = 64;
-                bukkitWorld.getBlockAt(0, voidBlockY, 0).setType(XMaterial.GOLD_BLOCK.get());
+                if (initialGeneration) {
+                    placeVoidBlock(bukkitWorld, voidBlockY);
+                }
                 bukkitWorld.setSpawnLocation(0, voidBlockY + 1, 0);
             }
             case FLAT -> {
@@ -217,6 +226,22 @@ public class BukkitWorldFactory {
             default -> {
                 // No special post-generation steps for other types
             }
+        }
+    }
+
+    /**
+     * Places the configured void-block at the world's spawn column, only when the world is generated for the first
+     * time. Only fills air — a block already there, e.g. from a pre-existing world folder, is never overwritten.
+     */
+    private void placeVoidBlock(World bukkitWorld, int voidBlockY) {
+        PluginConfig.World.VoidBlock voidBlock = configService.current().world().voidBlock();
+        if (!voidBlock.enabled()) {
+            return;
+        }
+
+        Block block = bukkitWorld.getBlockAt(0, voidBlockY, 0);
+        if (block.getType().isAir()) {
+            block.setType(voidBlock.material());
         }
     }
 }

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -33,6 +33,10 @@ world:
     - world
     - world_nether
     - world_the_end
+  # The block placed at the spawn of newly generated void worlds. Only placed if the position is still empty.
+  void-block:
+    enabled: true
+    material: GOLD_BLOCK
   limits:
     public: -1
     private: -1

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.world.data.PhysicsCategory;
 import java.util.logging.Logger;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +103,41 @@ class PluginConfigTest {
         assertTrue(cfg.world().defaults().physicsException(PhysicsCategory.FLUID_FLOW));
         assertTrue(cfg.world().defaults().physicsException(PhysicsCategory.LEAF_DECAY));
         assertFalse(cfg.world().defaults().physicsException(PhysicsCategory.CONNECTIONS));
+    }
+
+    @Test
+    void voidBlock_defaults_toEnabledGoldBlock() {
+        PluginConfig cfg = parse("");
+
+        assertTrue(cfg.world().voidBlock().enabled());
+        assertEquals(Material.GOLD_BLOCK, cfg.world().voidBlock().material());
+    }
+
+    @Test
+    void voidBlock_customValues_areParsed() {
+        PluginConfig cfg = parse("""
+                world:
+                  void-block:
+                    enabled: false
+                    material: DIAMOND_BLOCK
+                """);
+
+        assertFalse(cfg.world().voidBlock().enabled());
+        assertEquals(Material.DIAMOND_BLOCK, cfg.world().voidBlock().material());
+    }
+
+    @Test
+    void voidBlock_invalidOrNonBlockMaterial_fallsBackToGoldBlock() {
+        assertEquals(Material.GOLD_BLOCK, parse("""
+                        world:
+                          void-block:
+                            material: NOT_A_MATERIAL
+                        """).world().voidBlock().material());
+        assertEquals(Material.GOLD_BLOCK, parse("""
+                        world:
+                          void-block:
+                            material: DIAMOND_SWORD
+                        """).world().voidBlock().material());
     }
 
     // -----------------------------------------------------------------------

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/creation/BukkitWorldFactoryTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/creation/BukkitWorldFactoryTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.creation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import de.eintosti.buildsystem.api.world.data.BuildWorldType;
+import de.eintosti.buildsystem.config.ConfigService;
+import de.eintosti.buildsystem.config.PluginConfig;
+import java.util.logging.Logger;
+import org.bukkit.Material;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+/**
+ * Pins the void-block placement contract of {@link BukkitWorldFactory#applyPostGenerationSettings}: the configured
+ * block is placed at the spawn column of newly generated void worlds only — never over an existing block, never when
+ * disabled, and never when the world is merely re-generated (import/load/rename) — while the spawn is always set.
+ */
+@NullMarked
+class BukkitWorldFactoryTest {
+
+    private ServerMock server;
+    private ConfigService configService;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        configService = mock(ConfigService.class, RETURNS_DEEP_STUBS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    private BukkitWorldFactory factory(PluginConfig.World.VoidBlock voidBlock, boolean initialGeneration) {
+        lenient().when(configService.current().world().voidBlock()).thenReturn(voidBlock);
+        return new BukkitWorldFactory(
+                configService,
+                Logger.getLogger("test"),
+                "void-world",
+                BuildWorldType.VOID,
+                null,
+                null,
+                null,
+                null,
+                null,
+                initialGeneration);
+    }
+
+    @Test
+    void initialGeneration_placesConfiguredBlockAndSetsSpawn() {
+        WorldMock world = server.addSimpleWorld("void-world");
+        assertEquals(Material.AIR, world.getBlockAt(0, 64, 0).getType());
+
+        factory(new PluginConfig.World.VoidBlock(true, Material.DIAMOND_BLOCK), true)
+                .applyPostGenerationSettings(world, BuildWorldType.VOID);
+
+        assertEquals(Material.DIAMOND_BLOCK, world.getBlockAt(0, 64, 0).getType());
+        assertEquals(65, world.getSpawnLocation().getBlockY());
+    }
+
+    @Test
+    void initialGeneration_neverOverwritesAnExistingBlock() {
+        WorldMock world = server.addSimpleWorld("void-world");
+        world.getBlockAt(0, 64, 0).setType(Material.STONE);
+
+        factory(new PluginConfig.World.VoidBlock(true, Material.GOLD_BLOCK), true)
+                .applyPostGenerationSettings(world, BuildWorldType.VOID);
+
+        assertEquals(Material.STONE, world.getBlockAt(0, 64, 0).getType());
+    }
+
+    @Test
+    void placementDisabled_stillSetsSpawn() {
+        WorldMock world = server.addSimpleWorld("void-world");
+
+        factory(new PluginConfig.World.VoidBlock(false, Material.GOLD_BLOCK), true)
+                .applyPostGenerationSettings(world, BuildWorldType.VOID);
+
+        assertEquals(Material.AIR, world.getBlockAt(0, 64, 0).getType());
+        assertEquals(65, world.getSpawnLocation().getBlockY());
+    }
+
+    @Test
+    void regeneration_placesNothingButStillSetsSpawn() {
+        WorldMock world = server.addSimpleWorld("void-world");
+
+        factory(new PluginConfig.World.VoidBlock(true, Material.GOLD_BLOCK), false)
+                .applyPostGenerationSettings(world, BuildWorldType.VOID);
+
+        assertEquals(Material.AIR, world.getBlockAt(0, 64, 0).getType());
+        assertEquals(65, world.getSpawnLocation().getBlockY());
+    }
+}


### PR DESCRIPTION
Void worlds get a block at their spawn column so the first player to join does
not immediately fall. That block was hardcoded to `GOLD_BLOCK`, and it was
placed in two different places.

Now it is configurable:

```yaml
world:
  void-block:
    enabled: true
    material: GOLD_BLOCK
```

The material is resolved and validated when the config is parsed - an unknown
name or a non-block (`DIAMOND_SWORD`) logs a warning and falls back to
`GOLD_BLOCK`, so the placement path always has a usable block.

### Placement is now once, at generation

The block is placed only when a void world is generated from scratch, and only
if the spot is still air. Imports, loads and renames no longer place anything.

This fixes a real annoyance: `PlayerChangedWorldListener` used to re-place the
gold block on *every* world entry for any not-started void world, doing an
unconditional `setType(GOLD_BLOCK)` at `0,64,0`. If a builder put something
else there - or cleared it - it came back the next time anyone walked in. That
path is gone; `BukkitWorldFactory` owns the placement now.

Spawn location is still set to `0,65,0` for void worlds regardless of whether
the block was placed, so disabling this does not strand the spawn point.

### Testing

Covers initial generation placing the configured block, never overwriting an
existing block, placement disabled still setting spawn, and regeneration
placing nothing. Config parsing is covered for defaults, custom values, and
the invalid/non-block fallback.
