### PR TITLE
chore: stop renovate from updating paper-api

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,8 @@
   ],
   "automerge": true,
   "ignoreDeps": [
-    "org.spigotmc:spigot-api"
+    "org.spigotmc:spigot-api",
+    "io.papermc.paper:paper-api"
   ],
   "labels": [
     "renovate"


### PR DESCRIPTION
`paper-api` is test-only and has to match MockBukkit's Minecraft version, not spigot's, so it lags behind — it stays on 26.1.2 while `spigot` is already 26.2.

Renovate doesn't know that and proposes the bump anyway (the stale `renovate/paperapi` branch). Taking it would break the build in a quiet way: paper-api 26.2 against `mockbukkit-v26.1.2` **compiles fine and then fails 28 tests at runtime** (`NoClassDefFoundError: org.bukkit.Registry`, `ServiceConfigurationError` on `RegistryAccessMock`), so there's no compile-time signal.

This adds `io.papermc.paper:paper-api` to `ignoreDeps` alongside `org.spigotmc:spigot-api`, which is already there for the same reason.

The `26.1.2.build.+` wildcard stays — it only floats the build number within MC 26.1.2, which is API-compatible.

Both can move once MockBukkit ships `mockbukkit-v26.2`; Central has only `v1.21` and `v26.1.2` today.