### PR TITLE
refactor!: enforce menu button permissions in the framework

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/PhysicsCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/PhysicsCategory.java
@@ -75,10 +75,20 @@ public enum PhysicsCategory {
      */
     BLOCK_FADING("block-fading");
 
+    private final String id;
     private final WorldDataKey<Boolean> key;
 
     PhysicsCategory(String id) {
+        this.id = id;
         this.key = WorldDataKey.of("physics-exceptions." + id, Boolean.class);
+    }
+
+    /**
+     * {@return this category's identifier, e.g. {@code block-updates}} This is the name used in config and in the
+     * {@link #key() key}, and is stable across renames of the enum constant.
+     */
+    public String id() {
+        return id;
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ButtonMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/ButtonMenu.java
@@ -17,6 +17,7 @@
  */
 package de.eintosti.buildsystem.menu;
 
+import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.i18n.Messages;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -103,12 +104,35 @@ public abstract class ButtonMenu<B extends MenuButton> extends Menu {
     public void handleClick(InventoryClickEvent event) {
         event.setCancelled(true);
         Player player = (Player) event.getWhoClicked();
+
         B button = buttonAt(event);
-        if (button != null) {
-            button.onClick(player, event);
-        } else {
+        if (button == null) {
             onUnhandledClick(player, event);
+            return;
         }
+
+        String permission = button.permission();
+        if (permission != null && !player.hasPermission(permission)) {
+            onPermissionDenied(player, event);
+            return;
+        }
+
+        button.onClick(player, event);
+    }
+
+    /**
+     * Hook for a click on a button whose {@link MenuButton#permission() permission} the player lacks. The default
+     * closes the inventory, sends the permission error and plays the deny sound, matching
+     * the guard it replaces. Menus that must keep the inventory open on a denied click (e.g. per-toggle
+     * settings) override this.
+     *
+     * @param player The clicking player
+     * @param event The click event (already cancelled)
+     */
+    protected void onPermissionDenied(Player player, InventoryClickEvent event) {
+        player.closeInventory();
+        messages.sendPermissionError(player);
+        XSound.ENTITY_ITEM_BREAK.play(player);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/Menu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/Menu.java
@@ -17,7 +17,6 @@
  */
 package de.eintosti.buildsystem.menu;
 
-import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.i18n.Messages;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -91,27 +90,6 @@ public abstract class Menu implements InventoryHolder {
     public void open(Player player) {
         populate(player);
         player.openInventory(inventory);
-    }
-
-    /**
-     * Shared click-time permission guard: if the player lacks the permission, closes the menu, sends the permission
-     * error, and plays the deny sound.
-     *
-     * <p>Note that this <strong>closes the inventory</strong> on denial. Menus that must keep the inventory open on a
-     * denied click (e.g. per-toggle settings) deliberately do their own inline check instead of calling this.
-     *
-     * @param player The clicking player
-     * @param permission The required permission
-     * @return {@code true} if the player may proceed, {@code false} if denied (UX already handled)
-     */
-    protected boolean requirePermission(Player player, String permission) {
-        if (player.hasPermission(permission)) {
-            return true;
-        }
-        player.closeInventory();
-        messages.sendPermissionError(player);
-        XSound.ENTITY_ITEM_BREAK.play(player);
-        return false;
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuButton.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/menu/MenuButton.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A single slot in a {@link ButtonMenu}: it knows how to render its icon and how to react to a click. A menu keeps a
@@ -50,6 +51,17 @@ public interface MenuButton {
      * @param event The click event
      */
     void onClick(Player player, InventoryClickEvent event);
+
+    /**
+     * {@return the permission required to click this button, or {@code null} if it is unrestricted}
+     *
+     * <p>This is <em>enforced</em>: {@link ButtonMenu#handleClick} checks it before dispatching to
+     * {@link #onClick}, so a button that declares a permission never has to check it again. Denial is handled by
+     * {@link ButtonMenu#onPermissionDenied}.
+     */
+    default @Nullable String permission() {
+        return null;
+    }
 
     /**
      * {@return a new {@link Builder} for assembling a {@code MenuButton} from a renderer and a click handler} Either part
@@ -98,8 +110,21 @@ public interface MenuButton {
 
         private Renderer renderer = (player, inventory, slot) -> {};
         private ClickHandler clickHandler = (player, event) -> {};
+        private @Nullable String permission;
 
         private Builder() {}
+
+        /**
+         * Sets the permission required to click the button; {@code null} leaves it unrestricted. The menu enforces
+         * this before dispatching the click, so the handler does not repeat the check.
+         *
+         * @param permission The required permission, or {@code null}
+         * @return This builder
+         */
+        public Builder permission(@Nullable String permission) {
+            this.permission = permission;
+            return this;
+        }
 
         /**
          * Sets how the button renders into its slot.
@@ -129,6 +154,8 @@ public interface MenuButton {
         public MenuButton build() {
             Renderer builtRenderer = renderer;
             ClickHandler builtClickHandler = clickHandler;
+            String builtPermission = permission;
+
             return new MenuButton() {
                 @Override
                 public void render(Player player, Inventory inventory, int slot) {
@@ -138,6 +165,11 @@ public interface MenuButton {
                 @Override
                 public void onClick(Player player, InventoryClickEvent event) {
                     builtClickHandler.onClick(player, event);
+                }
+
+                @Override
+                public @Nullable String permission() {
+                    return builtPermission;
                 }
             };
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
@@ -83,6 +83,16 @@ public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
             clickHandler.accept(player, event);
         }
 
+        /**
+         * {@return the full permission node for this button, or {@code null} for the unrestricted design slot} The
+         * short {@link #node()} is the configurable part; the shared prefix is applied here so the menu enforces the
+         * same string the golden test pins.
+         */
+        @Override
+        public @Nullable String permission() {
+            return node == null ? null : PERMISSION_PREFIX + node;
+        }
+
         static Builder builder() {
             return new Builder();
         }
@@ -349,17 +359,11 @@ public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
     }
 
     /**
-     * The shared toggle click sequence. Note the two intentional differences from {@code Menu.requirePermission}: a
-     * denied permission does <strong>not</strong> close the inventory, and a rejected toggle (scoreboard disabled in
-     * config) plays the break sound without re-opening.
+     * The shared toggle click sequence. The permission is enforced by the menu before the click reaches here (see
+     * {@link #onPermissionDenied}); a rejected toggle (scoreboard disabled in config) plays the break sound without
+     * re-opening.
      */
     private void handleToggle(Player player, String node, BooleanSupplier onToggle) {
-        if (!player.hasPermission(PERMISSION_PREFIX + node)) {
-            messages.sendPermissionError(player);
-            XSound.ENTITY_ITEM_BREAK.play(player);
-            return;
-        }
-
         if (!onToggle.getAsBoolean()) {
             XSound.ENTITY_ITEM_BREAK.play(player);
             return;
@@ -367,6 +371,16 @@ public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
 
         XSound.ENTITY_ITEM_PICKUP.play(player);
         menus.openSettings(player);
+    }
+
+    /**
+     * Unlike the default, a denied toggle leaves the settings menu open: the player can still reach the toggles they
+     * do have, which is the point of per-option permissions.
+     */
+    @Override
+    protected void onPermissionDenied(Player player, InventoryClickEvent event) {
+        messages.sendPermissionError(player);
+        XSound.ENTITY_ITEM_BREAK.play(player);
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -557,6 +557,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
             XSound.ENTITY_ITEM_BREAK.play(player);
             return;
         }
+
         if (event.isRightClick()) {
             XSound.BLOCK_CHEST_OPEN.play(player);
             menus.openBuilder(buildWorld, player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -29,15 +29,13 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
-import de.eintosti.buildsystem.menu.ButtonMenu;
-import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.MenuButton;
-import de.eintosti.buildsystem.menu.MenuItems;
-import de.eintosti.buildsystem.menu.Menus;
-import de.eintosti.buildsystem.menu.Prompts;
+import de.eintosti.buildsystem.menu.*;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
 import de.eintosti.buildsystem.util.color.ColorAPI;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import org.bukkit.*;
@@ -202,10 +200,8 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .render((player, inventory) ->
                                 toggle.render(menuItems, buildWorld.getData(), player, inventory, slot))
                         .onClick((player, event) -> {
-                            if (requirePermission(player, toggle.permission())) {
-                                toggle.flip(buildWorld.getData());
-                                reopen(player);
-                            }
+                            toggle.flip(buildWorld.getData());
+                            reopen(player);
                         })
                         .build()));
 
@@ -216,9 +212,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderTime)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.time")) {
-                                changeTime(player);
-                            }
+                            changeTime(player);
                             reopen(player);
                         })
                         .build());
@@ -229,11 +223,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .permission("buildsystem.edit.entities")
                         .outcome(ClickOutcome.CLOSE)
                         .render(this::renderButcher)
-                        .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.entities")) {
-                                removeEntities(player);
-                            }
-                        })
+                        .onClick((player, event) -> removeEntities(player))
                         .build());
 
         register(
@@ -277,10 +267,8 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.SUBMENU)
                         .render(this::renderGameRules)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.gamerules")) {
