### PR TITLE
refactor: centralize permission nodes in a Permissions class

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/BuildSystemPlugin.java
@@ -27,6 +27,7 @@ import de.eintosti.buildsystem.integration.Integrations;
 import de.eintosti.buildsystem.listener.ListenerRegistrar;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
 import de.eintosti.buildsystem.player.LogoutLocation;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.UpdateChecker;
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
@@ -42,7 +43,7 @@ public class BuildSystemPlugin extends JavaPlugin {
 
     public static final int SPIGOT_ID = 60441;
     public static final int METRICS_ID = 7427;
-    public static final String ADMIN_PERMISSION = "buildsystem.admin";
+    public static final String ADMIN_PERMISSION = Permissions.ADMIN;
 
     private static final long CONFIG_SAVE_INTERVAL_TICKS = 5L * 60L * 20L;
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BackCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BackCommand.java
@@ -21,6 +21,7 @@ import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.api.storage.PlayerStorage;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import io.papermc.lib.PaperLib;
 import java.util.logging.Logger;
 import org.bukkit.Location;
@@ -39,7 +40,7 @@ public class BackCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.back")) {
+        if (!requirePermission(player, Permissions.BACK)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BlocksCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BlocksCommand.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.command;
 import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.logging.Logger;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -36,7 +37,7 @@ public class BlocksCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.blocks")) {
+        if (!requirePermission(player, Permissions.BLOCKS)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildCommand.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.player.PlayerService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
 import de.eintosti.buildsystem.player.CachedValues;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class BuildCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.build")) {
+        if (!requirePermission(player, Permissions.BUILD)) {
             return;
         }
 
@@ -53,7 +54,7 @@ public class BuildCommand extends CommandBase {
             case 0 -> toggleBuildMode(player, player);
 
             case 1 -> {
-                if (!requirePermission(player, "buildsystem.build.other")) {
+                if (!requirePermission(player, Permissions.BUILD_OTHER)) {
                     return;
                 }
 
@@ -73,11 +74,11 @@ public class BuildCommand extends CommandBase {
     @Override
     protected List<String> complete(Player player, String label, String[] args) {
         List<String> list = new ArrayList<>();
-        if (!player.hasPermission("buildsystem.build")) {
+        if (!player.hasPermission(Permissions.BUILD)) {
             return list;
         }
 
-        if (args.length == 1 && !player.hasPermission("buildsystem.build.other")) {
+        if (args.length == 1 && !player.hasPermission(Permissions.BUILD_OTHER)) {
             Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[0], pl.getName(), list));
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildSystemCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/BuildSystemCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import com.google.common.collect.Lists;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.List;
 import java.util.logging.Logger;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -34,7 +35,7 @@ public class BuildSystemCommand extends PagedCommand {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.help.buildsystem")) {
+        if (!requirePermission(player, Permissions.HELP_BUILDSYSTEM)) {
             return;
         }
 
@@ -55,28 +56,24 @@ public class BuildSystemCommand extends PagedCommand {
     @Override
     protected List<TextComponent> getCommands(Player player) {
         List<TextComponent> commands = Lists.newArrayList(
-                createComponent(player, "/back", "buildsystem_back", "/back", "buildsystem.back"),
-                createComponent(player, "/blocks", "buildsystem_blocks", "/blocks", "buildsystem.blocks"),
-                createComponent(player, "/build [player]", "buildsystem_build", "/build", "buildsystem.build"),
-                createComponent(player, "/config reload", "buildsystem_config", "/config reload", "buildsystem.config"),
-                createComponent(player, "/day [world]", "buildsystem_day", "/day", "buildsystem.day"),
+                createComponent(player, "/back", "buildsystem_back", "/back", Permissions.BACK),
+                createComponent(player, "/blocks", "buildsystem_blocks", "/blocks", Permissions.BLOCKS),
+                createComponent(player, "/build [player]", "buildsystem_build", "/build", Permissions.BUILD),
+                createComponent(player, "/config reload", "buildsystem_config", "/config reload", Permissions.CONFIG),
+                createComponent(player, "/day [world]", "buildsystem_day", "/day", Permissions.DAY),
                 createComponent(
-                        player,
-                        "/explosions [world]",
-                        "buildsystem_explosions",
-                        "/explosions",
-                        "buildsystem.explosions"),
+                        player, "/explosions [world]", "buildsystem_explosions", "/explosions", Permissions.EXPLOSIONS),
                 createComponent(
-                        player, "/gm <gamemode> [player]", "buildsystem_gamemode", "/gm ", "buildsystem.gamemode"),
-                createComponent(player, "/night [world]", "buildsystem_night", "/night", "buildsystem.night"),
-                createComponent(player, "/noai [world]", "buildsystem_noai", "/noai", "buildsystem.noai"),
-                createComponent(player, "/physics [world]", "buildsystem_physics", "/physics", "buildsystem.physics"),
-                createComponent(player, "/settings", "buildsystem_settings", "/settings", "buildsystem.settings"),
-                createComponent(player, "/setup", "buildsystem_setup", "/setup", "buildsystem.setup"),
-                createComponent(player, "/skull [player/id]", "buildsystem_skull", "/skull", "buildsystem.skull"),
+                        player, "/gm <gamemode> [player]", "buildsystem_gamemode", "/gm ", Permissions.GAMEMODE),
+                createComponent(player, "/night [world]", "buildsystem_night", "/night", Permissions.NIGHT),
+                createComponent(player, "/noai [world]", "buildsystem_noai", "/noai", Permissions.NOAI),
+                createComponent(player, "/physics [world]", "buildsystem_physics", "/physics", Permissions.PHYSICS),
+                createComponent(player, "/settings", "buildsystem_settings", "/settings", Permissions.SETTINGS),
+                createComponent(player, "/setup", "buildsystem_setup", "/setup", Permissions.SETUP),
+                createComponent(player, "/skull [player/id]", "buildsystem_skull", "/skull", Permissions.SKULL),
                 createComponent(player, "/spawn", "buildsystem_spawn", "/spawn", "-"),
-                createComponent(player, "/speed <1-5>", "buildsystem_speed", "/speed ", "buildsystem.speed"),
-                createComponent(player, "/top", "buildsystem_top", "/top", "buildsystem.top"),
+                createComponent(player, "/speed <1-5>", "buildsystem_speed", "/speed ", Permissions.SPEED),
+                createComponent(player, "/top", "buildsystem_top", "/top", Permissions.TOP),
                 createComponent(player, "/worlds help", "buildsystem_worlds", "/worlds help", "-"));
         commands.removeIf(textComponent -> textComponent.getText().isEmpty());
         return commands;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ConfigCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ConfigCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import de.eintosti.buildsystem.BuildSystemPlugin;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -39,7 +40,7 @@ public class ConfigCommand extends CommandBase {
 
     @Override
     protected void run(CommandSender sender, String label, String[] args) {
-        if (!requirePermission(sender, "buildsystem.config")) {
+        if (!requirePermission(sender, Permissions.CONFIG)) {
             return;
         }
 
@@ -64,7 +65,7 @@ public class ConfigCommand extends CommandBase {
     @Override
     protected List<String> complete(Player player, String label, String[] args) {
         List<String> list = new ArrayList<>();
-        if (player.hasPermission("buildsystem.config")) {
+        if (player.hasPermission(Permissions.CONFIG)) {
             list.add("reload");
         }
         return list;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/ExplosionsCommand.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class ExplosionsCommand extends CommandBase {
     protected void run(Player player, String label, String[] args) {
         String worldName = worldNameFromArgs(player, args, 0);
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, "buildsystem.explosions")) {
+        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, Permissions.EXPLOSIONS)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -63,7 +64,7 @@ public class ExplosionsCommand extends CommandBase {
         List<String> list = new ArrayList<>();
         if (args.length == 1) {
             worldStorage.getBuildWorlds().stream()
-                    .filter(world -> world.getPermissions().canPerformCommand(player, "buildsystem.explosions"))
+                    .filter(world -> world.getPermissions().canPerformCommand(player, Permissions.EXPLOSIONS))
                     .forEach(world -> addArgument(args[0], world.getName(), list));
         }
         return list;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/GamemodeCommand.java
@@ -18,6 +18,7 @@
 package de.eintosti.buildsystem.command;
 
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.*;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
@@ -73,7 +74,7 @@ public class GamemodeCommand extends CommandBase {
         if (args.length == 1) {
             Arrays.stream(GameMode.values())
                     .map(gameMode -> gameMode.name().toLowerCase(Locale.ROOT))
-                    .filter(gameModeName -> player.hasPermission("buildsystem.gamemode.%s".formatted(gameModeName)))
+                    .filter(gameModeName -> player.hasPermission(Permissions.gamemode(gameModeName)))
                     .forEach(gameModeName -> addArgument(args[0], gameModeName, list));
         } else if (args.length == 2) {
             String gameModeName =
@@ -85,7 +86,7 @@ public class GamemodeCommand extends CommandBase {
                         default -> null;
                     };
 
-            if (gameModeName != null && player.hasPermission("buildsystem.gamemode.%s.other".formatted(gameModeName))) {
+            if (gameModeName != null && player.hasPermission(Permissions.gamemodeOther(gameModeName))) {
                 Bukkit.getOnlinePlayers().forEach(pl -> addArgument(args[1], pl.getName(), list));
             }
         }
@@ -102,8 +103,7 @@ public class GamemodeCommand extends CommandBase {
     }
 
     private void setPlayerGamemode(Player player, GameMode gameMode, String gameModeName) {
-        if (!requirePermission(
-                player, "buildsystem.gamemode.%s".formatted(gameMode.name().toLowerCase(Locale.ROOT)))) {
+        if (!requirePermission(player, Permissions.gamemode(gameMode.name()))) {
             return;
         }
 
@@ -112,9 +112,7 @@ public class GamemodeCommand extends CommandBase {
     }
 
     private void setTargetGamemode(Player player, String[] args, GameMode gameMode, String gameModeName) {
-        if (!requirePermission(
-                player,
-                "buildsystem.gamemode.%s.other".formatted(gameMode.name().toLowerCase(Locale.ROOT)))) {
+        if (!requirePermission(player, Permissions.gamemodeOther(gameMode.name()))) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/NoAICommand.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class NoAICommand extends CommandBase {
     protected void run(Player player, String label, String[] args) {
         String worldName = worldNameFromArgs(player, args, 0);
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, "buildsystem.noai")) {
+        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, Permissions.NOAI)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -63,7 +64,7 @@ public class NoAICommand extends CommandBase {
         List<String> list = new ArrayList<>();
         if (args.length == 1) {
             worldStorage.getBuildWorlds().stream()
-                    .filter(world -> world.getPermissions().canPerformCommand(player, "buildsystem.noai"))
+                    .filter(world -> world.getPermissions().canPerformCommand(player, Permissions.NOAI))
                     .forEach(world -> addArgument(args[0], world.getName(), list));
         }
         return list;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/PhysicsCommand.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class PhysicsCommand extends CommandBase {
     protected void run(Player player, String label, String[] args) {
         String worldName = worldNameFromArgs(player, args, 0);
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
-        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, "buildsystem.physics")) {
+        if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, Permissions.PHYSICS)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -73,7 +74,7 @@ public class PhysicsCommand extends CommandBase {
         List<String> list = new ArrayList<>();
         if (args.length == 1) {
             worldStorage.getBuildWorlds().stream()
-                    .filter(world -> world.getPermissions().canPerformCommand(player, "buildsystem.physics"))
+                    .filter(world -> world.getPermissions().canPerformCommand(player, Permissions.PHYSICS))
                     .forEach(world -> addArgument(args[0], world.getName(), list));
         }
         return list;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SettingsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SettingsCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.logging.Logger;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -35,7 +36,7 @@ public class SettingsCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.settings")) {
+        if (!requirePermission(player, Permissions.SETTINGS)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SetupCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SetupCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.logging.Logger;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -35,7 +36,7 @@ public class SetupCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.setup")) {
+        if (!requirePermission(player, Permissions.SETUP)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SkullCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SkullCommand.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.command;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Map;
 import java.util.logging.Logger;
 import org.bukkit.entity.Player;
@@ -34,7 +35,7 @@ public class SkullCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.skull")) {
+        if (!requirePermission(player, Permissions.SKULL)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpawnCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpawnCommand.java
@@ -21,6 +21,7 @@ import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +64,7 @@ public class SpawnCommand extends CommandBase {
             }
 
             case 1 -> {
-                if (!player.hasPermission("buildsystem.spawn")) {
+                if (!player.hasPermission(Permissions.SPAWN)) {
                     messages.sendMessage(player, "spawn_usage");
                     return;
                 }
@@ -101,7 +102,7 @@ public class SpawnCommand extends CommandBase {
             }
 
             default -> {
-                String key = player.hasPermission("buildsystem.spawn") ? "spawn_admin" : "spawn_usage";
+                String key = player.hasPermission(Permissions.SPAWN) ? "spawn_admin" : "spawn_usage";
                 messages.sendMessage(player, key);
             }
         }
@@ -110,7 +111,7 @@ public class SpawnCommand extends CommandBase {
     @Override
     protected List<String> complete(Player player, String label, String[] args) {
         List<String> list = new ArrayList<>();
-        if (player.hasPermission("buildsystem.spawn")) {
+        if (player.hasPermission(Permissions.SPAWN)) {
             addArgument(args[0], "set", list);
             addArgument(args[0], "remove", list);
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpeedCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/SpeedCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class SpeedCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.speed")) {
+        if (!requirePermission(player, Permissions.SPEED)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TimeCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TimeCommand.java
@@ -21,6 +21,7 @@ import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -56,7 +57,7 @@ public class TimeCommand extends CommandBase {
 
         switch (label.toLowerCase(Locale.ROOT)) {
             case "day" -> {
-                if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, "buildsystem.day")) {
+                if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, Permissions.DAY)) {
                     messages.sendPermissionError(player);
                     return;
                 }
@@ -76,7 +77,7 @@ public class TimeCommand extends CommandBase {
             }
 
             case "night" -> {
-                if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, "buildsystem.night")) {
+                if (buildWorld != null && !buildWorld.getPermissions().canPerformCommand(player, Permissions.NIGHT)) {
                     messages.sendPermissionError(player);
                     return;
                 }
@@ -105,7 +106,7 @@ public class TimeCommand extends CommandBase {
             case "day":
             case "night":
                 worldStorage.getBuildWorlds().stream()
-                        .filter(world -> world.getPermissions().canPerformCommand(player, "buildsystem." + lc))
+                        .filter(world -> world.getPermissions().canPerformCommand(player, Permissions.command(lc)))
                         .forEach(world -> addArgument(args[0], world.getName(), list));
                 break;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TopCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/TopCommand.java
@@ -19,6 +19,7 @@ package de.eintosti.buildsystem.command;
 
 import com.cryptomorin.xseries.XSound;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.lifecycle.WorldTeleporterImpl;
 import io.papermc.lib.PaperLib;
 import java.util.logging.Logger;
@@ -35,7 +36,7 @@ public class TopCommand extends CommandBase {
 
     @Override
     protected void run(Player player, String label, String[] args) {
-        if (!requirePermission(player, "buildsystem.top")) {
+        if (!requirePermission(player, Permissions.TOP)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/WorldsCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/WorldsCommand.java
@@ -28,6 +28,7 @@ import de.eintosti.buildsystem.menu.NavigatorItems;
 import de.eintosti.buildsystem.menu.Prompts;
 import de.eintosti.buildsystem.player.PlayerLookupService;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.TaskScheduler;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import de.eintosti.buildsystem.world.backup.BackupServiceImpl;
@@ -102,7 +103,7 @@ public class WorldsCommand extends CommandBase {
     @Override
     protected void run(Player player, String label, String[] args) {
         if (args.length == 0) {
-            if (!requirePermission(player, "buildsystem.navigator")) {
+            if (!requirePermission(player, Permissions.NAVIGATOR)) {
                 return;
             }
             services.menus().openNavigator(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/FolderSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/FolderSubCommand.java
@@ -30,6 +30,7 @@ import de.eintosti.buildsystem.command.subcommand.AbstractSubCommand;
 import de.eintosti.buildsystem.command.subcommand.Argument;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Prompts;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import de.eintosti.buildsystem.world.display.NavigatorCategoryRegistryImpl;
 import java.util.*;
@@ -123,7 +124,7 @@ public class FolderSubCommand extends AbstractSubCommand {
 
         switch (operation) {
             case "add":
-                if (!player.hasPermission("buildsystem.folder.add")) {
+                if (!player.hasPermission(Permissions.FOLDER_ADD)) {
                     messages.sendPermissionError(player);
                     return;
                 }
@@ -161,7 +162,7 @@ public class FolderSubCommand extends AbstractSubCommand {
                 break;
 
             case "remove":
-                if (!player.hasPermission("buildsystem.folder.remove")) {
+                if (!player.hasPermission(Permissions.FOLDER_REMOVE)) {
                     messages.sendPermissionError(player);
                     return;
                 }
@@ -180,7 +181,7 @@ public class FolderSubCommand extends AbstractSubCommand {
     }
 
     private void handlePermissionInput(Player player, Folder folder) {
-        if (!player.hasPermission("buildsystem.folder.setpermission")) {
+        if (!player.hasPermission(Permissions.FOLDER_SETPERMISSION)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -194,7 +195,7 @@ public class FolderSubCommand extends AbstractSubCommand {
     }
 
     private void handleProjectInput(Player player, Folder folder) {
-        if (!player.hasPermission("buildsystem.folder.setproject")) {
+        if (!player.hasPermission(Permissions.FOLDER_SETPROJECT)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -208,7 +209,7 @@ public class FolderSubCommand extends AbstractSubCommand {
     }
 
     private void handleIconChange(Player player, Folder folder) {
-        if (!player.hasPermission("buildsystem.folder.setitem")) {
+        if (!player.hasPermission(Permissions.FOLDER_SETITEM)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -224,7 +225,7 @@ public class FolderSubCommand extends AbstractSubCommand {
     }
 
     private void handleDeletion(Player player, Folder folder) {
-        if (!player.hasPermission("buildsystem.folder.delete")) {
+        if (!player.hasPermission(Permissions.FOLDER_DELETE)) {
             messages.sendPermissionError(player);
             return;
         }
@@ -253,12 +254,12 @@ public class FolderSubCommand extends AbstractSubCommand {
         }
         if (args.length == 3) {
             Map<String, String> subCmds = Map.ofEntries(
-                    entry("add", "buildsystem.folder.add"),
-                    entry("remove", "buildsystem.folder.remove"),
-                    entry("delete", "buildsystem.folder.delete"),
-                    entry("setPermission", "buildsystem.folder.setpermission"),
-                    entry("setProject", "buildsystem.folder.setproject"),
-                    entry("setItem", "buildsystem.folder.setitem"));
+                    entry("add", Permissions.FOLDER_ADD),
+                    entry("remove", Permissions.FOLDER_REMOVE),
+                    entry("delete", Permissions.FOLDER_DELETE),
+                    entry("setPermission", Permissions.FOLDER_SETPERMISSION),
+                    entry("setProject", Permissions.FOLDER_SETPROJECT),
+                    entry("setItem", Permissions.FOLDER_SETITEM));
             subCmds.entrySet().stream()
                     .filter(e -> player.hasPermission(e.getValue()))
                     .forEach(e -> WorldsCompletions.addIfStartsWith(args[2], e.getKey(), result));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/HelpSubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/HelpSubCommand.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.command.PagedCommand;
 import de.eintosti.buildsystem.command.subcommand.Argument;
 import de.eintosti.buildsystem.command.subcommand.SubCommand;
 import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.List;
 import java.util.logging.Logger;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -60,104 +61,86 @@ public class HelpSubCommand extends PagedCommand implements SubCommand {
     protected List<TextComponent> getCommands(Player player) {
         List<TextComponent> commands = Lists.newArrayList(
                 createComponent(player, "/worlds help <page>", "worlds_help_help", "/worlds help", "-"),
-                createComponent(player, "/worlds info", "worlds_help_info", "/worlds info", "buildsystem.info"),
-                createComponent(
-                        player, "/worlds item", "worlds_help_item", "/worlds item", "buildsystem.navigator.item"),
-                createComponent(player, "/worlds tp <world>", "worlds_help_tp", "/worlds tp ", "buildsystem.worldtp"),
-                createComponent(
-                        player, "/worlds edit <world>", "worlds_help_edit", "/worlds edit ", "buildsystem.edit"),
+                createComponent(player, "/worlds info", "worlds_help_info", "/worlds info", Permissions.INFO),
+                createComponent(player, "/worlds item", "worlds_help_item", "/worlds item", Permissions.NAVIGATOR_ITEM),
+                createComponent(player, "/worlds tp <world>", "worlds_help_tp", "/worlds tp ", Permissions.WORLDTP),
+                createComponent(player, "/worlds edit <world>", "worlds_help_edit", "/worlds edit ", Permissions.EDIT),
                 createComponent(
                         player,
                         "/worlds addBuilder <world>",
                         "worlds_help_addbuilder",
                         "/worlds addBuilder ",
-                        "buildsystem.addbuilder"),
+                        Permissions.ADDBUILDER),
                 createComponent(
                         player,
                         "/worlds removeBuilder <world>",
                         "worlds_help_removebuilder",
                         "/worlds removeBuilder ",
-                        "buildsystem.removebuilder"),
+                        Permissions.REMOVEBUILDER),
                 createComponent(
                         player,
                         "/worlds builders <world>",
                         "worlds_help_builders",
                         "/worlds builders ",
-                        "buildsystem.builders"),
+                        Permissions.BUILDERS),
                 createComponent(
-                        player,
-                        "/worlds rename <world>",
-                        "worlds_help_rename",
-                        "/worlds rename ",
-                        "buildsystem.rename"),
+                        player, "/worlds rename <world>", "worlds_help_rename", "/worlds rename ", Permissions.RENAME),
                 createComponent(
                         player,
                         "/worlds setItem <world>",
                         "worlds_help_setitem",
                         "/worlds setItem ",
-                        "buildsystem.setitem"),
+                        Permissions.SETITEM),
                 createComponent(
                         player,
                         "/worlds setCreator <world>",
                         "worlds_help_setcreator",
                         "/worlds setCreator ",
-                        "buildsystem.setcreator"),
+                        Permissions.SETCREATOR),
                 createComponent(
                         player,
                         "/worlds setProject <world>",
                         "worlds_help_setproject",
                         "/worlds setProject ",
-                        "buildsystem.setproject"),
+                        Permissions.SETPROJECT),
                 createComponent(
                         player,
                         "/worlds saveTemplate <world> [template]",
                         "worlds_help_savetemplate",
                         "/worlds saveTemplate ",
-                        "buildsystem.savetemplate"),
+                        Permissions.SAVETEMPLATE),
                 createComponent(
                         player,
                         "/worlds setPermission <world>",
                         "worlds_help_setpermission",
                         "/worlds setPermission ",
-                        "buildsystem.setpermission"),
+                        Permissions.SETPERMISSION),
                 createComponent(
                         player,
                         "/worlds setStatus <world>",
                         "worlds_help_setstatus",
                         "/worlds setStatus ",
-                        "buildsystem.setstatus"),
+                        Permissions.SETSTATUS),
                 createComponent(
-                        player, "/worlds setSpawn", "worlds_help_setspawn", "/worlds setSpawn", "buildsystem.setspawn"),
+                        player, "/worlds setSpawn", "worlds_help_setspawn", "/worlds setSpawn", Permissions.SETSPAWN),
                 createComponent(
                         player,
                         "/worlds removeSpawn",
                         "worlds_help_removespawn",
                         "/worlds removeSpawn",
-                        "buildsystem.removespawn"),
+                        Permissions.REMOVESPAWN),
                 createComponent(
-                        player,
-                        "/worlds delete <world>",
-                        "worlds_help_delete",
-                        "/worlds delete ",
-                        "buildsystem.delete"),
+                        player, "/worlds delete <world>", "worlds_help_delete", "/worlds delete ", Permissions.DELETE),
                 createComponent(
-                        player,
-                        "/worlds import <world>",
-                        "worlds_help_import",
-                        "/worlds import ",
-                        "buildsystem.import"),
+                        player, "/worlds import <world>", "worlds_help_import", "/worlds import ", Permissions.IMPORT),
                 createComponent(
                         player,
                         "/worlds importAll",
                         "worlds_help_importall",
                         "/worlds importAll",
-                        "buildsystem.import.all"),
+                        Permissions.IMPORT_ALL),
                 createComponent(
-                        player,
-                        "/worlds unimport",
-                        "worlds_help_unimport",
-                        "/worlds unimport",
-                        "buildsystem.unimport"));
+                        player, "/worlds unimport", "worlds_help_unimport", "/worlds unimport", Permissions.UNIMPORT));
         commands.removeIf(textComponent -> textComponent.getText().isEmpty());
         return commands;
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsArgument.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsArgument.java
@@ -18,35 +18,36 @@
 package de.eintosti.buildsystem.command.subcommand.worlds;
 
 import de.eintosti.buildsystem.command.subcommand.Argument;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Arrays;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public enum WorldsArgument implements Argument {
-    ADD_BUILDER("addBuilder", "buildsystem.addbuilder"),
-    BACKUP("backup", "buildsystem.backup"),
-    BUILDERS("builders", "buildsystem.builders"),
-    DELETE("delete", "buildsystem.delete"),
-    EDIT("edit", "buildsystem.edit"),
-    FOLDER("folder", "buildsystem.folder"),
-    HELP("help", "buildsystem.help.worlds"),
-    IMPORT("import", "buildsystem.import"),
-    IMPORT_ALL("importAll", "buildsystem.import.all"),
-    INFO("info", "buildsystem.info"),
-    ITEM("item", "buildsystem.navigator.item"),
-    REMOVE_BUILDER("removeBuilder", "buildsystem.removebuilder"),
-    RENAME("rename", "buildsystem.rename"),
-    SAVE_TEMPLATE("saveTemplate", "buildsystem.savetemplate"),
-    SET_CREATOR("setCreator", "buildsystem.setcreator"),
-    SET_ITEM("setItem", "buildsystem.setitem"),
-    SET_PERMISSION("setPermission", "buildsystem.setpermission"),
-    SET_PROJECT("setProject", "buildsystem.setproject"),
-    SET_STATUS("setStatus", "buildsystem.setstatus"),
-    SET_SPAWN("setSpawn", "buildsystem.setspawn"),
-    REMOVE_SPAWN("removeSpawn", "buildsystem.removespawn"),
-    TP("tp", "buildsystem.worldtp"),
-    UNIMPORT("unimport", "buildsystem.unimport");
+    ADD_BUILDER("addBuilder", Permissions.ADDBUILDER),
+    BACKUP("backup", Permissions.BACKUP),
+    BUILDERS("builders", Permissions.BUILDERS),
+    DELETE("delete", Permissions.DELETE),
+    EDIT("edit", Permissions.EDIT),
+    FOLDER("folder", Permissions.FOLDER),
+    HELP("help", Permissions.HELP_WORLDS),
+    IMPORT("import", Permissions.IMPORT),
+    IMPORT_ALL("importAll", Permissions.IMPORT_ALL),
+    INFO("info", Permissions.INFO),
+    ITEM("item", Permissions.NAVIGATOR_ITEM),
+    REMOVE_BUILDER("removeBuilder", Permissions.REMOVEBUILDER),
+    RENAME("rename", Permissions.RENAME),
+    SAVE_TEMPLATE("saveTemplate", Permissions.SAVETEMPLATE),
+    SET_CREATOR("setCreator", Permissions.SETCREATOR),
+    SET_ITEM("setItem", Permissions.SETITEM),
+    SET_PERMISSION("setPermission", Permissions.SETPERMISSION),
+    SET_PROJECT("setProject", Permissions.SETPROJECT),
+    SET_STATUS("setStatus", Permissions.SETSTATUS),
+    SET_SPAWN("setSpawn", Permissions.SETSPAWN),
+    REMOVE_SPAWN("removeSpawn", Permissions.REMOVESPAWN),
+    TP("tp", Permissions.WORLDTP),
+    UNIMPORT("unimport", Permissions.UNIMPORT);
 
     private final String command;
     private final String permission;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/WorldsCompletions.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.command.subcommand.worlds;
 import de.eintosti.buildsystem.api.storage.WorldStorage;
 import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +36,7 @@ final class WorldsCompletions {
 
     /**
      * Returns world names the player may act on, filtered by world-level permission and a command-specific permission
-     * (e.g. "buildsystem.edit").
+     * (e.g. Permissions.EDIT).
      */
     static List<String> permittedWorldNames(
             Player player, WorldStorage worldStorage, @Nullable String commandPermission, String input) {
@@ -62,7 +63,7 @@ final class WorldsCompletions {
             if (deletionBlacklist.contains(world.getName().toLowerCase(Locale.ROOT))) {
                 continue;
             }
-            if (world.getPermissions().canPerformCommand(player, "buildsystem.delete")) {
+            if (world.getPermissions().canPerformCommand(player, Permissions.DELETE)) {
                 addIfStartsWith(input, world.getName(), result);
             }
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/color/AsyncPlayerChatListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/color/AsyncPlayerChatListener.java
@@ -17,6 +17,7 @@
  */
 package de.eintosti.buildsystem.listener.color;
 
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -31,7 +32,7 @@ public class AsyncPlayerChatListener implements Listener {
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         Player player = event.getPlayer();
-        if (!player.hasPermission("buildsystem.color.chat")) {
+        if (!player.hasPermission(Permissions.COLOR_CHAT)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/color/SignChangeListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/color/SignChangeListener.java
@@ -17,6 +17,7 @@
  */
 package de.eintosti.buildsystem.listener.color;
 
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -31,7 +32,7 @@ public class SignChangeListener implements Listener {
     @EventHandler
     public void onSignChange(SignChangeEvent event) {
         Player player = event.getPlayer();
-        if (!player.hasPermission("buildsystem.color.sign")) {
+        if (!player.hasPermission(Permissions.COLOR_SIGN)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/navigator/NavigatorListener.java
@@ -37,6 +37,7 @@ import de.eintosti.buildsystem.navigator.NavigatorService;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
 import de.eintosti.buildsystem.player.CachedValues;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Objects;
 import java.util.UUID;
 import org.bukkit.Material;
@@ -111,7 +112,7 @@ public class NavigatorListener implements Listener {
 
         if (navigatorItems.is(itemStack)) {
             event.setCancelled(true);
-            if (!player.hasPermission("buildsystem.navigator.item")) {
+            if (!player.hasPermission(Permissions.NAVIGATOR_ITEM)) {
                 messages.sendPermissionError(player);
                 return;
             }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerChangedWorldListener.java
@@ -29,6 +29,7 @@ import de.eintosti.buildsystem.navigator.NavigatorService;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
 import de.eintosti.buildsystem.player.CachedValues;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -79,7 +80,7 @@ public class PlayerChangedWorldListener implements Listener {
         BuildWorld newWorld = worldStorage.getBuildWorld(worldName);
         if (newWorld != null
                 && !newWorld.getData().get(WorldDataKey.PHYSICS)
-                && player.hasPermission("buildsystem.physics.message")) {
+                && player.hasPermission(Permissions.PHYSICS_MESSAGE)) {
             messages.sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", newWorld.getName()));
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/player/PlayerJoinListener.java
@@ -34,6 +34,7 @@ import de.eintosti.buildsystem.player.PlayerLookupService;
 import de.eintosti.buildsystem.player.noclip.NoClipService;
 import de.eintosti.buildsystem.player.settings.SettingsImpl;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.TaskScheduler;
 import de.eintosti.buildsystem.util.UpdateChecker;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
@@ -115,7 +116,7 @@ public class PlayerJoinListener implements Listener {
         BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
         if (buildWorld != null) {
             WorldData worldData = buildWorld.getData();
-            if (!worldData.get(WorldDataKey.PHYSICS) && player.hasPermission("buildsystem.physics.message")) {
+            if (!worldData.get(WorldDataKey.PHYSICS) && player.hasPermission(Permissions.PHYSICS_MESSAGE)) {
                 messages.sendMessage(player, "physics_deactivated_in_world", Map.entry("%world%", worldName));
             }
 
@@ -128,7 +129,7 @@ public class PlayerJoinListener implements Listener {
             }
         }
 
-        if (player.hasPermission("buildsystem.updates")) {
+        if (player.hasPermission(Permissions.UPDATES)) {
             performUpdateCheck(player);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlayerInventoryClearListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlayerInventoryClearListener.java
@@ -21,6 +21,7 @@ import de.eintosti.buildsystem.api.player.settings.Settings;
 import de.eintosti.buildsystem.event.player.PlayerInventoryClearEvent;
 import de.eintosti.buildsystem.menu.NavigatorItems;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -43,7 +44,7 @@ public class PlayerInventoryClearListener implements Listener {
     public void onPlayerInventoryClear(PlayerInventoryClearEvent event) {
         Player player = event.getPlayer();
         Settings settings = settingsManager.getSettings(player);
-        if (!settings.isKeepNavigator() || !player.hasPermission("buildsystem.navigator.item")) {
+        if (!settings.isKeepNavigator() || !player.hasPermission(Permissions.NAVIGATOR_ITEM)) {
             return;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
@@ -28,6 +28,7 @@ import de.eintosti.buildsystem.menu.NavigatorItems;
 import de.eintosti.buildsystem.player.BuildPlayerImpl;
 import de.eintosti.buildsystem.player.CachedValues;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.TaskScheduler;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import de.eintosti.buildsystem.world.display.NavigatorCategoryRegistryImpl;
@@ -182,7 +183,7 @@ public class NavigatorService {
 
     public void giveNavigator(Player player) {
         if (!configService.current().settings().navigator().giveItemOnJoin()
-                || !player.hasPermission("buildsystem.navigator.item")
+                || !player.hasPermission(Permissions.NAVIGATOR_ITEM)
                 || navigatorItems.has(player)) {
             return;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SettingsMenu.java
@@ -32,6 +32,7 @@ import de.eintosti.buildsystem.menu.Menus;
 import de.eintosti.buildsystem.navigator.NavigatorService;
 import de.eintosti.buildsystem.player.noclip.NoClipService;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -48,7 +49,6 @@ import org.jspecify.annotations.Nullable;
 public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
 
     private static final int DESIGN_SLOT = 11;
-    private static final String PERMISSION_PREFIX = "buildsystem.setting.";
 
     /**
      * Classifies a settings slot's click behavior, so the per-slot contract can be asserted as data. {@code TOGGLE}
@@ -90,7 +90,7 @@ public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
          */
         @Override
         public @Nullable String permission() {
-            return node == null ? null : PERMISSION_PREFIX + node;
+            return node == null ? null : Permissions.setting(node);
         }
 
         static Builder builder() {
@@ -410,7 +410,7 @@ public class SettingsMenu extends ButtonMenu<SettingsMenu.SettingsButton> {
         buttons().forEach((slot, button) -> {
             String node = button.node();
             if (node != null) {
-                nodes.put(slot, PERMISSION_PREFIX + node);
+                nodes.put(slot, Permissions.setting(node));
             }
         });
         return nodes;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/player/menu/SpeedMenu.java
@@ -24,6 +24,7 @@ import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.ItemBuilder;
 import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.player.settings.SettingsService;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Map;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -67,7 +68,7 @@ public class SpeedMenu extends ButtonMenu<MenuButton> {
                                 .name(messages.getString(option.nameKey(), player))
                                 .build()))
                 .onClick((player, event) -> {
-                    if (!player.hasPermission("buildsystem.speed")) {
+                    if (!player.hasPermission(Permissions.SPEED)) {
                         player.closeInventory();
                         return;
                     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/protection/WorldProtectionPolicy.java
@@ -22,6 +22,7 @@ import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.util.Permissions;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -67,7 +68,7 @@ public final class WorldProtectionPolicy {
      */
     public Denial checkStatus(Player player, BuildWorld world) {
         if (world.getPermissions().canBypassBuildRestriction(player)
-                || player.hasPermission("buildsystem.bypass.archive")) {
+                || player.hasPermission(Permissions.BYPASS_ARCHIVE)) {
             return Denial.NONE;
         }
 
@@ -88,7 +89,7 @@ public final class WorldProtectionPolicy {
      */
     public Denial checkBuilders(Player player, BuildWorld world) {
         if (world.getPermissions().canBypassBuildRestriction(player)
-                || player.hasPermission("buildsystem.bypass.builders")) {
+                || player.hasPermission(Permissions.BYPASS_BUILDERS)) {
             return Denial.NONE;
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/Permissions.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/Permissions.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.util;
+
+import java.util.Locale;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Every permission node the plugin checks. Nodes are declared here rather than inline so a typo is a compile error
+ * instead of a check that silently never passes, and so the full set the plugin ships can be read in one place.
+ *
+ * <p>Nodes whose last segment is supplied at runtime (world types, templates, generators, navigator categories,
+ * statuses, settings toggles, gamemodes) are built by the helper methods at the bottom rather than by concatenating
+ * a prefix at the call site.
+ */
+@NullMarked
+public final class Permissions {
+
+    private Permissions() {}
+
+    public static final String ADDBUILDER = "buildsystem.addbuilder";
+    public static final String ADMIN = "buildsystem.admin";
+    public static final String BACK = "buildsystem.back";
+    public static final String BACKUP = "buildsystem.backup";
+    public static final String BLOCKS = "buildsystem.blocks";
+    public static final String BUILD = "buildsystem.build";
+    public static final String BUILD_OTHER = "buildsystem.build.other";
+    public static final String BUILDERS = "buildsystem.builders";
+    public static final String BYPASS_ARCHIVE = "buildsystem.bypass.archive";
+    public static final String BYPASS_BUILDERS = "buildsystem.bypass.builders";
+    public static final String BYPASS_PERMISSION = "buildsystem.bypass.permission";
+    public static final String BYPASS_PERMISSION_ARCHIVE = "buildsystem.bypass.permission.archive";
+    public static final String BYPASS_PERMISSION_PRIVATE = "buildsystem.bypass.permission.private";
+    public static final String BYPASS_PERMISSION_PUBLIC = "buildsystem.bypass.permission.public";
+    public static final String BYPASS_SETTINGS = "buildsystem.bypass.settings";
+    public static final String COLOR_CHAT = "buildsystem.color.chat";
+    public static final String COLOR_SIGN = "buildsystem.color.sign";
+    public static final String CONFIG = "buildsystem.config";
+    public static final String CREATE_FOLDER = "buildsystem.create.folder";
+    public static final String DAY = "buildsystem.day";
+    public static final String DELETE = "buildsystem.delete";
+    public static final String EDIT = "buildsystem.edit";
+    public static final String EDIT_BREAKING = "buildsystem.edit.breaking";
+    public static final String EDIT_BUILDERS = "buildsystem.edit.builders";
+    public static final String EDIT_DIFFICULTY = "buildsystem.edit.difficulty";
+    public static final String EDIT_ENTITIES = "buildsystem.edit.entities";
+    public static final String EDIT_EXPLOSIONS = "buildsystem.edit.explosions";
+    public static final String EDIT_GAMERULES = "buildsystem.edit.gamerules";
+    public static final String EDIT_ICON = "buildsystem.edit.icon";
+    public static final String EDIT_INTERACTIONS = "buildsystem.edit.interactions";
+    public static final String EDIT_MOBAI = "buildsystem.edit.mobai";
+    public static final String EDIT_PERMISSION = "buildsystem.edit.permission";
+    public static final String EDIT_PHYSICS = "buildsystem.edit.physics";
+    public static final String EDIT_PIN = "buildsystem.edit.pin";
+    public static final String EDIT_PLACEMENT = "buildsystem.edit.placement";
+    public static final String EDIT_PROJECT = "buildsystem.edit.project";
+    public static final String EDIT_STATUS = "buildsystem.edit.status";
+    public static final String EDIT_TIME = "buildsystem.edit.time";
+    public static final String EDIT_VISIBILITY = "buildsystem.edit.visibility";
+    public static final String EXPLOSIONS = "buildsystem.explosions";
+    public static final String FOLDER = "buildsystem.folder";
+    public static final String FOLDER_ADD = "buildsystem.folder.add";
+    public static final String FOLDER_DELETE = "buildsystem.folder.delete";
+    public static final String FOLDER_REMOVE = "buildsystem.folder.remove";
+    public static final String FOLDER_SETITEM = "buildsystem.folder.setitem";
+    public static final String FOLDER_SETPERMISSION = "buildsystem.folder.setpermission";
+    public static final String FOLDER_SETPROJECT = "buildsystem.folder.setproject";
+    public static final String GAMEMODE = "buildsystem.gamemode";
+    public static final String HELP_BUILDSYSTEM = "buildsystem.help.buildsystem";
+    public static final String HELP_WORLDS = "buildsystem.help.worlds";
+    public static final String IMPORT = "buildsystem.import";
+    public static final String IMPORT_ALL = "buildsystem.import.all";
+    public static final String INFO = "buildsystem.info";
+    public static final String NAVIGATOR = "buildsystem.navigator";
+    public static final String NAVIGATOR_ITEM = "buildsystem.navigator.item";
+    public static final String NIGHT = "buildsystem.night";
+    public static final String NOAI = "buildsystem.noai";
+    public static final String PHYSICS = "buildsystem.physics";
+    public static final String PHYSICS_MESSAGE = "buildsystem.physics.message";
+    public static final String REMOVEBUILDER = "buildsystem.removebuilder";
+    public static final String REMOVESPAWN = "buildsystem.removespawn";
+    public static final String RENAME = "buildsystem.rename";
+    public static final String SAVETEMPLATE = "buildsystem.savetemplate";
+    public static final String SETCREATOR = "buildsystem.setcreator";
+    public static final String SETITEM = "buildsystem.setitem";
+    public static final String SETPERMISSION = "buildsystem.setpermission";
+    public static final String SETPROJECT = "buildsystem.setproject";
+    public static final String SETSPAWN = "buildsystem.setspawn";
+    public static final String SETSTATUS = "buildsystem.setstatus";
+    public static final String SETTINGS = "buildsystem.settings";
+    public static final String SETUP = "buildsystem.setup";
+    public static final String SKULL = "buildsystem.skull";
+    public static final String SPAWN = "buildsystem.spawn";
+    public static final String SPEED = "buildsystem.speed";
+    public static final String TOP = "buildsystem.top";
+    public static final String UNIMPORT = "buildsystem.unimport";
+    public static final String UPDATES = "buildsystem.updates";
+    public static final String WORLDTP = "buildsystem.worldtp";
+
+    /**
+     * {@return the permission to create a world of the given type} The type is lowercased, matching the nodes
+     * declared in {@code plugin.yml}.
+     *
+     * @param worldType The world type name
+     */
+    public static String createType(String worldType) {
+        return "buildsystem.create.type." + worldType.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * {@return the permission to create a world from the given template}
+     *
+     * @param templateName The template name, as it appears on disk
+     */
+    public static String createTemplate(String templateName) {
+        return "buildsystem.create.template." + templateName;
+    }
+
+    /**
+     * {@return the permission to create a world with the given custom generator}
+     *
+     * @param generatorName The generator name
+     */
+    public static String createGenerator(String generatorName) {
+        return "buildsystem.create.generator." + generatorName;
+    }
+
+    /**
+     * {@return the permission to create a world in the given navigator category}
+     *
+     * @param categoryId The category id
+     */
+    public static String createInCategory(String categoryId) {
+        return "buildsystem.create." + categoryId;
+    }
+
+    /**
+     * {@return the permission to see the given navigator category and use its {@code /worlds <category>} shortcut}
+     *
+     * @param categoryId The category id
+     */
+    public static String navigatorCategory(String categoryId) {
+        return "buildsystem.navigator." + categoryId;
+    }
+
+    /**
+     * {@return the permission to assign the given world status}
+     *
+     * @param statusId The status id
+     */
+    public static String setStatus(String statusId) {
+        return "buildsystem.setstatus." + statusId.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * {@return the permission to toggle the given {@code /settings} option}
+     *
+     * @param node The settings node, e.g. {@code no-clip}
+     */
+    public static String setting(String node) {
+        return "buildsystem.setting." + node;
+    }
+
+    /**
+     * {@return the permission to change one's own gamemode}
+     *
+     * @param gameMode The gamemode name
+     */
+    public static String gamemode(String gameMode) {
+        return "buildsystem.gamemode." + gameMode.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * {@return the permission to change another player's gamemode}
+     *
+     * @param gameMode The gamemode name
+     */
+    public static String gamemodeOther(String gameMode) {
+        return "buildsystem.gamemode." + gameMode.toLowerCase(Locale.ROOT) + ".other";
+    }
+
+    /**
+     * {@return the per-world command permission for the given command name} Used by the time commands, which gate
+     * {@code /day}, {@code /night} and friends per world.
+     *
+     * @param command The command name
+     */
+    public static String command(String command) {
+        return "buildsystem." + command.toLowerCase(Locale.ROOT);
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldCreationPrompts.java
@@ -26,6 +26,7 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldType;
 import de.eintosti.buildsystem.api.world.display.Folder;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.Prompts;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import de.eintosti.buildsystem.world.creation.generator.CustomGeneratorImpl;
 import java.util.Objects;
@@ -105,7 +106,7 @@ public class WorldCreationPrompts {
     private boolean generatorStep(Player player, Selection selection, String input) {
         // Generator names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is emulated: a
         // generator is permitted unless an admin has explicitly denied its specific node.
-        String generatorNode = "buildsystem.create.generator." + input.trim();
+        String generatorNode = Permissions.createGenerator(input.trim());
         boolean allowed = !player.isPermissionSet(generatorNode) || player.hasPermission(generatorNode);
         if (!allowed) {
             messages.sendPermissionError(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldDataImpl.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.data.Visibility;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.api.world.display.Folder;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.data.type.Bypassable;
 import de.eintosti.buildsystem.world.data.type.ConfigurableProperty;
 import de.eintosti.buildsystem.world.data.type.Overridable;
@@ -86,7 +87,7 @@ public class WorldDataImpl implements WorldData {
         register(
                 WorldDataKey.PERMISSION,
                 new ConfigurableProperty<>(builder.permission)
-                        .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.permission"))
+                        .withCapability(Bypassable.class, new Bypassable(Permissions.BYPASS_PERMISSION))
                         .withCapability(
                                 Overridable.class,
                                 folderOverride(builder.permissionOverrideEnabled, Folder::getPermission)));
@@ -107,7 +108,7 @@ public class WorldDataImpl implements WorldData {
                 WorldDataKey.STATUS,
                 new ConfigurableProperty<>(Objects.requireNonNull(builder.status, "status"))
                         .withConfigFormatter(BuildWorldStatus::getId)
-                        .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.archive")));
+                        .withCapability(Bypassable.class, new Bypassable(Permissions.BYPASS_ARCHIVE)));
 
         register(WorldDataKey.BLOCK_BREAKING, settingsBypassable(builder.blockBreaking));
         register(WorldDataKey.BLOCK_INTERACTIONS, settingsBypassable(builder.blockInteractions));
@@ -164,7 +165,7 @@ public class WorldDataImpl implements WorldData {
      */
     private static ConfigurableProperty<Boolean> settingsBypassable(boolean defaultValue) {
         return new ConfigurableProperty<>(defaultValue)
-                .withCapability(Bypassable.class, new Bypassable("buildsystem.bypass.settings"));
+                .withCapability(Bypassable.class, new Bypassable(Permissions.BYPASS_SETTINGS));
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
@@ -18,7 +18,7 @@
 package de.eintosti.buildsystem.world.data;
 
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
-import java.util.Locale;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Optional;
 import org.bukkit.Material;
 import org.jspecify.annotations.NullMarked;
@@ -116,7 +116,7 @@ public final class WorldStatusImpl implements BuildWorldStatus {
         // cannot
         // collapse onto the same permission node.
         String node = builtIn ? id.replace("_", "") : id;
-        return "buildsystem.setstatus." + node.toLowerCase(Locale.ROOT);
+        return Permissions.setStatus(node);
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/CategoryPermissions.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/CategoryPermissions.java
@@ -17,6 +17,7 @@
  */
 package de.eintosti.buildsystem.world.display;
 
+import de.eintosti.buildsystem.util.Permissions;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -41,7 +42,7 @@ public final class CategoryPermissions {
      * @param categoryId The category id
      */
     public static String node(String categoryId) {
-        return "buildsystem.navigator." + categoryId;
+        return Permissions.navigatorCategory(categoryId);
     }
 
     /**

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/lifecycle/WorldPermissionsImpl.java
@@ -24,6 +24,7 @@ import de.eintosti.buildsystem.api.world.access.WorldSetting;
 import de.eintosti.buildsystem.api.world.builder.Builders;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.WorldContext;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -90,7 +91,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
         }
 
         if (!buildWorld.getData().get(WorldDataKey.STATUS).isBuildingAllowed()
-                && !player.hasPermission("buildsystem.bypass.archive")) {
+                && !player.hasPermission(Permissions.BYPASS_ARCHIVE)) {
             return false;
         }
 
@@ -106,7 +107,7 @@ public class WorldPermissionsImpl implements WorldPermissions {
         Builders builders = buildWorld.getBuilders();
         return builders.isCreator(player)
                 || builders.isBuilder(player)
-                || player.hasPermission("buildsystem.bypass.builders")
+                || player.hasPermission(Permissions.BYPASS_BUILDERS)
                 || !buildWorld.getData().get(WorldDataKey.BUILDERS_ENABLED);
     }
 
@@ -147,12 +148,12 @@ public class WorldPermissionsImpl implements WorldPermissions {
 
         WorldData worldData = buildWorld.getData();
         if (!worldData.get(WorldDataKey.STATUS).isBuildingAllowed()) {
-            return player.hasPermission("buildsystem.bypass.permission.archive");
+            return player.hasPermission(Permissions.BYPASS_PERMISSION_ARCHIVE);
         }
 
         return worldData.get(WorldDataKey.VISIBILITY).isPrivate()
-                ? player.hasPermission("buildsystem.bypass.permission.private")
-                : player.hasPermission("buildsystem.bypass.permission.public");
+                ? player.hasPermission(Permissions.BYPASS_PERMISSION_PRIVATE)
+                : player.hasPermission(Permissions.BYPASS_PERMISSION_PUBLIC);
     }
 
     @Override

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CategoryWorldsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CategoryWorldsMenu.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.BuildWorld;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
 import de.eintosti.buildsystem.menu.ItemBuilder;
 import de.eintosti.buildsystem.menu.SkullTextures;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import de.eintosti.buildsystem.world.data.WorldStatusRegistryImpl;
 import org.bukkit.entity.Player;
@@ -76,7 +77,7 @@ public class CategoryWorldsMenu extends DisplayablesMenu {
                     .name(messages.getString("world_navigator_create_world", player))
                     .into(inventory, SLOT_CREATE_WORLD);
         }
-        if (player.hasPermission("buildsystem.create.folder")) {
+        if (player.hasPermission(Permissions.CREATE_FOLDER)) {
             // With the create-world button hidden, centre the lone folder button instead of leaving it off to the side.
             int folderSlot = createWorld ? SLOT_CREATE_FOLDER : SLOT_CREATE_CENTER;
             ItemBuilder.skull(Profileable.detect(CREATE_FOLDER_PROFILE))
@@ -103,6 +104,6 @@ public class CategoryWorldsMenu extends DisplayablesMenu {
      */
     private boolean hasCreatePermission(Player player) {
         return player.hasPermission(BuildSystemPlugin.ADMIN_PERMISSION)
-                || player.hasPermission("buildsystem.create." + category.getId());
+                || player.hasPermission(Permissions.createInCategory(category.getId()));
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CreateMenu.java
@@ -31,11 +31,11 @@ import de.eintosti.buildsystem.menu.Menus;
 import de.eintosti.buildsystem.menu.PaginatedMenu;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.util.FileUtils;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.WorldServiceImpl;
 import de.eintosti.buildsystem.world.display.CustomizableIcons;
 import java.io.File;
 import java.util.Arrays;
-import java.util.Locale;
 import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -185,8 +185,7 @@ public class CreateMenu extends PaginatedMenu {
     }
 
     private static boolean canCreateType(Player player, BuildWorldType worldType) {
-        return player.hasPermission(
-                "buildsystem.create.type." + worldType.name().toLowerCase(Locale.ROOT));
+        return player.hasPermission(Permissions.createType(worldType.name()));
     }
 
     private void registerGenerator(Player player) {
@@ -245,7 +244,7 @@ public class CreateMenu extends PaginatedMenu {
                 .onClick((player, event) -> {
                     // Template names are dynamic and cannot be pre-registered in plugin.yml, so default-allow is
                     // emulated: a template is permitted unless an admin has explicitly denied its specific node.
-                    String templateNode = "buildsystem.create.template." + rawTemplateName;
+                    String templateNode = Permissions.createTemplate(rawTemplateName);
                     if (player.isPermissionSet(templateNode) && !player.hasPermission(templateNode)) {
                         XSound.ENTITY_ITEM_BREAK.play(player);
                         return;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenu.java
@@ -31,6 +31,7 @@ import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.*;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -186,7 +187,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_WORLD_INFO,
                 EditButton.builder()
-                        .permission("buildsystem.edit.icon")
+                        .permission(Permissions.EDIT_ICON)
                         .outcome(ClickOutcome.SUBMENU)
                         .render(this::renderWorldInfo)
                         .onClick(this::onWorldInfoClick)
@@ -208,7 +209,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_TIME,
                 EditButton.builder()
-                        .permission("buildsystem.edit.time")
+                        .permission(Permissions.EDIT_TIME)
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderTime)
                         .onClick((player, event) -> {
@@ -220,7 +221,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_BUTCHER,
                 EditButton.builder()
-                        .permission("buildsystem.edit.entities")
+                        .permission(Permissions.EDIT_ENTITIES)
                         .outcome(ClickOutcome.CLOSE)
                         .render(this::renderButcher)
                         .onClick((player, event) -> removeEntities(player))
@@ -229,7 +230,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_PHYSICS,
                 EditButton.builder()
-                        .permission("buildsystem.edit.physics")
+                        .permission(Permissions.EDIT_PHYSICS)
                         .outcome(ClickOutcome.REOPEN)
                         .render((player, inventory) -> menuItems.addToggleItem(
                                 player,
@@ -245,7 +246,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_BUILDERS,
                 EditButton.builder()
-                        .permission("buildsystem.edit.builders")
+                        .permission(Permissions.EDIT_BUILDERS)
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderBuilders)
                         .onClick(this::onBuildersClick)
@@ -254,7 +255,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_VISIBILITY,
                 EditButton.builder()
-                        .permission("buildsystem.edit.visibility")
+                        .permission(Permissions.EDIT_VISIBILITY)
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderVisibility)
                         .onClick(this::onVisibilityClick)
@@ -263,7 +264,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_GAMERULES,
                 EditButton.builder()
-                        .permission("buildsystem.edit.gamerules")
+                        .permission(Permissions.EDIT_GAMERULES)
                         .outcome(ClickOutcome.SUBMENU)
                         .render(this::renderGameRules)
                         .onClick((player, event) -> {
@@ -275,7 +276,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_DIFFICULTY,
                 EditButton.builder()
-                        .permission("buildsystem.edit.difficulty")
+                        .permission(Permissions.EDIT_DIFFICULTY)
                         .outcome(ClickOutcome.REOPEN)
                         .render(this::renderDifficulty)
                         .onClick((player, event) -> {
@@ -287,7 +288,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_STATUS,
                 EditButton.builder()
-                        .permission("buildsystem.edit.status")
+                        .permission(Permissions.EDIT_STATUS)
                         .outcome(ClickOutcome.SUBMENU)
                         .render(this::renderStatus)
                         .onClick((player, event) -> {
@@ -299,7 +300,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_PROJECT,
                 EditButton.builder()
-                        .permission("buildsystem.edit.project")
+                        .permission(Permissions.EDIT_PROJECT)
                         .outcome(ClickOutcome.INPUT)
                         .render(this::renderProject)
                         .onClick((player, event) -> {
@@ -311,7 +312,7 @@ public class EditMenu extends ButtonMenu<EditMenu.EditButton> {
         register(
                 SLOT_PERMISSION,
                 EditButton.builder()
-                        .permission("buildsystem.edit.permission")
+                        .permission(Permissions.EDIT_PERMISSION)
                         .outcome(ClickOutcome.INPUT)
                         .render(this::renderPermission)
                         .onClick((player, event) -> {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenuToggles.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/EditMenuToggles.java
@@ -23,6 +23,7 @@ import com.cryptomorin.xseries.XMaterial;
 import de.eintosti.buildsystem.api.world.data.WorldData;
 import de.eintosti.buildsystem.api.world.data.WorldDataKey;
 import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.util.Permissions;
 import java.util.Map;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -45,7 +46,7 @@ final class EditMenuToggles {
                     new Toggle(
                             XMaterial.ITEM_FRAME,
                             XMaterial.GLOW_ITEM_FRAME,
-                            "buildsystem.edit.pin",
+                            Permissions.EDIT_PIN,
                             "worldeditor_pin_item",
                             "worldeditor_pin_lore",
                             WorldDataKey.PINNED)),
@@ -53,7 +54,7 @@ final class EditMenuToggles {
                     20,
                     new Toggle(
                             XMaterial.OAK_PLANKS,
-                            "buildsystem.edit.breaking",
+                            Permissions.EDIT_BREAKING,
                             "worldeditor_blockbreaking_item",
                             "worldeditor_blockbreaking_lore",
                             WorldDataKey.BLOCK_BREAKING)),
@@ -61,7 +62,7 @@ final class EditMenuToggles {
                     21,
                     new Toggle(
                             XMaterial.POLISHED_ANDESITE,
-                            "buildsystem.edit.placement",
+                            Permissions.EDIT_PLACEMENT,
                             "worldeditor_blockplacement_item",
                             "worldeditor_blockplacement_lore",
                             WorldDataKey.BLOCK_PLACEMENT)),
@@ -69,7 +70,7 @@ final class EditMenuToggles {
                     24,
                     new Toggle(
                             XMaterial.TNT,
-                            "buildsystem.edit.explosions",
+                            Permissions.EDIT_EXPLOSIONS,
                             "worldeditor_explosions_item",
                             "worldeditor_explosions_lore",
                             WorldDataKey.EXPLOSIONS)),
@@ -77,7 +78,7 @@ final class EditMenuToggles {
                     31,
                     new Toggle(
                             XMaterial.ARMOR_STAND,
-                            "buildsystem.edit.mobai",
+                            Permissions.EDIT_MOBAI,
                             "worldeditor_mobai_item",
                             "worldeditor_mobai_lore",
                             WorldDataKey.MOB_AI)),
@@ -85,7 +86,7 @@ final class EditMenuToggles {
                     33,
                     new Toggle(
                             XMaterial.TRIPWIRE_HOOK,
-                            "buildsystem.edit.interactions",
+                            Permissions.EDIT_INTERACTIONS,
                             "worldeditor_blockinteractions_item",
                             "worldeditor_blockinteractions_lore",
                             WorldDataKey.BLOCK_INTERACTIONS)));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
@@ -27,6 +27,7 @@ import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.MenuItems;
 import de.eintosti.buildsystem.menu.Menus;
 import de.eintosti.buildsystem.menu.SkullTextures;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.util.color.ColorAPI;
 import de.eintosti.buildsystem.world.display.CategoryPermissions;
 import de.eintosti.buildsystem.world.display.NavigatorCategoryRegistryImpl;
@@ -91,7 +92,7 @@ public class NavigatorMenu extends ButtonMenu<MenuButton> {
                         .name(messages.getString("old_navigator_settings", player))
                         .into(inventory, slot))
                 .onClick((player, event) -> {
-                    if (!player.hasPermission("buildsystem.settings")) {
+                    if (!player.hasPermission(Permissions.SETTINGS)) {
                         XSound.ENTITY_ITEM_BREAK.play(player);
                         return;
                     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/PhysicsMenu.java
@@ -29,6 +29,7 @@ import de.eintosti.buildsystem.menu.ButtonMenu;
 import de.eintosti.buildsystem.menu.MenuButton;
 import de.eintosti.buildsystem.menu.MenuItems;
 import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.util.Permissions;
 import de.eintosti.buildsystem.world.menu.EditMenuToggles.Toggle;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class PhysicsMenu extends ButtonMenu<MenuButton> {
 
-    private static final String PERMISSION = "buildsystem.edit.physics";
+    private static final String PERMISSION = Permissions.EDIT_PHYSICS;
 
     private static final int MENU_SIZE = 45;
     private static final int SLOT_MASTER = 4;

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/util/PermissionsTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/util/PermissionsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the single-source-of-truth property of {@link Permissions}: permission nodes belong there, not inline at the
+ * call site, so a typo fails to compile instead of silently never matching.
+ */
+class PermissionsTest {
+
+    private static final Path SOURCE_ROOT = Path.of("src/main/java");
+    private static final Path PERMISSIONS = SOURCE_ROOT.resolve("de/eintosti/buildsystem/util/Permissions.java");
+    private static final Pattern NODE = Pattern.compile("\"buildsystem\\.[a-z.%]*\"");
+
+    @Test
+    @DisplayName("No permission node is written inline outside Permissions")
+    void permissionNodesAreCentralized() throws IOException {
+        try (Stream<Path> sources = Files.walk(SOURCE_ROOT)) {
+            List<String> offenders = sources.filter(path -> path.toString().endsWith(".java"))
+                    .filter(path -> !path.equals(PERMISSIONS))
+                    .flatMap(PermissionsTest::nodesIn)
+                    .toList();
+
+            assertTrue(
+                    offenders.isEmpty(),
+                    "Permission nodes must be declared in Permissions, not inline. Found: " + offenders);
+        }
+    }
+
+    private static Stream<String> nodesIn(Path path) {
+        String source;
+        try {
+            source = Files.readString(path);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + path, e);
+        }
+
+        Matcher matcher = NODE.matcher(source);
+        Stream.Builder<String> found = Stream.builder();
+        while (matcher.find()) {
+            found.add(path.getFileName() + ": " + matcher.group());
+        }
+        return found.build();
+    }
+}


### PR DESCRIPTION
Permission nodes were written inline at 160-odd call sites across 37 files. A typo in one of those strings doesn't fail to compile — it produces a check that silently never passes (or, for a deny, never denies), and there was no single place to read what the plugin actually ships.

The pattern already existed for commands: `WorldsArgument` pairs each subcommand with its node. It just wasn't the source of truth — `HelpSubCommand` hardcoded `"buildsystem.edit"` right next to `WorldsArgument.EDIT` holding the same string.

All 78 static nodes are now constants on `Permissions`. The nodes whose last segment is supplied at runtime get helpers rather than a prefix concatenated at the call site:

```java
Permissions.createType(worldType.name())
Permissions.createTemplate(templateName)
Permissions.createGenerator(generatorName)
Permissions.createInCategory(categoryId)
Permissions.navigatorCategory(categoryId)
Permissions.setStatus(statusId)
Permissions.setting(node)
Permissions.gamemode(name) / gamemodeOther(name)
Permissions.command(name)
```

Those helpers also absorb the `toLowerCase(Locale.ROOT)` calls that were repeated at each site.

### Not included

I deliberately did **not** mass-declare the undeclared nodes in the `permissions {}` block. An undeclared node defaults to op-only, which is already the intended behaviour for admin operations — the block declares exactly the nodes that need `default = TRUE` or parent/child grouping. Declaring the rest would be a behaviour change dressed up as tidying.

### Guard

`PermissionsTest` walks `src/main/java` and fails if any file outside `Permissions` contains a `"buildsystem.*"` literal, so this doesn't drift back one convenient inline string at a time.

`SettingsMenu.PERMISSION_PREFIX` is gone, replaced by `Permissions.setting(node)`.
