### PR TITLE
fix: codec serialize maps cannot hold null values

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
@@ -73,17 +73,21 @@ public final class FolderCodec implements Codec<Folder> {
     }
 
     @Override
-    public Map<String, @Nullable Object> serialize(Folder folder) {
-        Map<String, @Nullable Object> serialized = new HashMap<>();
+    public Map<String, Object> serialize(Folder folder) {
+        Map<String, Object> serialized = new HashMap<>();
         serialized.put(NAME, folder.getName());
         serialized.put(UUID_KEY, folder.getUniqueId().toString());
         serialized.put(CREATOR, folder.getCreator().toString());
         serialized.put(CREATION, folder.getCreation());
         serialized.put(CATEGORY, folder.getCategory().getId());
-        serialized.put(
-                PARENT, folder.hasParent() ? folder.getParent().getUniqueId().toString() : null);
+        if (folder.hasParent()) {
+            serialized.put(PARENT, folder.getParent().getUniqueId().toString());
+        }
         serialized.put(MATERIAL, folder.getIcon().name());
-        serialized.put(ICON_SKULL_TEXTURE, folder.getIconSkullTexture());
+        String skullTexture = folder.getIconSkullTexture();
+        if (skullTexture != null) {
+            serialized.put(ICON_SKULL_TEXTURE, skullTexture);
+        }
         serialized.put(PERMISSION, folder.getPermission());
         serialized.put(PROJECT, folder.getProject());
         serialized.put(

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/PlayerCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/PlayerCodec.java
@@ -81,9 +81,9 @@ public final class PlayerCodec implements Codec<BuildPlayer> {
     }
 
     @Override
-    public Map<String, @Nullable Object> serialize(BuildPlayer value) {
+    public Map<String, Object> serialize(BuildPlayer value) {
         BuildPlayerImpl player = BuildPlayerImpl.of(value);
-        Map<String, @Nullable Object> serialized = new HashMap<>();
+        Map<String, Object> serialized = new HashMap<>();
 
         serialized.put(SETTINGS, serializeSettings(player.getSettings()));
         LogoutLocation logoutLocation = player.getLogoutLocation();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
@@ -84,8 +84,8 @@ public final class WorldCodec implements Codec<BuildWorld> {
     }
 
     @Override
-    public Map<String, @Nullable Object> serialize(BuildWorld buildWorld) {
-        Map<String, @Nullable Object> world = new HashMap<>();
+    public Map<String, Object> serialize(BuildWorld buildWorld) {
+        Map<String, Object> world = new HashMap<>();
 
         world.put(NAME, buildWorld.getName());
         world.put(UUID_KEY, buildWorld.getUniqueId().toString());
@@ -110,9 +110,9 @@ public final class WorldCodec implements Codec<BuildWorld> {
      * keys, so the nesting has to happen here for the file to gain real sections. Ids nest one section level deep,
      * which is all the catalog uses.
      */
-    private Map<String, @Nullable Object> serializeWorldData(WorldDataImpl worldData) {
-        Map<String, @Nullable Object> data = new HashMap<>();
-        Map<String, Map<String, @Nullable Object>> sections = new HashMap<>();
+    private Map<String, Object> serializeWorldData(WorldDataImpl worldData) {
+        Map<String, Object> data = new HashMap<>();
+        Map<String, Map<String, Object>> sections = new HashMap<>();
         worldData.getAllData().forEach((id, property) -> {
             int dot = id.indexOf('.');
             if (dot < 0) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlWorldStorage.java
@@ -73,7 +73,7 @@ public class YamlWorldStorage extends WorldStorageImpl {
         // Serialize on the calling (main) thread, where the world's data is owned: the async block must only write the
         // already-captured map to disk, never read live domain state off the main thread.
         String worldKey = codec().key(buildWorld);
-        Map<String, @Nullable Object> serialized = codec().serialize(buildWorld);
+        Map<String, Object> serialized = codec().serialize(buildWorld);
         return CompletableFuture.runAsync(
                 () -> store.atomicSave(() -> {
                     config.set(StorageMigration.VERSION_KEY, StorageMigration.CURRENT_VERSION);


### PR DESCRIPTION
`Codec#serialize` declares:

```java
Map<String, Object> serialize(T value);
```

Non-null values. But `FolderCodec`, `PlayerCodec` and `WorldCodec` all overrode it as `Map<String, @Nullable Object>`.

That compiles, because Java doesn't consider type annotations when matching an override — they aren't part of the method descriptor. So the implementations widened the contract while every caller holding a `Codec<T>` still got `Map<String, Object>` back and was entitled to treat the values as non-null.

Nothing legitimate was being overridden; the annotation was just wrong.

- `WorldCodec` and `PlayerCodec` already guarded every optional value (`if (creator != null)`, `if (logoutLocation != null)`), so only the declaration needed fixing.
- `FolderCodec` genuinely did store nulls, for an absent parent and an unset skull texture. It now omits those keys instead. That's equivalent on disk: `config.set(path, map)` replaces the whole folder section, so a key that's absent from the map is a key that's gone from the file — the same result `set(path, null)` produced.

`WorldCodec.serializeWorldData` was also declared with nullable values even though every entry comes from `PersistentProperty#getConfigFormat()`, which is non-null.