-                                XSound.BLOCK_CHEST_OPEN.play(player);
-                                menus.openGameRules(buildWorld, player);
-                            }
+                            XSound.BLOCK_CHEST_OPEN.play(player);
+                            menus.openGameRules(buildWorld, player);
                         })
                         .build());
 
@@ -291,9 +279,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderDifficulty)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.difficulty")) {
-                                cycleDifficulty();
-                            }
+                            cycleDifficulty();
                             reopen(player);
                         })
                         .build());
@@ -305,10 +291,8 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.SUBMENU)
                         .render(this::renderStatus)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.status")) {
-                                XSound.ENTITY_CHICKEN_EGG.play(player);
-                                menus.openStatus(buildWorld, player);
-                            }
+                            XSound.ENTITY_CHICKEN_EGG.play(player);
+                            menus.openStatus(buildWorld, player);
                         })
                         .build());
 
@@ -319,10 +303,8 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.INPUT)
                         .render(this::renderProject)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.project")) {
-                                XSound.ENTITY_CHICKEN_EGG.play(player);
-                                menus.promptWorldProject(buildWorld, player);
-                            }
+                            XSound.ENTITY_CHICKEN_EGG.play(player);
+                            menus.promptWorldProject(buildWorld, player);
                         })
                         .build());
 
@@ -333,10 +315,8 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
                         .outcome(ClickOutcome.INPUT)
                         .render(this::renderPermission)
                         .onClick((player, event) -> {
-                            if (requirePermission(player, "buildsystem.edit.permission")) {
-                                XSound.ENTITY_CHICKEN_EGG.play(player);
-                                menus.promptWorldPermission(buildWorld, player);
-                            }
+                            XSound.ENTITY_CHICKEN_EGG.play(player);
+                            menus.promptWorldPermission(buildWorld, player);
                         })
                         .build());
     }
@@ -364,9 +344,6 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
      * the viewing player's head, or {@code none} to clear).
      */
     private void onWorldInfoClick(Player player, InventoryClickEvent event) {
-        if (!requirePermission(player, "buildsystem.edit.icon")) {
-            return;
-        }
         if (buildWorld.getIcon() == Material.PLAYER_HEAD && event.isRightClick()) {
             promptIconTexture(player);
             return;
@@ -558,9 +535,6 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
      * the {@link PhysicsMenu} with the per-category exceptions.
      */
     private void onPhysicsClick(Player player, InventoryClickEvent event) {
-        if (!requirePermission(player, "buildsystem.edit.physics")) {
-            return;
-        }
         if (event.isRightClick()) {
             XSound.BLOCK_CHEST_OPEN.play(player);
             menus.openPhysics(buildWorld, player);
@@ -581,9 +555,6 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         ItemStack itemStack = event.getCurrentItem();
         if (itemStack != null && itemStack.getType() == XMaterial.BARRIER.get()) {
             XSound.ENTITY_ITEM_BREAK.play(player);
-            return;
-        }
-        if (!requirePermission(player, "buildsystem.edit.builders")) {
             return;
         }
         if (event.isRightClick()) {
@@ -608,14 +579,11 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
             XSound.ENTITY_ITEM_BREAK.play(player);
             return;
         }
-        if (requirePermission(player, "buildsystem.edit.visibility")) {
-            WorldData worldData = buildWorld.getData();
-            worldData.set(
-                    WorldDataKey.VISIBILITY,
-                    worldData.get(WorldDataKey.VISIBILITY).isPrivate()
-                            ? Visibility.EVERYONE
-                            : Visibility.ADDED_PLAYERS);
-        }
+
+        WorldData worldData = buildWorld.getData();
+        worldData.set(
+                WorldDataKey.VISIBILITY,
+                worldData.get(WorldDataKey.VISIBILITY).isPrivate() ? Visibility.EVERYONE : Visibility.ADDED_PLAYERS);
         reopen(player);
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
@@ -92,13 +92,12 @@ public class PhysicsMenu extends ButtonMenu<MenuButton> {
 
     private MenuButton toggleButton(Toggle toggle) {
         return MenuButton.builder()
+                .permission(PERMISSION)
                 .render((player, inventory, slot) ->
                         toggle.render(menuItems, buildWorld.getData(), player, inventory, slot))
                 .onClick((player, event) -> {
-                    if (requirePermission(player, PERMISSION)) {
-                        toggle.flip(buildWorld.getData());
-                        XSound.ENTITY_CHICKEN_EGG.play(player);
-                    }
+                    toggle.flip(buildWorld.getData());
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
                     populate(player);
                 })
                 .build();
@@ -116,10 +115,10 @@ public class PhysicsMenu extends ButtonMenu<MenuButton> {
 
     @Override
     protected void onUnhandledClick(Player player, InventoryClickEvent event) {
-        // Only the menu's own slots return to the editor; clicks in the player inventory are ignored.
         if (event.getRawSlot() < 0 || event.getRawSlot() >= getInventory().getSize()) {
             return;
         }
+
         XSound.BLOCK_CHEST_OPEN.play(player);
         menus.openEdit(buildWorld, player);
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
@@ -57,15 +57,15 @@ public class PhysicsMenu extends ButtonMenu<MenuButton> {
             WorldDataKey.PHYSICS);
 
     private static final Map<Integer, Toggle> CATEGORY_TOGGLES = Map.ofEntries(
-            entry(12, categoryToggle(XMaterial.OBSERVER, "blockupdates", PhysicsCategory.BLOCK_UPDATES)),
-            entry(13, categoryToggle(XMaterial.OAK_FENCE, "connections", PhysicsCategory.CONNECTIONS)),
-            entry(14, categoryToggle(XMaterial.GRAVEL, "fallingblocks", PhysicsCategory.FALLING_BLOCKS)),
-            entry(21, categoryToggle(XMaterial.WATER_BUCKET, "fluidflow", PhysicsCategory.FLUID_FLOW)),
-            entry(22, categoryToggle(XMaterial.OAK_LEAVES, "leafdecay", PhysicsCategory.LEAF_DECAY)),
-            entry(23, categoryToggle(XMaterial.WHEAT, "growth", PhysicsCategory.GROWTH)),
-            entry(30, categoryToggle(XMaterial.VINE, "spreading", PhysicsCategory.SPREADING)),
-            entry(31, categoryToggle(XMaterial.SNOW_BLOCK, "blockforming", PhysicsCategory.BLOCK_FORMING)),
-            entry(32, categoryToggle(XMaterial.ICE, "blockfading", PhysicsCategory.BLOCK_FADING)));
+            entry(12, categoryToggle(PhysicsCategory.BLOCK_UPDATES, XMaterial.OBSERVER)),
+            entry(13, categoryToggle(PhysicsCategory.CONNECTIONS, XMaterial.OAK_FENCE)),
+            entry(14, categoryToggle(PhysicsCategory.FALLING_BLOCKS, XMaterial.GRAVEL)),
+            entry(21, categoryToggle(PhysicsCategory.FLUID_FLOW, XMaterial.WATER_BUCKET)),
+            entry(22, categoryToggle(PhysicsCategory.LEAF_DECAY, XMaterial.OAK_LEAVES)),
+            entry(23, categoryToggle(PhysicsCategory.GROWTH, XMaterial.WHEAT)),
+            entry(30, categoryToggle(PhysicsCategory.SPREADING, XMaterial.VINE)),
+            entry(31, categoryToggle(PhysicsCategory.BLOCK_FORMING, XMaterial.SNOW_BLOCK)),
+            entry(32, categoryToggle(PhysicsCategory.BLOCK_FADING, XMaterial.ICE)));
 
     private final MenuItems menuItems;
     private final Menus menus;
@@ -81,7 +81,14 @@ public class PhysicsMenu extends ButtonMenu<MenuButton> {
         CATEGORY_TOGGLES.forEach((slot, toggle) -> register(slot, toggleButton(toggle)));
     }
 
-    private static Toggle categoryToggle(XMaterial material, String messageName, PhysicsCategory category) {
+    /**
+     * Builds a toggle for a category. The message keys are derived from the category's
+     * {@link PhysicsCategory#id() id} (e.g. {@code block-updates} &rarr;
+     * {@code worldeditor_physics_blockupdates_item}), so adding a category only means adding its entry above and its
+     * two message keys.
+     */
+    private static Toggle categoryToggle(PhysicsCategory category, XMaterial material) {
+        String messageName = category.id().replace("-", "");
         return new Toggle(
                 material,
                 PERMISSION,


### PR DESCRIPTION
`EditButton.permission(...)` read like enforcement but wasn't. The field was consumed by exactly one thing — `permissionBySlot()`, which feeds a golden test — while the actual check lived in each click handler:

```java
register(SLOT_PHYSICS, EditButton.builder()
        .permission("buildsystem.edit.physics")   // metadata only
        .onClick(this::onPhysicsClick)            // had to check again itself
```

All eleven buttons did remember to check, so nothing was open. But the golden test would happily confirm a permission is "declared" on a button that never checks it, which is the worst kind of green test.

Now `permission()` is on `MenuButton` itself and `ButtonMenu.handleClick` enforces it before dispatching:

```java
String permission = button.permission();
if (permission != null && !player.hasPermission(permission)) {
    onPermissionDenied(player, event);
    return;
}
button.onClick(player, event);
```

The declaration *is* the enforcement, so the failure mode stops existing rather than being caught in review.

### Denial behaviour

`onPermissionDenied` is overridable. The default matches the old `Menu#requirePermission` — close, error, deny sound. `SettingsMenu` overrides it to leave the menu open, which it previously achieved with a hand-rolled check and a comment explaining the difference. That comment is now a method.

`SettingsMenu`'s buttons keep their short `node()`; the shared `buildsystem.setting.` prefix is applied in one place, so the menu enforces exactly the string the golden test pins.

### Behaviour change

Three `EditMenu` buttons (time, difficulty, visibility) used to re-open the menu after a denied click, while the other eight closed it. They now all close, so denial is consistent across the menu.

`Menu#requirePermission` has no callers left and is removed. Handlers lost their guard clauses; `EditMenu` is down 78 lines.

### Also

`PhysicsCategory` now exposes the id it already held, so `PhysicsMenu` stops carrying a hand-written copy of it per entry — the nine message names are derived from the id (`block-updates` → `worldeditor_physics_blockupdates_item`). The category leads the argument list since the material is the only thing left that isn't derivable from it.
