### PR TITLE
refactor!: share the registry model and layout editor between statuses and categories

### DIFF
--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
@@ -29,7 +29,7 @@ import org.jspecify.annotations.NullMarked;
  * setup menu. Instances are obtained and resolved through the {@link WorldStatusRegistry}. Six statuses are
  * {@link #isBuiltIn() built in} and seeded by default — {@code not_started}, {@code in_progress},
  * {@code almost_finished}, {@code finished}, {@code archive}, and {@code hidden} — and can be restored after deletion
- * by resetting to defaults. The registry always keeps at least one status so a {@link WorldStatusRegistry#getDefaultStatus()
+ * by resetting to defaults. The registry always keeps at least one status so a {@link WorldStatusRegistry#getDefault()
  * default} fallback always exists.
  *
  * <p>Behavioral traits are data-driven and defined by individual properties, such as whether building is permitted,

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/BuildWorldStatus.java
@@ -18,8 +18,8 @@
 package de.eintosti.buildsystem.api.world.data;
 
 import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.api.world.display.RegistryEntry;
 import java.util.Optional;
-import org.bukkit.Material;
 import org.jspecify.annotations.NullMarked;
 
 /**
@@ -43,47 +43,7 @@ import org.jspecify.annotations.NullMarked;
  * @since 4.0.0
  */
 @NullMarked
-public interface BuildWorldStatus {
-
-    /**
-     * Gets the stable, lower-case identifier of this status (e.g. {@code "in_progress"}). The id is unique within the
-     * {@link WorldStatusRegistry} and is what gets persisted; it never changes once created.
-     *
-     * @return The status identifier
-     */
-    String getId();
-
-    /**
-     * Gets the configurable display name of this status, with legacy colour codes unresolved.
-     *
-     * @return The display name
-     */
-    String getDisplayName();
-
-    /**
-     * Gets the legacy colour-code token (e.g. {@code "&a"}) applied to this status and, by default, to the worlds that
-     * carry it.
-     *
-     * @return The colour token
-     */
-    String getColor();
-
-    /**
-     * Gets the material used to represent this status in menus.
-     *
-     * @return The icon material
-     */
-    Material getIcon();
-
-    /**
-     * Gets the display name prefixed with this status's {@link #getColor() colour}, with legacy colour codes still
-     * unresolved. Callers translate the codes when rendering.
-     *
-     * @return The colour-prefixed display name
-     */
-    default String getStyledName() {
-        return getColor() + getDisplayName();
-    }
+public interface BuildWorldStatus extends RegistryEntry {
 
     /**
      * Gets the ordering weight of this status. Lower values are considered earlier in a world's lifecycle and are used
@@ -114,30 +74,4 @@ public interface BuildWorldStatus {
      * @return The target status id, or {@link Optional#empty()} if this status does not auto-advance
      */
     Optional<String> getProgressesTo();
-
-    /**
-     * Gets the slot this status occupies in the {@code /worlds setStatus} picker. The layout is configured through the
-     * setup menu's status editor, exactly as navigator categories are arranged. A status that is not
-     * {@link #isShownInStatusMenu() shown}, or whose slot falls outside the picker, is omitted from it.
-     *
-     * @return The picker slot, or a negative value when the status has no assigned slot
-     */
-    int getStatusSlot();
-
-    /**
-     * Gets whether this status appears in the {@code /worlds setStatus} picker. A hidden status still exists and can be
-     * assigned through other means; it is simply not offered in the picker until it is placed back into the layout.
-     *
-     * @return {@code true} if shown in the picker, otherwise {@code false}
-     */
-    boolean isShownInStatusMenu();
-
-    /**
-     * Gets whether this status is one of the plugin's built-in defaults, as opposed to an administrator-created custom
-     * status. Built-in statuses can be restyled and deleted like any other; deleting one only removes it until the
-     * statuses are reset to their defaults.
-     *
-     * @return {@code true} if built-in, otherwise {@code false}
-     */
-    boolean isBuiltIn();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldStatusRegistry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/data/WorldStatusRegistry.java
@@ -17,11 +17,8 @@
  */
 package de.eintosti.buildsystem.api.world.data;
 
-import java.util.Collection;
-import java.util.Optional;
-import org.jetbrains.annotations.Unmodifiable;
+import de.eintosti.buildsystem.api.world.display.Registry;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
  * The registry of all {@link BuildWorldStatus statuses} known to the server, both the built-in defaults and any custom
@@ -30,7 +27,7 @@ import org.jspecify.annotations.Nullable;
  * @since 4.0.0
  */
 @NullMarked
-public interface WorldStatusRegistry {
+public interface WorldStatusRegistry extends Registry<BuildWorldStatus> {
 
     /**
      * The id of the built-in {@code not_started} status, which is also the global default fallback.
@@ -61,28 +58,4 @@ public interface WorldStatusRegistry {
      * The id of the built-in {@code hidden} status (not shown in the navigator).
      */
     String HIDDEN_ID = "hidden";
-
-    /**
-     * Gets all registered statuses, ordered by {@link BuildWorldStatus#getOrder()}.
-     *
-     * @return An unmodifiable view of all statuses
-     */
-    @Unmodifiable
-    Collection<BuildWorldStatus> getStatuses();
-
-    /**
-     * Resolves a status by its {@link BuildWorldStatus#getId() id}.
-     *
-     * @param id The status id, or {@code null}
-     * @return The matching status, or {@link Optional#empty()} if {@code id} is {@code null} or no status is registered
-     *     with that id
-     */
-    Optional<BuildWorldStatus> getStatus(@Nullable String id);
-
-    /**
-     * Gets the global default status worlds fall back to (the built-in {@code not_started}). Always present.
-     *
-     * @return The default status
-     */
-    BuildWorldStatus getDefaultStatus();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
@@ -22,7 +22,6 @@ import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
 import de.eintosti.buildsystem.api.world.data.Visibility;
 import java.util.List;
 import java.util.Set;
-import org.bukkit.Material;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -48,47 +47,7 @@ import org.jspecify.annotations.Nullable;
  * @since 4.0.0
  */
 @NullMarked
-public interface NavigatorCategory {
-
-    /**
-     * Gets the stable, lower-case identifier of this category (e.g. {@code "public"}). Unique within the
-     * {@link NavigatorCategoryRegistry}; this is what folders and the navigator persist.
-     *
-     * @return The category identifier
-     */
-    String getId();
-
-    /**
-     * Gets the configurable display name of this category, with legacy colour codes unresolved.
-     *
-     * @return The display name
-     */
-    String getDisplayName();
-
-    /**
-     * Gets the legacy colour-code token (e.g. {@code "&b"}) applied to this category in the navigator.
-     *
-     * @return The colour token
-     */
-    String getColor();
-
-    /**
-     * Gets the display name prefixed with this category's {@link #getColor() colour}, with legacy colour codes still
-     * unresolved. Callers translate the codes when rendering.
-     *
-     * @return The colour-prefixed display name
-     * @since 4.0.0
-     */
-    default String getStyledName() {
-        return getColor() + getDisplayName();
-    }
-
-    /**
-     * Gets the material used to represent this category in the navigator and setup menus.
-     *
-     * @return The icon material
-     */
-    Material getIcon();
+public interface NavigatorCategory extends RegistryEntry {
 
     /**
      * Gets the skull texture applied when this category's {@link #getIcon() icon} is a player head. Returns
@@ -144,28 +103,4 @@ public interface NavigatorCategory {
     default boolean groups(Visibility visibility, String statusId) {
         return getVisibilities().contains(visibility) && getStatusIds().contains(statusId);
     }
-
-    /**
-     * Gets whether this category is given a section in the navigator. When {@code false}, its worlds are only reachable
-     * directly via commands or secondary menus.
-     *
-     * @return {@code true} if shown in the navigator, otherwise {@code false}
-     */
-    boolean isShownInNavigator();
-
-    /**
-     * Gets the default navigator slot used when a layout is generated for this category.
-     *
-     * @return The navigator slot
-     */
-    int getNavigatorSlot();
-
-    /**
-     * Gets whether this category is one of the plugin's built-in defaults, as opposed to an administrator-created
-     * custom category. Built-in categories can be restyled and deleted like any other; deleting one only removes it
-     * until the categories are reset to their defaults.
-     *
-     * @return {@code true} if built-in, otherwise {@code false}
-     */
-    boolean isBuiltIn();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategory.java
@@ -37,7 +37,7 @@ import org.jspecify.annotations.Nullable;
  * <p>Server administrators can create, restyle, and delete categories at runtime through the in-game setup menu. Three
  * categories are {@link #isBuiltIn() built in} and seeded by default ({@code public}, {@code private},
  * {@code archive}) and can be restored after deletion by resetting to defaults. The registry always keeps at least one
- * category so a {@link NavigatorCategoryRegistry#getDefaultCategory() default} fallback always exists.
+ * category so a {@link NavigatorCategoryRegistry#getDefault() default} fallback always exists.
  *
  * <p>Two categories are equal if and only if they share the same {@link #getId() id}. Compare categories with
  * {@link Object#equals(Object) equals}, never with {@code ==}: this type is no longer an enum, so reference identity is

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
@@ -49,7 +49,7 @@ public interface NavigatorCategoryRegistry {
     String PRIVATE_ID = "private";
 
     /**
-     * Gets all registered categories, ordered by {@link NavigatorCategory#getNavigatorSlot()}.
+     * Gets all registered categories, ordered by {@link NavigatorCategory#getSlot()}.
      *
      * @return An unmodifiable view of all categories
      */

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/NavigatorCategoryRegistry.java
@@ -18,11 +18,7 @@
 package de.eintosti.buildsystem.api.world.display;
 
 import de.eintosti.buildsystem.api.world.BuildWorld;
-import java.util.Collection;
-import java.util.Optional;
-import org.jetbrains.annotations.Unmodifiable;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
  * The registry of all {@link NavigatorCategory navigator categories} known to the server, both the built-in defaults
@@ -31,7 +27,7 @@ import org.jspecify.annotations.Nullable;
  * @since 4.0.0
  */
 @NullMarked
-public interface NavigatorCategoryRegistry {
+public interface NavigatorCategoryRegistry extends Registry<NavigatorCategory> {
 
     /**
      * The id of the built-in {@code public} category (everyone, shown in the navigator).
@@ -49,38 +45,15 @@ public interface NavigatorCategoryRegistry {
     String PRIVATE_ID = "private";
 
     /**
-     * Gets all registered categories, ordered by {@link NavigatorCategory#getSlot()}.
-     *
-     * @return An unmodifiable view of all categories
-     */
-    @Unmodifiable
-    Collection<NavigatorCategory> getCategories();
-
-    /**
-     * Resolves a category by its {@link NavigatorCategory#getId() id}.
-     *
-     * @param id The category id
-     * @return The matching category, or {@link Optional#empty()} if none is registered with that id
-     */
-    Optional<NavigatorCategory> getCategory(@Nullable String id);
-
-    /**
      * Resolves a world's primary ("home") category — the first category whose
      * {@link NavigatorCategory#getVisibilities() visibilities} contain the world's visibility and whose
      * {@link NavigatorCategory#getStatusIds() statuses} contain the world's status. A world may additionally appear in
      * other overlapping categories; whether any single category lists a world is tested with
      * {@link NavigatorCategory#groups}. This method only picks the single representative category (e.g. for a world's
-     * default folder), falling back to the {@link #getDefaultCategory() default} when nothing matches.
+     * default folder), falling back to the {@link #getDefault() default} when nothing matches.
      *
      * @param world The world whose primary category to resolve
-     * @return The resolved primary category, or the {@link #getDefaultCategory() default} when nothing matches
+     * @return The resolved primary category, or the {@link #getDefault() default} when nothing matches
      */
     NavigatorCategory getCategoryForWorld(BuildWorld world);
-
-    /**
-     * Gets the default category worlds fall back to (the built-in {@code public}). Always present.
-     *
-     * @return The default category
-     */
-    NavigatorCategory getDefaultCategory();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Registry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Registry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.api.world.display;
+
+import java.util.Collection;
+import java.util.Optional;
+import org.jetbrains.annotations.Unmodifiable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The admin-managed set of {@link RegistryEntry entries} of one kind — world statuses or navigator categories.
+ * Entries are keyed by their {@link RegistryEntry#getId() id} and kept in the order they are shown.
+ *
+ * <p>A registry is never empty: deleting the last remaining entry is refused, so {@link #getDefault()} always has
+ * something to return.
+ *
+ * @param <T> The entry type
+ * @since 4.0.0
+ */
+@NullMarked
+public interface Registry<T extends RegistryEntry> {
+
+    /**
+     * Gets every entry, in display order.
+     *
+     * @return The entries
+     */
+    @Unmodifiable
+    Collection<T> getAll();
+
+    /**
+     * Gets the entry with the given id.
+     *
+     * @param id The id to look up, may be {@code null}
+     * @return The entry, or empty if no entry has that id
+     */
+    Optional<T> get(@Nullable String id);
+
+    /**
+     * Gets the entry used when none is specified — for a status, what a newly created world starts as; for a
+     * category, where an uncategorised world is listed.
+     *
+     * @return The default entry
+     */
+    T getDefault();
+}

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Registry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/Registry.java
@@ -59,4 +59,41 @@ public interface Registry<T extends RegistryEntry> {
      * @return The default entry
      */
     T getDefault();
+
+    /**
+     * Creates a new entry with the given display name, assigns it an id, and persists it. The entry starts hidden and
+     * unplaced; give it a slot with {@link RegistryEntry#setSlot(int)} and show it with
+     * {@link RegistryEntry#setShown(boolean)}.
+     *
+     * @param displayName The display name to create it under
+     * @return The created entry
+     */
+    T create(String displayName);
+
+    /**
+     * Deletes the entry with the given id. The last remaining entry is never deleted, so {@link #getDefault()} always
+     * has something to return.
+     *
+     * @param id The id to delete
+     * @return {@code true} if it was deleted
+     */
+    boolean delete(String id);
+
+    /**
+     * Writes an entry's current state to storage. Mutating an entry does not save it on its own, so a drag that
+     * touches several fields costs one write rather than one per field.
+     *
+     * @param entry The entry to persist
+     */
+    void persist(T entry);
+
+    /**
+     * Restores the built-in entries to their default slots and hides the rest, keeping custom entries.
+     */
+    void resetLayout();
+
+    /**
+     * Restores every entry to the built-in defaults, discarding custom entries.
+     */
+    void resetToDefaults();
 }

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/RegistryEntry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/RegistryEntry.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.api.world.display;
+
+import org.bukkit.Material;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A named, styled, admin-managed entry in a registry that is arranged on a menu grid — a world status or a navigator
+ * category. Entries are identified by a stable {@link #getId() id}, occupy a {@link #getSlot() slot} in their editor's
+ * layout, and can be hidden without being deleted.
+ *
+ * <p>This is deliberately not a {@link Displayable}: a displayable renders per viewer
+ * ({@code getDisplayName(Player)}, {@code getLore(Player)}), whereas a registry entry is static configuration whose
+ * name and colour do not depend on who is looking.
+ *
+ * @since 4.0.0
+ */
+@NullMarked
+public interface RegistryEntry {
+
+    /**
+     * Gets the stable identifier for this entry, used in config, storage and permission nodes. Unlike the display
+     * name, it does not change when the entry is restyled.
+     *
+     * @return The id
+     */
+    String getId();
+
+    /**
+     * Gets the name shown to players, without colour.
+     *
+     * @return The display name
+     */
+    String getDisplayName();
+
+    /**
+     * Gets the legacy colour code prefix applied to this entry's {@link #getStyledName() styled name}.
+     *
+     * @return The colour code
+     */
+    String getColor();
+
+    /**
+     * Gets the display name prefixed with this entry's {@link #getColor() colour}.
+     *
+     * @return The styled display name
+     */
+    default String getStyledName() {
+        return getColor() + getDisplayName();
+    }
+
+    /**
+     * Gets the material shown for this entry in menus.
+     *
+     * @return The icon material
+     */
+    Material getIcon();
+
+    /**
+     * Gets the slot this entry occupies in its editor's layout.
+     *
+     * @return The inventory slot
+     */
+    int getSlot();
+
+    /**
+     * Gets whether this entry is shown in its menu. A hidden entry still exists and can still be assigned; it is only
+     * absent from the picker.
+     *
+     * @return {@code true} if shown
+     */
+    boolean isShown();
+
+    /**
+     * Gets whether this entry ships with the plugin rather than having been created by an admin. Built-in entries can
+     * be restyled and deleted like any other; the flag exists so "reset to defaults" knows what to restore.
+     *
+     * @return {@code true} if built in
+     */
+    boolean isBuiltIn();
+}

--- a/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/RegistryEntry.java
+++ b/buildsystem-api/src/main/java/de/eintosti/buildsystem/api/world/display/RegistryEntry.java
@@ -80,12 +80,26 @@ public interface RegistryEntry {
     int getSlot();
 
     /**
+     * Sets the slot this entry occupies in its editor's layout.
+     *
+     * @param slot The inventory slot
+     */
+    void setSlot(int slot);
+
+    /**
      * Gets whether this entry is shown in its menu. A hidden entry still exists and can still be assigned; it is only
      * absent from the picker.
      *
      * @return {@code true} if shown
      */
     boolean isShown();
+
+    /**
+     * Sets whether this entry is shown in its menu.
+     *
+     * @param shown {@code true} to show it
+     */
+    void setShown(boolean shown);
 
     /**
      * Gets whether this entry ships with the plugin rather than having been created by an admin. Built-in entries can

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/CategoryShortcuts.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/CategoryShortcuts.java
@@ -44,13 +44,13 @@ public final class CategoryShortcuts implements DynamicSubCommands {
     @Override
     public Optional<SubCommand> resolve(String name) {
         return services.navigatorCategoryRegistry()
-                .getCategory(name.toLowerCase(Locale.ROOT))
+                .get(name.toLowerCase(Locale.ROOT))
                 .map(category -> categoryCommand(category.getId()));
     }
 
     @Override
     public List<SubCommand> available(Player player) {
-        return services.navigatorCategoryRegistry().getCategories().stream()
+        return services.navigatorCategoryRegistry().getAll().stream()
                 .filter(category -> CategoryPermissions.canAccess(player, category.getId()))
                 .<SubCommand>map(category -> categoryCommand(category.getId()))
                 .toList();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/CategorySubCommand.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/command/subcommand/worlds/CategorySubCommand.java
@@ -64,7 +64,7 @@ public class CategorySubCommand extends AbstractSubCommand {
         }
 
         NavigatorCategoryRegistry registry = navigatorCategoryRegistry;
-        NavigatorCategory category = registry.getCategory(categoryId).orElse(null);
+        NavigatorCategory category = registry.get(categoryId).orElse(null);
         if (category == null) {
             // The category was deleted between the shortcut being listed and this invocation.
             messages.sendMessage(player, "worlds_unknown_command");

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/player/PlayerInventoryClearEvent.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/event/player/PlayerInventoryClearEvent.java
@@ -47,7 +47,7 @@ public class PlayerInventoryClearEvent extends PlayerEvent {
      *
      * @return A list of slot numbers containing navigator items
      */
-    public List<Integer> getNavigatorSlots() {
+    public List<Integer> getSlots() {
         return navigatorSlots;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlayerInventoryClearListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/settings/PlayerInventoryClearListener.java
@@ -50,6 +50,6 @@ public class PlayerInventoryClearListener implements Listener {
 
         PlayerInventory playerInventory = player.getInventory();
         ItemStack navigatorItem = navigatorItems.create(player);
-        event.getNavigatorSlots().forEach(slot -> playerInventory.setItem(slot, navigatorItem));
+        event.getSlots().forEach(slot -> playerInventory.setItem(slot, navigatorItem));
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/world/WorldManipulateListener.java
@@ -155,7 +155,7 @@ public class WorldManipulateListener implements Listener {
         worldData
                 .get(WorldDataKey.STATUS)
                 .getProgressesTo()
-                .flatMap(worldStatusRegistry::getStatus)
+                .flatMap(worldStatusRegistry::get)
                 .ifPresent(next -> {
                     worldData.set(WorldDataKey.STATUS, next);
                     settingsService.forceUpdateSidebar(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
@@ -89,9 +89,7 @@ public class NavigatorService {
 
     public @Nullable NavigatorCategory matchNavigatorCategory(ArmorStand armorStand) {
         String categoryId = armorStand.getPersistentDataContainer().get(categoryKey, PersistentDataType.STRING);
-        return categoryId != null
-                ? navigatorCategoryRegistry.getCategory(categoryId).orElse(null)
-                : null;
+        return categoryId != null ? navigatorCategoryRegistry.get(categoryId).orElse(null) : null;
     }
 
     public @Nullable UUID getOwner(ArmorStand armorStand) {
@@ -100,7 +98,7 @@ public class NavigatorService {
     }
 
     public void spawnArmorStands(Player player) {
-        List<NavigatorCategory> shownCategories = navigatorCategoryRegistry.getCategories().stream()
+        List<NavigatorCategory> shownCategories = navigatorCategoryRegistry.getAll().stream()
                 .filter(NavigatorCategory::isShown)
                 .toList();
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/navigator/NavigatorService.java
@@ -101,7 +101,7 @@ public class NavigatorService {
 
     public void spawnArmorStands(Player player) {
         List<NavigatorCategory> shownCategories = navigatorCategoryRegistry.getCategories().stream()
-                .filter(NavigatorCategory::isShownInNavigator)
+                .filter(NavigatorCategory::isShown)
                 .toList();
 
         ArmorStand[] stands = new ArmorStand[shownCategories.size()];

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/Codec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/Codec.java
@@ -48,6 +48,11 @@ public interface Codec<T> {
     /**
      * Serializes the entity into the map persisted under its {@link #key(Object) key}.
      *
+     * <p>Values are never {@code null}: an absent field is omitted from the map rather than mapped to {@code null}.
+     * The storages write the whole map at the entity's key, which replaces the entity's section outright, so an
+     * omitted key is already an erased key. Null would only carry extra meaning if a storage ever merged into the
+     * existing section field by field, where absence would mean "keep the old value".
+     *
      * @param value The entity to serialize
      * @return The persisted map form, round-trippable by {@link #deserialize(String, ConfigurationSection)}
      */

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
@@ -147,7 +147,7 @@ public final class FolderCodec implements Codec<Folder> {
         String categoryId = section.getString(CATEGORY);
         categoryId = categoryId != null ? categoryId.toLowerCase(Locale.ROOT) : null;
         return categoryId != null
-                ? categoryRegistry.getCategory(categoryId).orElseGet(categoryRegistry::getDefaultCategory)
-                : categoryRegistry.getDefaultCategory();
+                ? categoryRegistry.get(categoryId).orElseGet(categoryRegistry::getDefault)
+                : categoryRegistry.getDefault();
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/WorldCodec.java
@@ -217,6 +217,7 @@ public final class WorldCodec implements Codec<BuildWorld> {
         if (raw == null) {
             return BuildWorldType.UNKNOWN;
         }
+
         try {
             return BuildWorldType.valueOf(raw);
         } catch (IllegalArgumentException e) {
@@ -249,14 +250,15 @@ public final class WorldCodec implements Codec<BuildWorld> {
         WorldStatusRegistry registry = context.statusRegistry();
         String raw = section.getString(dataPath(WorldDataKey.STATUS));
         if (raw == null) {
-            return registry.getDefaultStatus();
+            return registry.getDefault();
         }
+
         String id = raw.toLowerCase(Locale.ROOT);
-        return registry.getStatus(id).orElseGet(() -> {
+        return registry.get(id).orElseGet(() -> {
             context.logger()
                     .warning("Unknown status \"" + raw + "\" for \"" + worldName + "\". Defaulting to "
-                            + registry.getDefaultStatus().getId() + ".");
-            return registry.getDefaultStatus();
+                            + registry.getDefault().getId() + ".");
+            return registry.getDefault();
         });
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlCategoryStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlCategoryStorage.java
@@ -164,8 +164,8 @@ public class YamlCategoryStorage extends AbstractYamlStorage {
         config.set(
                 path + ".visibilities",
                 category.getVisibilities().stream().map(Visibility::name).toList());
-        config.set(path + ".shown-in-navigator", category.isShownInNavigator());
-        config.set(path + ".navigator-slot", category.getNavigatorSlot());
+        config.set(path + ".shown-in-navigator", category.isShown());
+        config.set(path + ".navigator-slot", category.getSlot());
         config.set(path + ".built-in", category.isBuiltIn());
         config.set(path + ".statuses", category.getStatusIds());
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlStatusStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/yaml/YamlStatusStorage.java
@@ -124,7 +124,7 @@ public class YamlStatusStorage extends AbstractYamlStorage {
         config.set(path + ".building-allowed", status.isBuildingAllowed());
         config.set(path + ".progresses-to", status.getProgressesTo().orElse(null));
         config.set(path + ".built-in", status.isBuiltIn());
-        config.set(path + ".status-slot", status.getStatusSlot());
-        config.set(path + ".shown-in-status-menu", status.isShownInStatusMenu());
+        config.set(path + ".status-slot", status.getSlot());
+        config.set(path + ".shown-in-status-menu", status.isShown());
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/BuildWorldImpl.java
@@ -112,7 +112,7 @@ public final class BuildWorldImpl implements BuildWorld, HeadProfileSource {
                 : defaults.buildersEnabled().publicBuilders();
         WorldDataBuilder builder = new WorldDataBuilder(name)
                 .withVisibility(Visibility.matchVisibility(privateWorld))
-                .withStatus(context.statusRegistry().getDefaultStatus())
+                .withStatus(context.statusRegistry().getDefault())
                 .withMaterial(
                         privateWorld
                                 ? Material.PLAYER_HEAD

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusImpl.java
@@ -138,20 +138,20 @@ public final class WorldStatusImpl implements BuildWorldStatus {
     }
 
     @Override
-    public int getStatusSlot() {
+    public int getSlot() {
         return statusSlot;
     }
 
-    public void setStatusSlot(int statusSlot) {
+    public void setSlot(int statusSlot) {
         this.statusSlot = statusSlot;
     }
 
     @Override
-    public boolean isShownInStatusMenu() {
+    public boolean isShown() {
         return shownInStatusMenu;
     }
 
-    public void setShownInStatusMenu(boolean shownInStatusMenu) {
+    public void setShown(boolean shownInStatusMenu) {
         this.shownInStatusMenu = shownInStatusMenu;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
@@ -238,10 +238,10 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
         for (WorldStatusImpl status : this.statuses.values()) {
             Integer preset = DEFAULT_SLOTS.get(status.getId());
             if (preset != null) {
-                status.setStatusSlot(preset);
-                status.setShownInStatusMenu(true);
+                status.setSlot(preset);
+                status.setShown(true);
             } else {
-                status.setShownInStatusMenu(false);
+                status.setShown(false);
             }
             storage.save(status);
         }
@@ -253,7 +253,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
      */
     private void placeUnplacedStatuses() {
         List<WorldStatusImpl> unplaced = this.statuses.values().stream()
-                .filter(status -> status.getStatusSlot() < 0)
+                .filter(status -> status.getSlot() < 0)
                 .sorted(Comparator.comparingInt(WorldStatusImpl::getOrder))
                 .toList();
         for (WorldStatusImpl status : unplaced) {
@@ -261,8 +261,8 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
             if (slot < 0) {
                 break;
             }
-            status.setStatusSlot(slot);
-            status.setShownInStatusMenu(true);
+            status.setSlot(slot);
+            status.setShown(true);
             storage.save(status);
         }
     }
@@ -273,8 +273,8 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
     private int firstFreeSlot() {
         Set<Integer> occupied = new HashSet<>();
         for (WorldStatusImpl status : this.statuses.values()) {
-            if (status.isShownInStatusMenu() && status.getStatusSlot() >= 0) {
-                occupied.add(status.getStatusSlot());
+            if (status.isShown() && status.getSlot() >= 0) {
+                occupied.add(status.getSlot());
             }
         }
         for (int slot = 0; slot < STATUS_MENU_SIZE; slot++) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
@@ -44,7 +44,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Owns every {@link BuildWorldStatus}, seeding the built-in defaults on first run and persisting all administrator
- * changes. Deleting a status cascades: every world that used it is reset to the {@link #getDefaultStatus() default}
+ * changes. Deleting a status cascades: every world that used it is reset to the {@link #getDefault() default}
  * status and the id is removed from every category that grouped it. The last remaining status can never be deleted, so
  * a valid default always exists.
  */
@@ -175,26 +175,26 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
     }
 
     @Override
-    public Collection<BuildWorldStatus> getStatuses() {
+    public Collection<BuildWorldStatus> getAll() {
         List<BuildWorldStatus> ordered = new ArrayList<>(this.statuses.values());
         ordered.sort(Comparator.comparingInt(BuildWorldStatus::getOrder));
         return Collections.unmodifiableList(ordered);
     }
 
     @Override
-    public Optional<BuildWorldStatus> getStatus(@Nullable String id) {
+    public Optional<BuildWorldStatus> get(@Nullable String id) {
         return Optional.ofNullable(this.statuses.get(id));
     }
 
     @Override
-    public BuildWorldStatus getDefaultStatus() {
+    public BuildWorldStatus getDefault() {
         if (this.statuses.isEmpty()) {
             seedDefaults();
             storage.saveAll(this.statuses.values());
         }
         WorldStatusImpl notStarted = this.statuses.get(NOT_STARTED_ID);
         // Prefer the built-in fallback, but it may have been deleted by an admin; then the lowest-order status wins.
-        return notStarted != null ? notStarted : getStatuses().iterator().next();
+        return notStarted != null ? notStarted : getAll().iterator().next();
     }
 
     /**
@@ -301,7 +301,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
 
     /**
      * Deletes a status (built-in or custom), cascading every world that used it back to the
-     * {@link #getDefaultStatus() default} and removing the id from every category that grouped it. The last remaining
+     * {@link #getDefault() default} and removing the id from every category that grouped it. The last remaining
      * status is never deleted, so a valid default always exists; an admin can restore the built-ins with
      * {@link #resetToDefaults()}.
      *
@@ -313,7 +313,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
         }
 
         this.statuses.remove(id);
-        BuildWorldStatus fallback = getDefaultStatus();
+        BuildWorldStatus fallback = getDefault();
         for (BuildWorld world : worldsWithStatus(id)) {
             world.getData().set(WorldDataKey.STATUS, fallback);
             worldService.get().getWorldStorage().save(world);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImpl.java
@@ -207,7 +207,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
         storage.saveAll(this.statuses.values());
     }
 
-    public WorldStatusImpl createStatus(String displayName) {
+    public WorldStatusImpl create(String displayName) {
         String id = StringUtils.uniqueId(displayName, "status", this.statuses::containsKey);
         int order = this.statuses.values().stream()
                         .mapToInt(WorldStatusImpl::getOrder)
@@ -234,7 +234,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
      * without otherwise changing the statuses. Backs the status editor's "reset layout" control, mirroring the
      * navigator's layout reset; a full {@link #resetToDefaults()} is the separate "reset everything".
      */
-    public void resetStatusLayout() {
+    public void resetLayout() {
         for (WorldStatusImpl status : this.statuses.values()) {
             Integer preset = DEFAULT_SLOTS.get(status.getId());
             if (preset != null) {
@@ -285,8 +285,9 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
         return -1;
     }
 
-    public void persist(WorldStatusImpl status) {
-        storage.save(status);
+    public void persist(BuildWorldStatus status) {
+        // The registry only ever hands out its own instances, so anything it is asked to persist is one of them.
+        storage.save((WorldStatusImpl) status);
     }
 
     /**
@@ -307,7 +308,7 @@ public class WorldStatusRegistryImpl implements WorldStatusRegistry {
      *
      * @return {@code true} if the status was deleted, {@code false} if it was unknown or the last remaining status
      */
-    public boolean deleteStatus(String id) {
+    public boolean delete(String id) {
         if (!this.statuses.containsKey(id) || this.statuses.size() == 1) {
             return false;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryImpl.java
@@ -143,20 +143,20 @@ public final class NavigatorCategoryImpl implements NavigatorCategory {
     }
 
     @Override
-    public boolean isShownInNavigator() {
+    public boolean isShown() {
         return shownInNavigator;
     }
 
-    public void setShownInNavigator(boolean shownInNavigator) {
+    public void setShown(boolean shownInNavigator) {
         this.shownInNavigator = shownInNavigator;
     }
 
     @Override
-    public int getNavigatorSlot() {
+    public int getSlot() {
         return navigatorSlot;
     }
 
-    public void setNavigatorSlot(int navigatorSlot) {
+    public void setSlot(int navigatorSlot) {
         this.navigatorSlot = navigatorSlot;
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
@@ -210,7 +210,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
      * themselves. Built-in categories return to their default slots and become visible again; custom categories are kept
      * but removed from the navigator (so they can be re-added). The settings button returns to its default slot.
      */
-    public void resetNavigatorLayout() {
+    public void resetLayout() {
         Map<String, NavigatorCategoryImpl> defaults = buildDefaults();
         for (NavigatorCategoryImpl category : this.categories.values()) {
             NavigatorCategoryImpl preset = defaults.get(category.getId());
@@ -225,7 +225,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         setSettingsSlot(DEFAULT_SETTINGS_SLOT);
     }
 
-    public NavigatorCategoryImpl createCategory(String displayName) {
+    public NavigatorCategoryImpl create(String displayName) {
         String id = StringUtils.uniqueId(displayName, "category", this.categories::containsKey);
         int slot = this.categories.values().stream()
                         .mapToInt(NavigatorCategory::getSlot)
@@ -241,8 +241,9 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         return category;
     }
 
-    public void persist(NavigatorCategoryImpl category) {
-        storage.save(category);
+    public void persist(NavigatorCategory category) {
+        // The registry only ever hands out its own instances, so anything it is asked to persist is one of them.
+        storage.save((NavigatorCategoryImpl) category);
     }
 
     /**
@@ -284,7 +285,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
      *
      * @return {@code true} if the category was deleted, {@code false} if it was unknown
      */
-    public boolean deleteCategory(String id) {
+    public boolean delete(String id) {
         if (!this.categories.containsKey(id)) {
             return false;
         }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
@@ -50,7 +50,7 @@ import org.jspecify.annotations.Nullable;
  * changes. The category a world is displayed in is resolved by matching both the category's
  * {@link NavigatorCategory#getVisibilities() visibilities} and its statuses against the world. Any category may be
  * deleted, including the last one — the navigator then simply shows no categories until {@link #resetToDefaults()}
- * restores the built-ins. As a safety net for folders (which always need a home category), {@link #getDefaultCategory()}
+ * restores the built-ins. As a safety net for folders (which always need a home category), {@link #getDefault()}
  * reseeds the built-ins on demand when the registry is empty. Deleting a category never orphans a status because statuses
  * are shared, not owned.
  */
@@ -156,14 +156,14 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     }
 
     @Override
-    public Collection<NavigatorCategory> getCategories() {
+    public Collection<NavigatorCategory> getAll() {
         List<NavigatorCategory> ordered = new ArrayList<>(this.categories.values());
         ordered.sort(Comparator.comparingInt(NavigatorCategory::getSlot));
         return Collections.unmodifiableList(ordered);
     }
 
     @Override
-    public Optional<NavigatorCategory> getCategory(@Nullable String id) {
+    public Optional<NavigatorCategory> get(@Nullable String id) {
         return Optional.ofNullable(this.categories.get(id));
     }
 
@@ -171,17 +171,17 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     public NavigatorCategory getCategoryForWorld(BuildWorld world) {
         WorldData data = world.getData();
         String statusId = data.get(WorldDataKey.STATUS).getId();
-        for (NavigatorCategory category : getCategories()) {
+        for (NavigatorCategory category : getAll()) {
             if (category.getVisibilities().contains(data.get(WorldDataKey.VISIBILITY))
                     && category.getStatusIds().contains(statusId)) {
                 return category;
             }
         }
-        return getDefaultCategory();
+        return getDefault();
     }
 
     @Override
-    public NavigatorCategory getDefaultCategory() {
+    public NavigatorCategory getDefault() {
         // Folders always need a home category, so an empty registry reseeds the built-ins on demand rather than handing
         // back nothing. The navigator's own browse paths never call this, so deleting every category still leaves the
         // navigator empty until an admin resets — only folder operations trigger the reseed.
@@ -191,9 +191,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         }
         NavigatorCategoryImpl publicCategory = this.categories.get(PUBLIC_ID);
         // Prefer the built-in public category, but it may have been deleted; then the lowest-slot category wins.
-        return publicCategory != null
-                ? publicCategory
-                : getCategories().iterator().next();
+        return publicCategory != null ? publicCategory : getAll().iterator().next();
     }
 
     /**
@@ -257,7 +255,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         if (this.categories.isEmpty()) {
             return;
         }
-        NavigatorCategoryImpl defaultSet = (NavigatorCategoryImpl) getDefaultCategory();
+        NavigatorCategoryImpl defaultSet = (NavigatorCategoryImpl) getDefault();
         defaultSet.addStatusId(statusId);
         storage.save(defaultSet);
     }
@@ -278,7 +276,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     /**
      * Removes a category (built-in or custom). Any category may be deleted, including the last one; the navigator then
      * shows no categories until an admin restores the built-ins with {@link #resetToDefaults()}. Worlds previously
-     * displayed in the category simply resolve to another matching category (or the {@link #getDefaultCategory() default})
+     * displayed in the category simply resolve to another matching category (or the {@link #getDefault() default})
      * on the next render; no status is orphaned because statuses are shared rather than owned by a category. Folders,
      * which hold a fixed category, are re-homed to the default so they (and the worlds they contain) stay reachable — but
      * only while at least one category remains, since deleting the very last category leaves nothing to re-home them to
@@ -299,13 +297,13 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     }
 
     /**
-     * Re-homes every folder that belonged to the just-deleted category to the {@link #getDefaultCategory() default}, so
+     * Re-homes every folder that belonged to the just-deleted category to the {@link #getDefault() default}, so
      * the folders (and the worlds they contain) stay reachable in the navigator instead of vanishing until the next
      * reload. Mirrors how deleting a status resets the worlds that used it. Whole subtrees move together because a
      * subfolder shares its parent's category.
      */
     private void rehomeFolders(String deletedId) {
-        NavigatorCategory fallback = getDefaultCategory();
+        NavigatorCategory fallback = getDefault();
         var folderStorage = worldService.get().getFolderStorage();
         List<Folder> rehomed = new ArrayList<>();
         for (Folder folder : folderStorage.getFolders()) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImpl.java
@@ -158,7 +158,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     @Override
     public Collection<NavigatorCategory> getCategories() {
         List<NavigatorCategory> ordered = new ArrayList<>(this.categories.values());
-        ordered.sort(Comparator.comparingInt(NavigatorCategory::getNavigatorSlot));
+        ordered.sort(Comparator.comparingInt(NavigatorCategory::getSlot));
         return Collections.unmodifiableList(ordered);
     }
 
@@ -217,10 +217,10 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
         for (NavigatorCategoryImpl category : this.categories.values()) {
             NavigatorCategoryImpl preset = defaults.get(category.getId());
             if (preset != null) {
-                category.setNavigatorSlot(preset.getNavigatorSlot());
-                category.setShownInNavigator(preset.isShownInNavigator());
+                category.setSlot(preset.getSlot());
+                category.setShown(preset.isShown());
             } else {
-                category.setShownInNavigator(false);
+                category.setShown(false);
             }
             storage.save(category);
         }
@@ -230,7 +230,7 @@ public class NavigatorCategoryRegistryImpl implements NavigatorCategoryRegistry 
     public NavigatorCategoryImpl createCategory(String displayName) {
         String id = StringUtils.uniqueId(displayName, "category", this.categories::containsKey);
         int slot = this.categories.values().stream()
-                        .mapToInt(NavigatorCategory::getNavigatorSlot)
+                        .mapToInt(NavigatorCategory::getSlot)
                         .max()
                         .orElse(10)
                 + 1;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CategoryWorldsMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/CategoryWorldsMenu.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.NullMarked;
  * and offers world/folder creation.
  *
  * <p>World creation is offered dynamically: a category shows the "create world" item only when a freshly created world
- * — which always starts at the registry's {@link de.eintosti.buildsystem.api.world.data.WorldStatusRegistry#getDefaultStatus()
+ * — which always starts at the registry's {@link de.eintosti.buildsystem.api.world.data.WorldStatusRegistry#getDefault()
  * default status} — would actually be grouped into this category, and the player holds the per-category create
  * permission {@code buildsystem.create.<categoryId>} (e.g. {@code buildsystem.create.public}). This is why the archive
  * category, which never contains the default status, never offers world creation.
@@ -92,7 +92,7 @@ public class CategoryWorldsMenu extends DisplayablesMenu {
      * per-category create permission.
      */
     private boolean canCreateWorldHere(Player player) {
-        String defaultStatusId = worldStatusRegistry.getDefaultStatus().getId();
+        String defaultStatusId = worldStatusRegistry.getDefault().getId();
         return category.getStatusIds().contains(defaultStatusId)
                 && playerService.canCreateWorld(player, category.getPrimaryVisibility())
                 && hasCreatePermission(player);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
@@ -59,7 +59,7 @@ public class NavigatorMenu extends ButtonMenu<MenuButton> {
         this.menus = menus;
 
         int settingsSlot = navigatorCategoryRegistry.getSettingsSlot();
-        for (NavigatorCategory category : navigatorCategoryRegistry.getCategories()) {
+        for (NavigatorCategory category : navigatorCategoryRegistry.getAll()) {
             int slot = category.getSlot();
             if (!category.isShown() || slot < 0 || slot >= INVENTORY_SIZE || slot == settingsSlot) {
                 continue;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/NavigatorMenu.java
@@ -60,8 +60,8 @@ public class NavigatorMenu extends ButtonMenu<MenuButton> {
 
         int settingsSlot = navigatorCategoryRegistry.getSettingsSlot();
         for (NavigatorCategory category : navigatorCategoryRegistry.getCategories()) {
-            int slot = category.getNavigatorSlot();
-            if (!category.isShownInNavigator() || slot < 0 || slot >= INVENTORY_SIZE || slot == settingsSlot) {
+            int slot = category.getSlot();
+            if (!category.isShown() || slot < 0 || slot >= INVENTORY_SIZE || slot == settingsSlot) {
                 continue;
             }
             if (!CategoryPermissions.canAccess(player, category.getId())) {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -70,8 +70,8 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
         this.buildWorld = buildWorld;
 
         for (BuildWorldStatus status : worldStatusRegistry.getStatuses()) {
-            int slot = status.getStatusSlot();
-            if (!status.isShownInStatusMenu() || slot < 0 || slot >= WorldStatusRegistryImpl.STATUS_MENU_SIZE) {
+            int slot = status.getSlot();
+            if (!status.isShown() || slot < 0 || slot >= WorldStatusRegistryImpl.STATUS_MENU_SIZE) {
                 continue;
             }
             register(slot, statusButton(status));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/StatusMenu.java
@@ -69,7 +69,7 @@ public class StatusMenu extends ButtonMenu<MenuButton> {
         this.menus = menus;
         this.buildWorld = buildWorld;
 
-        for (BuildWorldStatus status : worldStatusRegistry.getStatuses()) {
+        for (BuildWorldStatus status : worldStatusRegistry.getAll()) {
             int slot = status.getSlot();
             if (!status.isShown() || slot < 0 || slot >= WorldStatusRegistryImpl.STATUS_MENU_SIZE) {
                 continue;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryEditorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryEditorMenu.java
@@ -180,7 +180,7 @@ public class CategoryEditorMenu extends RegistryEditorMenu {
                         lore.add(messages.getString("setup_category_statuses_none", player));
                     } else {
                         category.getStatusIds().stream()
-                                .map(id -> worldStatusRegistry.getStatus(id).orElse(null))
+                                .map(id -> worldStatusRegistry.get(id).orElse(null))
                                 .filter(Objects::nonNull)
                                 .sorted(Comparator.comparingInt(BuildWorldStatus::getOrder))
                                 .map(status -> messages.getString(

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryStatusesMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/CategoryStatusesMenu.java
@@ -77,7 +77,7 @@ public class CategoryStatusesMenu extends PaginatedMenu {
 
     @Override
     protected int totalItems() {
-        return worldStatusRegistry.getStatuses().size();
+        return worldStatusRegistry.getAll().size();
     }
 
     @Override
@@ -87,7 +87,7 @@ public class CategoryStatusesMenu extends PaginatedMenu {
         // Top + bottom glass border with a hollow middle, matching the status/category management menus.
         menuItems.fillWithGlass(getInventory(), player);
 
-        List<BuildWorldStatus> statuses = List.copyOf(worldStatusRegistry.getStatuses());
+        List<BuildWorldStatus> statuses = List.copyOf(worldStatusRegistry.getAll());
         registerPageItems(FIRST_CONTENT_SLOT, ITEMS_PER_PAGE, statuses, this::createStatusToggle);
 
         register(SLOT_BACK, createBackButton());

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/LayoutEditorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/LayoutEditorMenu.java
@@ -1,0 +1,587 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.menu.setup;
+
+import com.cryptomorin.xseries.XMaterial;
+import com.cryptomorin.xseries.XSound;
+import com.cryptomorin.xseries.profiles.objects.Profileable;
+import de.eintosti.buildsystem.api.world.display.Registry;
+import de.eintosti.buildsystem.api.world.display.RegistryEntry;
+import de.eintosti.buildsystem.i18n.Messages;
+import de.eintosti.buildsystem.menu.ItemBuilder;
+import de.eintosti.buildsystem.menu.Menu;
+import de.eintosti.buildsystem.menu.MenuItems;
+import de.eintosti.buildsystem.menu.Menus;
+import de.eintosti.buildsystem.menu.Prompts;
+import de.eintosti.buildsystem.menu.SkullTextures;
+import de.eintosti.buildsystem.navigator.NavigatorEditorService;
+import de.eintosti.buildsystem.util.TaskScheduler;
+import de.eintosti.buildsystem.util.color.ColorAPI;
+import java.util.List;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The drag-and-drop layout editor shared by the navigator and status setups. The top inventory is a live preview of
+ * the menu being arranged; the player's own inventory is taken over (snapshotted and cleared by the
+ * {@link NavigatorEditorService}, restored on close/quit/shutdown) to show a back button, a create button, reset and
+ * delete controls, and the palette of entries not currently placed.
+ *
+ * <p>Entries are picked up by clicking, placed by clicking a slot, swapped by dropping onto an occupant, hidden by
+ * dropping outside, and deleted by dropping on the bin. Shift-clicking opens the entry's editor.
+ *
+ * <p>Subclasses supply their registry, their icon rendering, their message keys, and their editor navigation. The
+ * navigator additionally drags a settings button that is not a registry entry; the {@code ...Extra...} hooks exist for
+ * it and default to doing nothing.
+ *
+ * @param <T> The registry entry type being arranged
+ */
+@NullMarked
+public abstract class LayoutEditorMenu<T extends RegistryEntry> extends Menu {
+
+    protected static final int BACK_SLOT = 0;
+    protected static final int CREATE_SLOT = 4;
+    protected static final int RESET_SLOT = 7;
+    protected static final int DELETE_SLOT = 8;
+    protected static final int PALETTE_FIRST_SLOT = 9;
+    protected static final int PALETTE_LAST_SLOT = 35;
+
+    /**
+     * The message keys that differ between the two editors. Grouped as data so the shared code reads them by role
+     * rather than each subclass overriding a dozen accessors.
+     *
+     * @param createItem The create button's name
+     * @param createLore The create button's lore
+     * @param reset The reset button's name, reused as the confirm-dialog title
+     * @param resetLore The reset button's lore
+     * @param resetConfirmLore The confirm lore when resetting only the layout
+     * @param resetAllConfirmLore The confirm lore when resetting every entry to defaults
+     * @param delete The delete (bin) button's name
+     * @param deleteLore The delete button's lore
+     * @param placedLore The lore on an entry sitting in the preview
+     * @param paletteLore The lore on an entry sitting in the palette
+     * @param addPrompt The prompt title when creating an entry
+     */
+    protected record LayoutMessages(
+            String createItem,
+            String createLore,
+            String reset,
+            String resetLore,
+            String resetConfirmLore,
+            String resetAllConfirmLore,
+            String delete,
+            String deleteLore,
+            String placedLore,
+            String paletteLore,
+            String addPrompt) {}
+
+    private final int previewSize;
+    private final LayoutMessages keys;
+    protected final MenuItems menuItems;
+    protected final Menus menus;
+    protected final Prompts prompts;
+    private final TaskScheduler scheduler;
+    private final NavigatorEditorService navigatorEditorService;
+    private final Held held = new Held();
+
+    protected LayoutEditorMenu(
+            Messages messages,
+            int previewSize,
+            String title,
+            LayoutMessages keys,
+            MenuItems menuItems,
+            Menus menus,
+            TaskScheduler scheduler,
+            Prompts prompts,
+            NavigatorEditorService navigatorEditorService) {
+        super(messages, previewSize, title);
+        this.previewSize = previewSize;
+        this.keys = keys;
+        this.menuItems = menuItems;
+        this.menus = menus;
+        this.scheduler = scheduler;
+        this.prompts = prompts;
+        this.navigatorEditorService = navigatorEditorService;
+    }
+
+    // ---------------------------------------------------------------- subclass contract
+
+    /**
+     * {@return the registry being arranged}
+     */
+    protected abstract Registry<T> registry();
+
+    /**
+     * {@return a builder for the entry's icon, already resolved but not yet named}
+     *
+     * @param entry The entry to render
+     * @param player The viewing player
+     */
+    protected abstract ItemBuilder icon(T entry, Player player);
+
+    /**
+     * Opens the per-entry editor, reached by shift-clicking an entry.
+     *
+     * @param entry The entry to edit
+     * @param player The viewing player
+     */
+    protected abstract void openEditor(T entry, Player player);
+
+    /**
+     * Re-opens this editor, used after a confirm dialog or a prompt is cancelled.
+     *
+     * @param player The viewing player
+     */
+    protected abstract void reopen(Player player);
+
+    /**
+     * Hook for a slot the preview reserves for something that is not a registry entry (the navigator's settings
+     * button). Reserved slots are skipped when placing entries and when searching for a free slot.
+     *
+     * @param slot The slot to test
+     * @return {@code true} if the slot is reserved
+     */
+    protected boolean isReserved(int slot) {
+        return false;
+    }
+
+    /**
+     * Hook for rendering non-entry items into the preview.
+     *
+     * @param player The viewing player
+     * @param inventory The preview inventory
+     */
+    protected void renderPreviewExtras(Player player, Inventory inventory) {}
+
+    /**
+     * Hook for rendering non-entry items into the palette, after the entries.
+     *
+     * @param player The viewing player
+     * @param playerInventory The player's inventory
+     * @param notAddedCount How many entries precede the extras in the palette
+     */
+    protected void renderPaletteExtras(Player player, Inventory playerInventory, int notAddedCount) {}
+
+    /**
+     * Hook for a preview click that the shared machinery should not handle (picking up or placing the navigator's
+     * settings button).
+     *
+     * @param player The clicking player
+     * @param slot The clicked slot
+     * @return {@code true} if the click was consumed
+     */
+    protected boolean onExtraPreviewClick(Player player, int slot) {
+        return false;
+    }
+
+    /**
+     * Hook for a palette click that the shared machinery should not handle.
+     *
+     * @param player The clicking player
+     * @param slot The clicked slot
+     * @return {@code true} if the click was consumed
+     */
+    protected boolean onExtraPaletteClick(Player player, int slot) {
+        return false;
+    }
+
+    /**
+     * Hook for dropping a held non-entry item outside the inventory.
+     *
+     * @param player The clicking player
+     * @return {@code true} if the drop was consumed
+     */
+    protected boolean onExtraOutsideDrop(Player player) {
+        return false;
+    }
+
+    /**
+     * Hook run after an entry is created, before its editor opens.
+     *
+     * @param created The newly created entry
+     */
+    protected void afterCreate(T created) {}
+
+    // ---------------------------------------------------------------- rendering
+
+    @Override
+    public void open(Player player) {
+        navigatorEditorService.beginSession(player);
+        populate(player);
+        player.openInventory(getInventory());
+        renderControls(player);
+    }
+
+    @Override
+    protected void populate(Player player) {
+        Inventory inventory = getInventory();
+        for (int slot = 0; slot < previewSize; slot++) {
+            menuItems.addGlassPane(player, inventory, slot);
+        }
+
+        renderPreviewExtras(player, inventory);
+
+        for (T entry : registry().getAll()) {
+            int slot = entry.getSlot();
+            if (!entry.isShown() || !isSlotValid(slot) || isReserved(slot) || isHeld(entry)) {
+                continue;
+            }
+            icon(entry, player)
+                    .name(ColorAPI.process(entry.getStyledName()))
+                    .lore(messages.getStringList(keys.placedLore(), player))
+                    .into(inventory, slot);
+        }
+    }
+
+    protected final void renderControls(Player player) {
+        Inventory playerInventory = player.getInventory();
+        playerInventory.clear();
+
+        ItemBuilder.of(XMaterial.BARRIER)
+                .name(messages.getString("setup_back", player))
+                .into(playerInventory, BACK_SLOT);
+        ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
+                .name(messages.getString(keys.createItem(), player))
+                .lore(messages.getStringList(keys.createLore(), player))
+                .into(playerInventory, CREATE_SLOT);
+        ItemBuilder.skull(Profileable.detect(SkullTextures.RESET))
+                .name(messages.getString(keys.reset(), player))
+                .lore(messages.getStringList(keys.resetLore(), player))
+                .into(playerInventory, RESET_SLOT);
+        ItemBuilder.skull(Profileable.detect(SkullTextures.DELETE))
+                .name(messages.getString(keys.delete(), player))
+                .lore(messages.getStringList(keys.deleteLore(), player))
+                .into(playerInventory, DELETE_SLOT);
+
+        List<T> notAdded = notAdded();
+        for (int i = 0; i < notAdded.size() && PALETTE_FIRST_SLOT + i <= PALETTE_LAST_SLOT; i++) {
+            T entry = notAdded.get(i);
+            if (isHeld(entry)) {
+                continue;
+            }
+            icon(entry, player)
+                    .name(ColorAPI.process(entry.getStyledName()))
+                    .lore(messages.getStringList(keys.paletteLore(), player))
+                    .into(playerInventory, PALETTE_FIRST_SLOT + i);
+        }
+
+        renderPaletteExtras(player, playerInventory, notAdded.size());
+    }
+
+    protected final List<T> notAdded() {
+        return registry().getAll().stream().filter(entry -> !entry.isShown()).toList();
+    }
+
+    protected final void refresh(Player player) {
+        populate(player);
+        renderControls(player);
+    }
+
+    // ---------------------------------------------------------------- clicks
+
+    @Override
+    public void handleClick(InventoryClickEvent event) {
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+
+        if (event.getClickedInventory() == getInventory()) {
+            handlePreviewClick(player, event.getRawSlot(), event.isShiftClick());
+        } else if (event.getClickedInventory() == player.getInventory()) {
+            handlePlayerClick(player, event.getSlot(), event.isRightClick(), event.isShiftClick());
+        } else {
+            handleOutsideClickWhileHolding(player);
+        }
+    }
+
+    private void handlePreviewClick(Player player, int slot, boolean shiftClick) {
+        if (!isSlotValid(slot)) {
+            return;
+        }
+        if (onExtraPreviewClick(player, slot)) {
+            return;
+        }
+        if (held.isHolding()) {
+            placeHeld(player, slot);
+            return;
+        }
+
+        T occupant = entryAtSlot(slot);
+        if (occupant == null) {
+            return;
+        }
+        if (shiftClick) {
+            openEditor(occupant, player);
+        } else {
+            pickUp(player, occupant.getId(), slot);
+        }
+    }
+
+    /**
+     * Places the held entry at {@code slot}. An occupant is displaced to the slot the held entry came from, or hidden
+     * when the held entry came from the palette and has no slot to give back.
+     */
+    protected final void placeHeld(Player player, int slot) {
+        T heldEntry = currentHeld();
+        if (heldEntry == null) {
+            clearHeld(player);
+            return;
+        }
+
+        if (!displaceReserved(slot, held.getFromSlot())) {
+            T occupant = entryAtSlot(slot);
+            if (occupant != null && !occupant.getId().equals(heldEntry.getId())) {
+                if (held.getFromSlot() >= 0) {
+                    occupant.setSlot(held.getFromSlot());
+                } else {
+                    occupant.setShown(false);
+                }
+                registry().persist(occupant);
+            }
+        }
+
+        heldEntry.setSlot(slot);
+        heldEntry.setShown(true);
+        registry().persist(heldEntry);
+        clearHeld(player);
+        refresh(player);
+    }
+
+    private void handlePlayerClick(Player player, int slot, boolean rightClick, boolean shiftClick) {
+        if (held.isHolding() && slot == DELETE_SLOT) {
+            deleteHeld(player);
+            return;
+        }
+        if (held.isHolding() || isHoldingExtra()) {
+            handleOutsideClickWhileHolding(player);
+            return;
+        }
+
+        if (slot == BACK_SLOT) {
+            XSound.BLOCK_CHEST_OPEN.play(player);
+            player.closeInventory();
+            menus.openSetup(player);
+            return;
+        }
+        if (slot == CREATE_SLOT) {
+            beginCreation(player);
+            return;
+        }
+        if (slot == RESET_SLOT) {
+            // Left-click resets only the layout; right-click resets every entry to the built-in defaults.
+            promptReset(player, rightClick);
+            return;
+        }
+        if (onExtraPaletteClick(player, slot)) {
+            return;
+        }
+
+        int paletteIndex = slot - PALETTE_FIRST_SLOT;
+        List<T> notAdded = notAdded();
+        if (paletteIndex < 0 || paletteIndex >= notAdded.size() || slot > PALETTE_LAST_SLOT) {
+            return;
+        }
+
+        T clicked = notAdded.get(paletteIndex);
+        if (shiftClick) {
+            openEditor(clicked, player);
+        } else {
+            pickUp(player, clicked.getId(), -1);
+        }
+    }
+
+    private void deleteHeld(Player player) {
+        if (held.isHolding() && registry().delete(held.getEntryId())) {
+            XSound.ENTITY_ITEM_BREAK.play(player);
+        }
+        clearHeld(player);
+        refresh(player);
+    }
+
+    /**
+     * Dropping outside puts the held entry back in the palette rather than deleting it; deletion is the bin's job.
+     */
+    protected final void handleOutsideClickWhileHolding(Player player) {
+        if (!onExtraOutsideDrop(player)) {
+            T heldEntry = currentHeld();
+            if (heldEntry != null) {
+                heldEntry.setShown(false);
+                registry().persist(heldEntry);
+            }
+        }
+        clearHeld(player);
+        refresh(player);
+    }
+
+    private void promptReset(Player player, boolean resetEverything) {
+        String confirmLoreKey = resetEverything ? keys.resetAllConfirmLore() : keys.resetConfirmLore();
+        menus.openDeletionConfirm(
+                player,
+                messages.getString(keys.reset(), player),
+                messages.getStringList(confirmLoreKey, player),
+                () -> {
+                    if (resetEverything) {
+                        registry().resetToDefaults();
+                    } else {
+                        registry().resetLayout();
+                    }
+                    XSound.ENTITY_CHICKEN_EGG.play(player);
+                    reopen(player);
+                },
+                () -> reopen(player));
+    }
+
+    private void beginCreation(Player player) {
+        prompts.prompt(player)
+                .title(keys.addPrompt())
+                .sanitizeName("setup_name_invalid_characters", "setup_name_empty")
+                .onCancel(() -> reopen(player))
+                .request(name -> {
+                    T created = registry().create(name);
+                    afterCreate(created);
+                    openEditor(created, player);
+                });
+    }
+
+    // ---------------------------------------------------------------- cursor
+
+    protected final void pickUp(Player player, String entryId, int fromSlot) {
+        held.track(entryId, fromSlot);
+        T entry = registry().get(entryId).orElse(null);
+        ItemStack cursor = entry == null
+                ? null
+                : icon(entry, player)
+                        .name(ColorAPI.process(entry.getStyledName()))
+                        .build();
+
+        setCursorNextTick(player, cursor);
+        XSound.ITEM_ARMOR_EQUIP_LEATHER.play(player);
+        refresh(player);
+    }
+
+    protected final void clearHeld(Player player) {
+        held.reset();
+        onClearHeld();
+        setCursorNextTick(player, null);
+    }
+
+    /**
+     * Hook for placing an entry onto a {@link #isReserved(int) reserved} slot: the reserved occupant moves aside
+     * instead of an entry being displaced.
+     *
+     * @param slot The slot being placed into
+     * @param heldFromSlot The slot the held entry came from, or {@code -1} if it came from the palette
+     * @return {@code true} if the slot was reserved and has been vacated
+     */
+    protected boolean displaceReserved(int slot, int heldFromSlot) {
+        return false;
+    }
+
+    /**
+     * {@return whether a registry entry is currently on the cursor}
+     */
+    protected final boolean isHoldingEntry() {
+        return held.isHolding();
+    }
+
+    /**
+     * Hook to clear any subclass-held cursor state alongside the shared one.
+     */
+    protected void onClearHeld() {}
+
+    /**
+     * {@return whether the subclass is holding something that is not a registry entry}
+     */
+    protected boolean isHoldingExtra() {
+        return false;
+    }
+
+    protected final void setCursorNextTick(Player player, @Nullable ItemStack cursor) {
+        scheduler.run(() -> {
+            if (navigatorEditorService.hasSession(player)) {
+                player.setItemOnCursor(cursor);
+            }
+        });
+    }
+
+    // ---------------------------------------------------------------- lookup
+
+    protected final @Nullable T entryAtSlot(int slot) {
+        return registry().getAll().stream()
+                .filter(entry -> entry.isShown() && entry.getSlot() == slot)
+                .findFirst()
+                .orElse(null);
+    }
+
+    protected final @Nullable T currentHeld() {
+        String id = held.getEntryId();
+        return id == null ? null : registry().get(id).orElse(null);
+    }
+
+    private boolean isHeld(T entry) {
+        return entry.getId().equals(held.getEntryId());
+    }
+
+    protected final boolean isSlotValid(int slot) {
+        return slot >= 0 && slot < previewSize;
+    }
+
+    protected final int previewSize() {
+        return previewSize;
+    }
+
+    @Override
+    public void handleClose(InventoryCloseEvent event) {
+        navigatorEditorService.restore((Player) event.getPlayer());
+    }
+
+    /**
+     * Pick-and-place tracking for the entry currently held on the cursor. {@code fromSlot} is {@code -1} when the
+     * entry was taken from the palette, which is what distinguishes "swap" from "displace into the palette".
+     */
+    private static final class Held {
+        private @Nullable String entryId;
+        private int fromSlot = -1;
+
+        void track(String entryId, int fromSlot) {
+            this.entryId = entryId;
+            this.fromSlot = fromSlot;
+        }
+
+        void reset() {
+            this.entryId = null;
+            this.fromSlot = -1;
+        }
+
+        @Nullable String getEntryId() {
+            return entryId;
+        }
+
+        boolean isHolding() {
+            return entryId != null;
+        }
+
+        int getFromSlot() {
+            return fromSlot;
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
@@ -115,8 +115,8 @@ public class NavigatorLayoutMenu extends Menu {
         }
 
         for (NavigatorCategory category : registry.getCategories()) {
-            int slot = category.getNavigatorSlot();
-            if (!category.isShownInNavigator() || !isSlotValid(slot) || slot == settingsSlot) {
+            int slot = category.getSlot();
+            if (!category.isShown() || !isSlotValid(slot) || slot == settingsSlot) {
                 continue;
             }
             if (category.getId().equals(cursorState.getHeldCategoryId())) {
@@ -184,7 +184,7 @@ public class NavigatorLayoutMenu extends Menu {
 
     private List<NavigatorCategory> notAddedCategories() {
         return registry.getCategories().stream()
-                .filter(category -> !category.isShownInNavigator())
+                .filter(category -> !category.isShown())
                 .toList();
     }
 
@@ -246,16 +246,16 @@ public class NavigatorLayoutMenu extends Menu {
             NavigatorCategoryImpl occupant = categoryAtSlot(slot);
             if (occupant != null && !occupant.equals(held)) {
                 if (cursorState.getHeldFromSlot() >= 0) {
-                    occupant.setNavigatorSlot(cursorState.getHeldFromSlot());
+                    occupant.setSlot(cursorState.getHeldFromSlot());
                 } else {
-                    occupant.setShownInNavigator(false);
+                    occupant.setShown(false);
                 }
                 registry.persist(occupant);
             }
         }
 
-        held.setNavigatorSlot(slot);
-        held.setShownInNavigator(true);
+        held.setSlot(slot);
+        held.setShown(true);
         registry.persist(held);
         clearHeld(player);
         refresh(player);
@@ -267,11 +267,11 @@ public class NavigatorLayoutMenu extends Menu {
             int previousSettingsSlot = registry.getSettingsSlot();
             if (isSlotValid(previousSettingsSlot)) {
                 // Swap: the displaced category takes the slot the settings button just vacated.
-                occupant.setNavigatorSlot(previousSettingsSlot);
+                occupant.setSlot(previousSettingsSlot);
             } else {
                 // Settings came from the palette (no slot to swap into); send the occupant to the palette rather than
                 // an invalid slot, which would hide it from the navigator entirely.
-                occupant.setShownInNavigator(false);
+                occupant.setShown(false);
             }
             registry.persist(occupant);
         }
@@ -339,7 +339,7 @@ public class NavigatorLayoutMenu extends Menu {
             NavigatorCategoryImpl held = (NavigatorCategoryImpl)
                     registry.getCategory(cursorState.getHeldCategoryId()).orElse(null);
             if (held != null) {
-                held.setShownInNavigator(false);
+                held.setShown(false);
                 registry.persist(held);
             }
         }
@@ -375,11 +375,11 @@ public class NavigatorLayoutMenu extends Menu {
                     NavigatorCategoryImpl created = registry.createCategory(name);
                     int freeSlot = firstFreeSlot();
                     if (freeSlot >= 0) {
-                        created.setShownInNavigator(true);
-                        created.setNavigatorSlot(freeSlot);
+                        created.setShown(true);
+                        created.setSlot(freeSlot);
                     } else {
                         // Grid is full: leave the new category in the palette rather than overwriting slot 0.
-                        created.setShownInNavigator(false);
+                        created.setShown(false);
                     }
                     registry.persist(created);
                     menus.openCategoryEditor(created, player);
@@ -432,7 +432,7 @@ public class NavigatorLayoutMenu extends Menu {
 
     private @Nullable NavigatorCategoryImpl categoryAtSlot(int slot) {
         return registry.getCategories().stream()
-                .filter(category -> category.isShownInNavigator() && category.getNavigatorSlot() == slot)
+                .filter(category -> category.isShown() && category.getSlot() == slot)
                 .map(category -> (NavigatorCategoryImpl) category)
                 .findFirst()
                 .orElse(null);
@@ -445,8 +445,8 @@ public class NavigatorLayoutMenu extends Menu {
     private int firstFreeSlot() {
         // Snapshot the occupied slots once rather than re-fetching the (sorted) category list for every slot.
         Set<Integer> occupied = registry.getCategories().stream()
-                .filter(NavigatorCategory::isShownInNavigator)
-                .map(NavigatorCategory::getNavigatorSlot)
+                .filter(NavigatorCategory::isShown)
+                .map(NavigatorCategory::getSlot)
                 .collect(Collectors.toSet());
         // The settings button holds a navigator slot too; never hand its slot out, or the category placed there is
         // skipped by populate() and silently vanishes from the navigator.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
@@ -17,59 +17,53 @@
  */
 package de.eintosti.buildsystem.world.menu.setup;
 
-import com.cryptomorin.xseries.XMaterial;
 import com.cryptomorin.xseries.XSound;
 import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.world.display.NavigatorCategory;
+import de.eintosti.buildsystem.api.world.display.Registry;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
 import de.eintosti.buildsystem.menu.MenuItems;
 import de.eintosti.buildsystem.menu.Menus;
 import de.eintosti.buildsystem.menu.Prompts;
 import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.navigator.NavigatorEditorService;
 import de.eintosti.buildsystem.util.TaskScheduler;
-import de.eintosti.buildsystem.util.color.ColorAPI;
-import de.eintosti.buildsystem.world.display.NavigatorCategoryImpl;
 import de.eintosti.buildsystem.world.display.NavigatorCategoryRegistryImpl;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
- * The combined navigator setup: it both manages categories and arranges their navigator layout in one screen. The top
- * inventory is a live, exact preview of the inventory navigator — each shown category at its slot plus the settings
- * button at its slot. The player's own inventory is taken over (snapshotted and cleared by
- * {@link de.eintosti.buildsystem.navigator.NavigatorEditorService}, restored on close/quit/shutdown) to present a
- * back button, a create-category button, and the palette of categories not yet in the navigator.
+ * The navigator setup: the preview is a live copy of the inventory navigator, and categories are dragged into it from
+ * the palette. The drag-and-drop itself lives in {@link LayoutEditorMenu}.
+ *
+ * <p>Unlike the status editor, this screen also arranges the settings button, which is not a registry entry. It
+ * occupies a navigator slot, can be picked up and placed like a category, and returns to the palette when dropped
+ * outside — which is what the {@code ...Extra...} and {@link #displaceReserved} hooks are for.
  */
 @NullMarked
-public class NavigatorLayoutMenu extends Menu {
+public class NavigatorLayoutMenu extends LayoutEditorMenu<NavigatorCategory> {
 
     private static final int NAVIGATOR_SIZE = 27;
 
-    private static final int BACK_SLOT = 0;
-    private static final int CREATE_SLOT = 4;
-    private static final int RESET_SLOT = 7;
-    private static final int DELETE_SLOT = 8;
-    private static final int PALETTE_FIRST_SLOT = 9;
-    private static final int PALETTE_LAST_SLOT = 35;
+    private static final LayoutMessages MESSAGES = new LayoutMessages(
+            "setup_category_add",
+            "setup_navigator_create_lore",
+            "setup_navigator_reset",
+            "setup_navigator_reset_lore",
+            "setup_navigator_reset_confirm_lore",
+            "setup_navigator_reset_all_confirm_lore",
+            "setup_navigator_delete",
+            "setup_navigator_delete_lore",
+            "setup_navigator_placed_lore",
+            "setup_navigator_palette_lore",
+            "setup_category_add_prompt");
 
-    private final MenuItems menuItems;
-    private final Menus menus;
-    private final TaskScheduler scheduler;
-    private final Prompts prompts;
     private final NavigatorCategoryRegistryImpl registry;
-    private final NavigatorEditorService navigatorEditorService;
-    private final ActiveCursorState cursorState = new ActiveCursorState();
+    private boolean holdingSettings;
 
     public NavigatorLayoutMenu(
             Messages messages,
@@ -80,189 +74,143 @@ public class NavigatorLayoutMenu extends Menu {
             NavigatorCategoryRegistryImpl navigatorCategoryRegistry,
             NavigatorEditorService navigatorEditorService,
             Player player) {
-        super(messages, NAVIGATOR_SIZE, messages.getString("setup_navigator_title", player));
-        this.menuItems = menuItems;
-        this.menus = menus;
-        this.scheduler = scheduler;
-        this.prompts = prompts;
+        super(
+                messages,
+                NAVIGATOR_SIZE,
+                messages.getString("setup_navigator_title", player),
+                MESSAGES,
+                menuItems,
+                menus,
+                scheduler,
+                prompts,
+                navigatorEditorService);
         this.registry = navigatorCategoryRegistry;
-        this.navigatorEditorService = navigatorEditorService;
     }
 
     @Override
-    public void open(Player player) {
-        navigatorEditorService.beginSession(player);
-        populate(player);
-        player.openInventory(getInventory());
-        renderControls(player);
+    protected Registry<NavigatorCategory> registry() {
+        return registry;
     }
 
     @Override
-    protected void populate(Player player) {
-        Inventory inventory = getInventory();
+    protected ItemBuilder icon(NavigatorCategory category, Player player) {
+        return ItemBuilder.icon(category, player);
+    }
 
-        // Empty navigator slots default to structural filler design panes
-        for (int slot = 0; slot < NAVIGATOR_SIZE; slot++) {
-            menuItems.addGlassPane(player, inventory, slot);
-        }
+    @Override
+    protected void openEditor(NavigatorCategory category, Player player) {
+        menus.openCategoryEditor(category, player);
+    }
 
+    @Override
+    protected void reopen(Player player) {
+        menus.openNavigatorLayout(player);
+    }
+
+    // ---------------------------------------------------------------- the settings button
+
+    @Override
+    protected boolean isReserved(int slot) {
+        return slot == registry.getSettingsSlot();
+    }
+
+    @Override
+    protected void renderPreviewExtras(Player player, Inventory inventory) {
         int settingsSlot = registry.getSettingsSlot();
-        if (!cursorState.isHoldingSettings() && isSlotValid(settingsSlot)) {
+        if (!holdingSettings && isSlotValid(settingsSlot)) {
             ItemBuilder.skull(Profileable.detect(SkullTextures.SETTINGS))
                     .name(messages.getString("old_navigator_settings", player))
                     .lore(messages.getStringList("setup_navigator_settings_placed_lore", player))
                     .into(inventory, settingsSlot);
         }
-
-        for (NavigatorCategory category : registry.getAll()) {
-            int slot = category.getSlot();
-            if (!category.isShown() || !isSlotValid(slot) || slot == settingsSlot) {
-                continue;
-            }
-            if (category.getId().equals(cursorState.getHeldCategoryId())) {
-                continue;
-            }
-            ItemBuilder.icon(category, player)
-                    .name(ColorAPI.process(category.getStyledName()))
-                    .lore(messages.getStringList("setup_navigator_placed_lore", player))
-                    .into(inventory, slot);
-        }
-    }
-
-    private void renderControls(Player player) {
-        Inventory playerInventory = player.getInventory();
-        playerInventory.clear();
-
-        ItemBuilder.of(XMaterial.BARRIER)
-                .name(messages.getString("setup_back", player))
-                .into(playerInventory, BACK_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
-                .name(messages.getString("setup_category_add", player))
-                .lore(messages.getStringList("setup_navigator_create_lore", player))
-                .into(playerInventory, CREATE_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.RESET))
-                .name(messages.getString("setup_navigator_reset", player))
-                .lore(messages.getStringList("setup_navigator_reset_lore", player))
-                .into(playerInventory, RESET_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.DELETE))
-                .name(messages.getString("setup_navigator_delete", player))
-                .lore(messages.getStringList("setup_navigator_delete_lore", player))
-                .into(playerInventory, DELETE_SLOT);
-
-        List<NavigatorCategory> notAdded = notAddedCategories();
-        for (int i = 0; i < notAdded.size() && PALETTE_FIRST_SLOT + i <= PALETTE_LAST_SLOT; i++) {
-            NavigatorCategory category = notAdded.get(i);
-            int slot = PALETTE_FIRST_SLOT + i;
-
-            if (category.getId().equals(cursorState.getHeldCategoryId())) {
-                continue;
-            }
-            ItemBuilder.icon(category, player)
-                    .name(ColorAPI.process(category.getStyledName()))
-                    .lore(messages.getStringList("setup_navigator_palette_lore", player))
-                    .into(playerInventory, slot);
-        }
-
-        int settingsTokenSlot = settingsPaletteSlot(notAdded.size());
-        if (!cursorState.isHoldingSettings() && registry.getSettingsSlot() < 0 && settingsTokenSlot >= 0) {
-            ItemBuilder.skull(Profileable.detect(SkullTextures.SETTINGS))
-                    .name(messages.getString("old_navigator_settings", player))
-                    .lore(messages.getStringList("setup_navigator_settings_palette_lore", player))
-                    .into(playerInventory, settingsTokenSlot);
-        }
-    }
-
-    private int settingsPaletteSlot() {
-        return settingsPaletteSlot(notAddedCategories().size());
-    }
-
-    /** The palette slot the settings token occupies, given the number of not-yet-added categories before it. */
-    private int settingsPaletteSlot(int notAddedCount) {
-        int slot = PALETTE_FIRST_SLOT + notAddedCount;
-        return slot <= PALETTE_LAST_SLOT ? slot : -1;
-    }
-
-    private List<NavigatorCategory> notAddedCategories() {
-        return registry.getAll().stream()
-                .filter(category -> !category.isShown())
-                .toList();
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        if (event.getClickedInventory() == getInventory()) {
-            handleNavigatorClick(player, event.getRawSlot(), event.isShiftClick());
-        } else if (event.getClickedInventory() == player.getInventory()) {
-            handlePlayerClick(player, event.getSlot(), event.isRightClick(), event.isShiftClick());
-        } else {
-            handleOutsideClickWhileHolding(player);
+    protected void renderPaletteExtras(Player player, Inventory playerInventory, int notAddedCount) {
+        int slot = settingsPaletteSlot(notAddedCount);
+        if (!holdingSettings && registry.getSettingsSlot() < 0 && slot >= 0) {
+            ItemBuilder.skull(Profileable.detect(SkullTextures.SETTINGS))
+                    .name(messages.getString("old_navigator_settings", player))
+                    .lore(messages.getStringList("setup_navigator_settings_palette_lore", player))
+                    .into(playerInventory, slot);
         }
     }
 
-    private void handleNavigatorClick(Player player, int slot, boolean shiftClick) {
-        if (!isSlotValid(slot)) {
-            return;
-        }
-
-        if (cursorState.isHoldingSettings()) {
+    @Override
+    protected boolean onExtraPreviewClick(Player player, int slot) {
+        if (holdingSettings) {
             placeSettings(player, slot);
-            return;
+            return true;
         }
-        if (cursorState.isHoldingCategory()) {
-            placeHeldCategory(player, slot);
-            return;
+        if (isHoldingEntry()) {
+            // A held category is placed by the shared machinery, even onto the settings slot.
+            return false;
         }
-
         if (slot == registry.getSettingsSlot()) {
             pickUpSettings(player);
-            return;
+            return true;
         }
-
-        NavigatorCategoryImpl occupant = categoryAtSlot(slot);
-        if (occupant != null) {
-            if (shiftClick) {
-                menus.openCategoryEditor(occupant, player);
-            } else {
-                pickUpCategory(player, occupant.getId(), slot);
-            }
-        }
+        return false;
     }
 
-    private void placeHeldCategory(Player player, int slot) {
-        NavigatorCategoryImpl held = (NavigatorCategoryImpl)
-                registry.get(cursorState.getHeldCategoryId()).orElse(null);
-        if (held == null) {
-            clearHeld(player);
-            return;
+    @Override
+    protected boolean onExtraPaletteClick(Player player, int slot) {
+        if (registry.getSettingsSlot() < 0
+                && slot == settingsPaletteSlot(notAdded().size())) {
+            pickUpSettings(player);
+            return true;
         }
+        return false;
+    }
 
-        if (slot == registry.getSettingsSlot()) {
-            registry.setSettingsSlot(
-                    cursorState.getHeldFromSlot() >= 0 ? cursorState.getHeldFromSlot() : firstFreeSlot());
+    @Override
+    protected boolean onExtraOutsideDrop(Player player) {
+        if (!holdingSettings) {
+            return false;
+        }
+        registry.setSettingsSlot(-1);
+        return true;
+    }
+
+    @Override
+    protected boolean displaceReserved(int slot, int heldFromSlot) {
+        if (slot != registry.getSettingsSlot()) {
+            return false;
+        }
+        // The settings button takes the slot the category vacated, or any free slot when it came from the palette.
+        registry.setSettingsSlot(heldFromSlot >= 0 ? heldFromSlot : firstFreeSlot());
+        return true;
+    }
+
+    @Override
+    protected boolean isHoldingExtra() {
+        return holdingSettings;
+    }
+
+    @Override
+    protected void onClearHeld() {
+        holdingSettings = false;
+    }
+
+    /**
+     * A new category is placed straight into the navigator when there is room, so it is visible immediately rather
+     * than hiding in the palette.
+     */
+    @Override
+    protected void afterCreate(NavigatorCategory created) {
+        int freeSlot = firstFreeSlot();
+        if (freeSlot >= 0) {
+            created.setShown(true);
+            created.setSlot(freeSlot);
         } else {
-            NavigatorCategoryImpl occupant = categoryAtSlot(slot);
-            if (occupant != null && !occupant.equals(held)) {
-                if (cursorState.getHeldFromSlot() >= 0) {
-                    occupant.setSlot(cursorState.getHeldFromSlot());
-                } else {
-                    occupant.setShown(false);
-                }
-                registry.persist(occupant);
-            }
+            // Grid is full: leave the new category in the palette rather than overwriting slot 0.
+            created.setShown(false);
         }
-
-        held.setSlot(slot);
-        held.setShown(true);
-        registry.persist(held);
-        clearHeld(player);
-        refresh(player);
+        registry.persist(created);
     }
 
     private void placeSettings(Player player, int slot) {
-        NavigatorCategoryImpl occupant = categoryAtSlot(slot);
+        NavigatorCategory occupant = entryAtSlot(slot);
         if (occupant != null) {
             int previousSettingsSlot = registry.getSettingsSlot();
             if (isSlotValid(previousSettingsSlot)) {
@@ -280,128 +228,8 @@ public class NavigatorLayoutMenu extends Menu {
         refresh(player);
     }
 
-    private void handlePlayerClick(Player player, int slot, boolean rightClick, boolean shiftClick) {
-        if (cursorState.isHoldingCategory() && slot == DELETE_SLOT) {
-            deleteHeldCategory(player);
-            return;
-        }
-        if (cursorState.isHoldingCategory() || cursorState.isHoldingSettings()) {
-            handleOutsideClickWhileHolding(player);
-            return;
-        }
-
-        if (slot == BACK_SLOT) {
-            XSound.BLOCK_CHEST_OPEN.play(player);
-            player.closeInventory();
-            menus.openSetup(player);
-            return;
-        }
-        if (slot == CREATE_SLOT) {
-            beginCategoryCreation(player);
-            return;
-        }
-        if (slot == RESET_SLOT) {
-            // Left-click resets only the layout; right-click resets every category to the built-in defaults.
-            promptReset(player, rightClick);
-            return;
-        }
-        if (registry.getSettingsSlot() < 0 && slot == settingsPaletteSlot()) {
-            pickUpSettings(player);
-            return;
-        }
-
-        int paletteIndex = slot - PALETTE_FIRST_SLOT;
-        List<NavigatorCategory> notAdded = notAddedCategories();
-        if (paletteIndex < 0 || paletteIndex >= notAdded.size() || slot > PALETTE_LAST_SLOT) {
-            return;
-        }
-
-        NavigatorCategory clicked = notAdded.get(paletteIndex);
-        if (shiftClick) {
-            menus.openCategoryEditor(clicked, player);
-        } else {
-            pickUpCategory(player, clicked.getId(), -1);
-        }
-    }
-
-    private void deleteHeldCategory(Player player) {
-        if (cursorState.isHoldingCategory() && registry.deleteCategory(cursorState.getHeldCategoryId())) {
-            XSound.ENTITY_ITEM_BREAK.play(player);
-        }
-        clearHeld(player);
-        refresh(player);
-    }
-
-    private void handleOutsideClickWhileHolding(Player player) {
-        if (cursorState.isHoldingSettings()) {
-            registry.setSettingsSlot(-1);
-        } else if (cursorState.isHoldingCategory()) {
-            NavigatorCategoryImpl held = (NavigatorCategoryImpl)
-                    registry.get(cursorState.getHeldCategoryId()).orElse(null);
-            if (held != null) {
-                held.setShown(false);
-                registry.persist(held);
-            }
-        }
-        clearHeld(player);
-        refresh(player);
-    }
-
-    private void promptReset(Player player, boolean resetEverything) {
-        String confirmLoreKey =
-                resetEverything ? "setup_navigator_reset_all_confirm_lore" : "setup_navigator_reset_confirm_lore";
-        menus.openDeletionConfirm(
-                player,
-                messages.getString("setup_navigator_reset", player),
-                messages.getStringList(confirmLoreKey, player),
-                () -> {
-                    if (resetEverything) {
-                        registry.resetToDefaults();
-                    } else {
-                        registry.resetNavigatorLayout();
-                    }
-                    XSound.ENTITY_CHICKEN_EGG.play(player);
-                    menus.openNavigatorLayout(player);
-                },
-                () -> menus.openNavigatorLayout(player));
-    }
-
-    private void beginCategoryCreation(Player player) {
-        prompts.prompt(player)
-                .title("setup_category_add_prompt")
-                .sanitizeName("setup_name_invalid_characters", "setup_name_empty")
-                .onCancel(() -> menus.openNavigatorLayout(player))
-                .request(name -> {
-                    NavigatorCategoryImpl created = registry.createCategory(name);
-                    int freeSlot = firstFreeSlot();
-                    if (freeSlot >= 0) {
-                        created.setShown(true);
-                        created.setSlot(freeSlot);
-                    } else {
-                        // Grid is full: leave the new category in the palette rather than overwriting slot 0.
-                        created.setShown(false);
-                    }
-                    registry.persist(created);
-                    menus.openCategoryEditor(created, player);
-                });
-    }
-
-    private void pickUpCategory(Player player, String categoryId, int fromSlot) {
-        cursorState.trackCategory(categoryId, fromSlot);
-        NavigatorCategory category = registry.get(categoryId).orElse(null);
-        ItemStack cursor = category == null
-                ? null
-                : ItemBuilder.icon(category, player)
-                        .name(ColorAPI.process(category.getStyledName()))
-                        .build();
-
-        setCursorNextTick(player, cursor);
-        XSound.ITEM_ARMOR_EQUIP_LEATHER.play(player);
-        refresh(player);
-    }
-
     private void pickUpSettings(Player player) {
-        cursorState.trackSettings();
+        holdingSettings = true;
         setCursorNextTick(
                 player,
                 ItemBuilder.skull(Profileable.detect(SkullTextures.SETTINGS))
@@ -412,30 +240,10 @@ public class NavigatorLayoutMenu extends Menu {
         refresh(player);
     }
 
-    private void clearHeld(Player player) {
-        cursorState.reset();
-        setCursorNextTick(player, null);
-    }
-
-    private void setCursorNextTick(Player player, @Nullable ItemStack cursor) {
-        scheduler.run(() -> {
-            if (navigatorEditorService.hasSession(player)) {
-                player.setItemOnCursor(cursor);
-            }
-        });
-    }
-
-    private void refresh(Player player) {
-        populate(player);
-        renderControls(player);
-    }
-
-    private @Nullable NavigatorCategoryImpl categoryAtSlot(int slot) {
-        return registry.getAll().stream()
-                .filter(category -> category.isShown() && category.getSlot() == slot)
-                .map(category -> (NavigatorCategoryImpl) category)
-                .findFirst()
-                .orElse(null);
+    /** The palette slot the settings token occupies, immediately after the not-yet-added categories. */
+    private int settingsPaletteSlot(int notAddedCount) {
+        int slot = PALETTE_FIRST_SLOT + notAddedCount;
+        return slot <= PALETTE_LAST_SLOT ? slot : -1;
     }
 
     /**
@@ -443,7 +251,6 @@ public class NavigatorLayoutMenu extends Menu {
      * as "no room" rather than placing at slot 0, which would overwrite the category already there.
      */
     private int firstFreeSlot() {
-        // Snapshot the occupied slots once rather than re-fetching the (sorted) category list for every slot.
         Set<Integer> occupied = registry.getAll().stream()
                 .filter(NavigatorCategory::isShown)
                 .map(NavigatorCategory::getSlot)
@@ -457,57 +264,5 @@ public class NavigatorLayoutMenu extends Menu {
             }
         }
         return -1;
-    }
-
-    private static boolean isSlotValid(int slot) {
-        return slot >= 0 && slot < NAVIGATOR_SIZE;
-    }
-
-    @Override
-    public void handleClose(InventoryCloseEvent event) {
-        navigatorEditorService.restore((Player) event.getPlayer());
-    }
-
-    /**
-     * Inner structured manager wrapping pick-and-place tracking metrics.
-     */
-    private static final class ActiveCursorState {
-        private @Nullable String heldCategoryId;
-        private boolean heldSettings;
-        private int heldFromSlot = -1;
-
-        public void trackCategory(String categoryId, int fromSlot) {
-            this.heldCategoryId = categoryId;
-            this.heldSettings = false;
-            this.heldFromSlot = fromSlot;
-        }
-
-        public void trackSettings() {
-            this.heldSettings = true;
-            this.heldCategoryId = null;
-            this.heldFromSlot = -1;
-        }
-
-        public void reset() {
-            this.heldCategoryId = null;
-            this.heldSettings = false;
-            this.heldFromSlot = -1;
-        }
-
-        public @Nullable String getHeldCategoryId() {
-            return heldCategoryId;
-        }
-
-        public boolean isHoldingSettings() {
-            return heldSettings;
-        }
-
-        public boolean isHoldingCategory() {
-            return heldCategoryId != null;
-        }
-
-        public int getHeldFromSlot() {
-            return heldFromSlot;
-        }
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/NavigatorLayoutMenu.java
@@ -114,7 +114,7 @@ public class NavigatorLayoutMenu extends Menu {
                     .into(inventory, settingsSlot);
         }
 
-        for (NavigatorCategory category : registry.getCategories()) {
+        for (NavigatorCategory category : registry.getAll()) {
             int slot = category.getSlot();
             if (!category.isShown() || !isSlotValid(slot) || slot == settingsSlot) {
                 continue;
@@ -183,7 +183,7 @@ public class NavigatorLayoutMenu extends Menu {
     }
 
     private List<NavigatorCategory> notAddedCategories() {
-        return registry.getCategories().stream()
+        return registry.getAll().stream()
                 .filter(category -> !category.isShown())
                 .toList();
     }
@@ -233,7 +233,7 @@ public class NavigatorLayoutMenu extends Menu {
 
     private void placeHeldCategory(Player player, int slot) {
         NavigatorCategoryImpl held = (NavigatorCategoryImpl)
-                registry.getCategory(cursorState.getHeldCategoryId()).orElse(null);
+                registry.get(cursorState.getHeldCategoryId()).orElse(null);
         if (held == null) {
             clearHeld(player);
             return;
@@ -337,7 +337,7 @@ public class NavigatorLayoutMenu extends Menu {
             registry.setSettingsSlot(-1);
         } else if (cursorState.isHoldingCategory()) {
             NavigatorCategoryImpl held = (NavigatorCategoryImpl)
-                    registry.getCategory(cursorState.getHeldCategoryId()).orElse(null);
+                    registry.get(cursorState.getHeldCategoryId()).orElse(null);
             if (held != null) {
                 held.setShown(false);
                 registry.persist(held);
@@ -388,7 +388,7 @@ public class NavigatorLayoutMenu extends Menu {
 
     private void pickUpCategory(Player player, String categoryId, int fromSlot) {
         cursorState.trackCategory(categoryId, fromSlot);
-        NavigatorCategory category = registry.getCategory(categoryId).orElse(null);
+        NavigatorCategory category = registry.get(categoryId).orElse(null);
         ItemStack cursor = category == null
                 ? null
                 : ItemBuilder.icon(category, player)
@@ -431,7 +431,7 @@ public class NavigatorLayoutMenu extends Menu {
     }
 
     private @Nullable NavigatorCategoryImpl categoryAtSlot(int slot) {
-        return registry.getCategories().stream()
+        return registry.getAll().stream()
                 .filter(category -> category.isShown() && category.getSlot() == slot)
                 .map(category -> (NavigatorCategoryImpl) category)
                 .findFirst()
@@ -444,7 +444,7 @@ public class NavigatorLayoutMenu extends Menu {
      */
     private int firstFreeSlot() {
         // Snapshot the occupied slots once rather than re-fetching the (sorted) category list for every slot.
-        Set<Integer> occupied = registry.getCategories().stream()
+        Set<Integer> occupied = registry.getAll().stream()
                 .filter(NavigatorCategory::isShown)
                 .map(NavigatorCategory::getSlot)
                 .collect(Collectors.toSet());

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusEditorMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusEditorMenu.java
@@ -118,7 +118,7 @@ public class StatusEditorMenu extends RegistryEditorMenu {
 
     private String getProgressesLabel(Player player) {
         return status.getProgressesTo()
-                .flatMap(registry::getStatus)
+                .flatMap(registry::get)
                 .map(target -> ColorAPI.process(target.getStyledName()))
                 .orElseGet(() -> messages.getString("setup_status_progresses_none", player));
     }
@@ -128,7 +128,7 @@ public class StatusEditorMenu extends RegistryEditorMenu {
      * itself). Only real registry values are cycled; clearing to "none" is a separate right-click on the button.
      */
     private @Nullable String nextProgressTarget() {
-        List<String> candidates = registry.getStatuses().stream()
+        List<String> candidates = registry.getAll().stream()
                 .map(BuildWorldStatus::getId)
                 .filter(id -> !id.equals(status.getId()))
                 .toList();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
@@ -104,10 +104,8 @@ public class StatusLayoutMenu extends Menu {
         }
 
         for (BuildWorldStatus status : registry.getStatuses()) {
-            int slot = status.getStatusSlot();
-            if (!status.isShownInStatusMenu()
-                    || !isSlotValid(slot)
-                    || status.getId().equals(held.getStatusId())) {
+            int slot = status.getSlot();
+            if (!status.isShown() || !isSlotValid(slot) || status.getId().equals(held.getStatusId())) {
                 continue;
             }
             ItemBuilder.of(status.getIcon())
@@ -152,7 +150,7 @@ public class StatusLayoutMenu extends Menu {
 
     private List<BuildWorldStatus> notAddedStatuses() {
         return registry.getStatuses().stream()
-                .filter(status -> !status.isShownInStatusMenu())
+                .filter(status -> !status.isShown())
                 .toList();
     }
 
@@ -199,15 +197,15 @@ public class StatusLayoutMenu extends Menu {
         WorldStatusImpl occupant = statusAtSlot(slot);
         if (occupant != null && !occupant.equals(heldStatus)) {
             if (held.getFromSlot() >= 0) {
-                occupant.setStatusSlot(held.getFromSlot());
+                occupant.setSlot(held.getFromSlot());
             } else {
-                occupant.setShownInStatusMenu(false);
+                occupant.setShown(false);
             }
             registry.persist(occupant);
         }
 
-        heldStatus.setStatusSlot(slot);
-        heldStatus.setShownInStatusMenu(true);
+        heldStatus.setSlot(slot);
+        heldStatus.setShown(true);
         registry.persist(heldStatus);
         clearHeld(player);
         refresh(player);
@@ -264,7 +262,7 @@ public class StatusLayoutMenu extends Menu {
     private void handleOutsideClickWhileHolding(Player player) {
         WorldStatusImpl heldStatus = currentHeld();
         if (heldStatus != null) {
-            heldStatus.setShownInStatusMenu(false);
+            heldStatus.setShown(false);
             registry.persist(heldStatus);
         }
         clearHeld(player);
@@ -336,7 +334,7 @@ public class StatusLayoutMenu extends Menu {
 
     private @Nullable WorldStatusImpl statusAtSlot(int slot) {
         return registry.getStatuses().stream()
-                .filter(status -> status.isShownInStatusMenu() && status.getStatusSlot() == slot)
+                .filter(status -> status.isShown() && status.getSlot() == slot)
                 .map(status -> (WorldStatusImpl) status)
                 .findFirst()
                 .orElse(null);

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
@@ -17,58 +17,41 @@
  */
 package de.eintosti.buildsystem.world.menu.setup;
 
-import com.cryptomorin.xseries.XMaterial;
-import com.cryptomorin.xseries.XSound;
-import com.cryptomorin.xseries.profiles.objects.Profileable;
 import de.eintosti.buildsystem.api.world.data.BuildWorldStatus;
+import de.eintosti.buildsystem.api.world.display.Registry;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.menu.ItemBuilder;
-import de.eintosti.buildsystem.menu.Menu;
 import de.eintosti.buildsystem.menu.MenuItems;
 import de.eintosti.buildsystem.menu.Menus;
 import de.eintosti.buildsystem.menu.Prompts;
-import de.eintosti.buildsystem.menu.SkullTextures;
 import de.eintosti.buildsystem.navigator.NavigatorEditorService;
 import de.eintosti.buildsystem.util.TaskScheduler;
-import de.eintosti.buildsystem.util.color.ColorAPI;
-import de.eintosti.buildsystem.world.data.WorldStatusImpl;
 import de.eintosti.buildsystem.world.data.WorldStatusRegistryImpl;
-import java.util.List;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
- * The status setup, built as the exact counterpart of the {@link NavigatorLayoutMenu navigator layout editor}: the top
- * inventory is a live preview of the {@code /worlds setStatus} picker, and the player's own inventory is taken over (by
- * the shared {@link de.eintosti.buildsystem.navigator.NavigatorEditorService}, restored on close/quit/shutdown) to show
- * a back button, a create button, reset and delete controls, and the palette of statuses not currently in the picker.
- * Statuses are dragged into slots, dropped onto the bin to delete, and shift-clicked to open the
- * {@link StatusEditorMenu}.
+ * The status setup: the preview is a live {@code /worlds setStatus} picker, and statuses are dragged into it from the
+ * palette. All of the drag-and-drop lives in {@link LayoutEditorMenu}; this class supplies only the registry, the
+ * icon, the message keys, and where shift-click goes.
  */
 @NullMarked
-public class StatusLayoutMenu extends Menu {
+public class StatusLayoutMenu extends LayoutEditorMenu<BuildWorldStatus> {
 
-    private static final int PREVIEW_SIZE = WorldStatusRegistryImpl.STATUS_MENU_SIZE;
+    private static final LayoutMessages MESSAGES = new LayoutMessages(
+            "setup_status_add",
+            "setup_status_layout_create_lore",
+            "setup_status_layout_reset",
+            "setup_status_layout_reset_lore",
+            "setup_status_layout_reset_confirm_lore",
+            "setup_status_layout_reset_all_confirm_lore",
+            "setup_status_layout_delete",
+            "setup_status_layout_delete_lore",
+            "setup_status_layout_placed_lore",
+            "setup_status_layout_palette_lore",
+            "setup_status_add_prompt");
 
-    private static final int BACK_SLOT = 0;
-    private static final int CREATE_SLOT = 4;
-    private static final int RESET_SLOT = 7;
-    private static final int DELETE_SLOT = 8;
-    private static final int PALETTE_FIRST_SLOT = 9;
-    private static final int PALETTE_LAST_SLOT = 35;
-
-    private final MenuItems menuItems;
-    private final Menus menus;
-    private final TaskScheduler scheduler;
-    private final Prompts prompts;
     private final WorldStatusRegistryImpl registry;
-    private final NavigatorEditorService navigatorEditorService;
-    private final Held held = new Held();
 
     public StatusLayoutMenu(
             Messages messages,
@@ -79,305 +62,36 @@ public class StatusLayoutMenu extends Menu {
             WorldStatusRegistryImpl worldStatusRegistry,
             NavigatorEditorService navigatorEditorService,
             Player player) {
-        super(messages, PREVIEW_SIZE, messages.getString("setup_statuses_title", player));
-        this.menuItems = menuItems;
-        this.menus = menus;
-        this.scheduler = scheduler;
-        this.prompts = prompts;
+        super(
+                messages,
+                WorldStatusRegistryImpl.STATUS_MENU_SIZE,
+                messages.getString("setup_statuses_title", player),
+                MESSAGES,
+                menuItems,
+                menus,
+                scheduler,
+                prompts,
+                navigatorEditorService);
         this.registry = worldStatusRegistry;
-        this.navigatorEditorService = navigatorEditorService;
     }
 
     @Override
-    public void open(Player player) {
-        navigatorEditorService.beginSession(player);
-        populate(player);
-        player.openInventory(getInventory());
-        renderControls(player);
+    protected Registry<BuildWorldStatus> registry() {
+        return registry;
     }
 
     @Override
-    protected void populate(Player player) {
-        Inventory inventory = getInventory();
-        for (int slot = 0; slot < PREVIEW_SIZE; slot++) {
-            menuItems.addGlassPane(player, inventory, slot);
-        }
-
-        for (BuildWorldStatus status : registry.getAll()) {
-            int slot = status.getSlot();
-            if (!status.isShown() || !isSlotValid(slot) || status.getId().equals(held.getStatusId())) {
-                continue;
-            }
-            ItemBuilder.of(status.getIcon())
-                    .name(ColorAPI.process(status.getStyledName()))
-                    .lore(messages.getStringList("setup_status_layout_placed_lore", player))
-                    .into(inventory, slot);
-        }
-    }
-
-    private void renderControls(Player player) {
-        Inventory playerInventory = player.getInventory();
-        playerInventory.clear();
-
-        ItemBuilder.of(XMaterial.BARRIER)
-                .name(messages.getString("setup_back", player))
-                .into(playerInventory, BACK_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.ADD_ITEM))
-                .name(messages.getString("setup_status_add", player))
-                .lore(messages.getStringList("setup_status_layout_create_lore", player))
-                .into(playerInventory, CREATE_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.RESET))
-                .name(messages.getString("setup_status_layout_reset", player))
-                .lore(messages.getStringList("setup_status_layout_reset_lore", player))
-                .into(playerInventory, RESET_SLOT);
-        ItemBuilder.skull(Profileable.detect(SkullTextures.DELETE))
-                .name(messages.getString("setup_status_layout_delete", player))
-                .lore(messages.getStringList("setup_status_layout_delete_lore", player))
-                .into(playerInventory, DELETE_SLOT);
-
-        List<BuildWorldStatus> notAdded = notAddedStatuses();
-        for (int i = 0; i < notAdded.size() && PALETTE_FIRST_SLOT + i <= PALETTE_LAST_SLOT; i++) {
-            BuildWorldStatus status = notAdded.get(i);
-            if (status.getId().equals(held.getStatusId())) {
-                continue;
-            }
-            ItemBuilder.of(status.getIcon())
-                    .name(ColorAPI.process(status.getStyledName()))
-                    .lore(messages.getStringList("setup_status_layout_palette_lore", player))
-                    .into(playerInventory, PALETTE_FIRST_SLOT + i);
-        }
-    }
-
-    private List<BuildWorldStatus> notAddedStatuses() {
-        return registry.getAll().stream().filter(status -> !status.isShown()).toList();
+    protected ItemBuilder icon(BuildWorldStatus status, Player player) {
+        return ItemBuilder.of(status.getIcon());
     }
 
     @Override
-    public void handleClick(InventoryClickEvent event) {
-        event.setCancelled(true);
-        Player player = (Player) event.getWhoClicked();
-
-        if (event.getClickedInventory() == getInventory()) {
-            handlePreviewClick(player, event.getRawSlot(), event.isShiftClick());
-        } else if (event.getClickedInventory() == player.getInventory()) {
-            handlePlayerClick(player, event.getSlot(), event.isRightClick(), event.isShiftClick());
-        } else {
-            handleOutsideClickWhileHolding(player);
-        }
-    }
-
-    private void handlePreviewClick(Player player, int slot, boolean shiftClick) {
-        if (!isSlotValid(slot)) {
-            return;
-        }
-        if (held.isHolding()) {
-            placeHeld(player, slot);
-            return;
-        }
-
-        WorldStatusImpl occupant = statusAtSlot(slot);
-        if (occupant != null) {
-            if (shiftClick) {
-                menus.openStatusEditor(occupant, player);
-            } else {
-                pickUp(player, occupant.getId(), slot);
-            }
-        }
-    }
-
-    private void placeHeld(Player player, int slot) {
-        WorldStatusImpl heldStatus = currentHeld();
-        if (heldStatus == null) {
-            clearHeld(player);
-            return;
-        }
-
-        WorldStatusImpl occupant = statusAtSlot(slot);
-        if (occupant != null && !occupant.equals(heldStatus)) {
-            if (held.getFromSlot() >= 0) {
-                occupant.setSlot(held.getFromSlot());
-            } else {
-                occupant.setShown(false);
-            }
-            registry.persist(occupant);
-        }
-
-        heldStatus.setSlot(slot);
-        heldStatus.setShown(true);
-        registry.persist(heldStatus);
-        clearHeld(player);
-        refresh(player);
-    }
-
-    private void handlePlayerClick(Player player, int slot, boolean rightClick, boolean shiftClick) {
-        if (held.isHolding() && slot == DELETE_SLOT) {
-            deleteHeld(player);
-            return;
-        }
-        if (held.isHolding()) {
-            handleOutsideClickWhileHolding(player);
-            return;
-        }
-
-        if (slot == BACK_SLOT) {
-            XSound.BLOCK_CHEST_OPEN.play(player);
-            player.closeInventory();
-            menus.openSetup(player);
-            return;
-        }
-        if (slot == CREATE_SLOT) {
-            beginStatusCreation(player);
-            return;
-        }
-        if (slot == RESET_SLOT) {
-            // Left-click resets only the layout; right-click resets every status to the built-in defaults.
-            promptReset(player, rightClick);
-            return;
-        }
-
-        int paletteIndex = slot - PALETTE_FIRST_SLOT;
-        List<BuildWorldStatus> notAdded = notAddedStatuses();
-        if (paletteIndex < 0 || paletteIndex >= notAdded.size() || slot > PALETTE_LAST_SLOT) {
-            return;
-        }
-
-        BuildWorldStatus clicked = notAdded.get(paletteIndex);
-        if (shiftClick) {
-            menus.openStatusEditor(clicked, player);
-        } else {
-            pickUp(player, clicked.getId(), -1);
-        }
-    }
-
-    private void deleteHeld(Player player) {
-        if (held.isHolding() && registry.deleteStatus(held.getStatusId())) {
-            XSound.ENTITY_ITEM_BREAK.play(player);
-        }
-        clearHeld(player);
-        refresh(player);
-    }
-
-    private void handleOutsideClickWhileHolding(Player player) {
-        WorldStatusImpl heldStatus = currentHeld();
-        if (heldStatus != null) {
-            heldStatus.setShown(false);
-            registry.persist(heldStatus);
-        }
-        clearHeld(player);
-        refresh(player);
-    }
-
-    private void promptReset(Player player, boolean resetEverything) {
-        String confirmLoreKey = resetEverything
-                ? "setup_status_layout_reset_all_confirm_lore"
-                : "setup_status_layout_reset_confirm_lore";
-        menus.openDeletionConfirm(
-                player,
-                messages.getString("setup_status_layout_reset", player),
-                messages.getStringList(confirmLoreKey, player),
-                () -> {
-                    if (resetEverything) {
-                        registry.resetToDefaults();
-                    } else {
-                        registry.resetStatusLayout();
-                    }
-                    XSound.ENTITY_CHICKEN_EGG.play(player);
-                    menus.openStatusLayout(player);
-                },
-                () -> menus.openStatusLayout(player));
-    }
-
-    private void beginStatusCreation(Player player) {
-        prompts.prompt(player)
-                .title("setup_status_add_prompt")
-                .sanitizeName("setup_name_invalid_characters", "setup_name_empty")
-                .onCancel(() -> menus.openStatusLayout(player))
-                .request(name -> {
-                    WorldStatusImpl created = registry.createStatus(name);
-                    menus.openStatusEditor(created, player);
-                });
-    }
-
-    private void pickUp(Player player, String statusId, int fromSlot) {
-        held.track(statusId, fromSlot);
-        BuildWorldStatus status = registry.get(statusId).orElse(null);
-        ItemStack cursor = status == null
-                ? null
-                : ItemBuilder.of(status.getIcon())
-                        .name(ColorAPI.process(status.getStyledName()))
-                        .build();
-
-        setCursorNextTick(player, cursor);
-        XSound.ITEM_ARMOR_EQUIP_LEATHER.play(player);
-        refresh(player);
-    }
-
-    private void clearHeld(Player player) {
-        held.reset();
-        setCursorNextTick(player, null);
-    }
-
-    private void setCursorNextTick(Player player, @Nullable ItemStack cursor) {
-        scheduler.run(() -> {
-            if (navigatorEditorService.hasSession(player)) {
-                player.setItemOnCursor(cursor);
-            }
-        });
-    }
-
-    private void refresh(Player player) {
-        populate(player);
-        renderControls(player);
-    }
-
-    private @Nullable WorldStatusImpl statusAtSlot(int slot) {
-        return registry.getAll().stream()
-                .filter(status -> status.isShown() && status.getSlot() == slot)
-                .map(status -> (WorldStatusImpl) status)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private @Nullable WorldStatusImpl currentHeld() {
-        return (WorldStatusImpl) registry.get(held.getStatusId()).orElse(null);
-    }
-
-    private static boolean isSlotValid(int slot) {
-        return slot >= 0 && slot < PREVIEW_SIZE;
+    protected void openEditor(BuildWorldStatus status, Player player) {
+        menus.openStatusEditor(status, player);
     }
 
     @Override
-    public void handleClose(InventoryCloseEvent event) {
-        navigatorEditorService.restore((Player) event.getPlayer());
-    }
-
-    /**
-     * Pick-and-place tracking for the status currently held on the cursor.
-     */
-    private static final class Held {
-        private @Nullable String statusId;
-        private int fromSlot = -1;
-
-        void track(String statusId, int fromSlot) {
-            this.statusId = statusId;
-            this.fromSlot = fromSlot;
-        }
-
-        void reset() {
-            this.statusId = null;
-            this.fromSlot = -1;
-        }
-
-        @Nullable String getStatusId() {
-            return statusId;
-        }
-
-        boolean isHolding() {
-            return statusId != null;
-        }
-
-        int getFromSlot() {
-            return fromSlot;
-        }
+    protected void reopen(Player player) {
+        menus.openStatusLayout(player);
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/menu/setup/StatusLayoutMenu.java
@@ -103,7 +103,7 @@ public class StatusLayoutMenu extends Menu {
             menuItems.addGlassPane(player, inventory, slot);
         }
 
-        for (BuildWorldStatus status : registry.getStatuses()) {
+        for (BuildWorldStatus status : registry.getAll()) {
             int slot = status.getSlot();
             if (!status.isShown() || !isSlotValid(slot) || status.getId().equals(held.getStatusId())) {
                 continue;
@@ -149,9 +149,7 @@ public class StatusLayoutMenu extends Menu {
     }
 
     private List<BuildWorldStatus> notAddedStatuses() {
-        return registry.getStatuses().stream()
-                .filter(status -> !status.isShown())
-                .toList();
+        return registry.getAll().stream().filter(status -> !status.isShown()).toList();
     }
 
     @Override
@@ -302,7 +300,7 @@ public class StatusLayoutMenu extends Menu {
 
     private void pickUp(Player player, String statusId, int fromSlot) {
         held.track(statusId, fromSlot);
-        BuildWorldStatus status = registry.getStatus(statusId).orElse(null);
+        BuildWorldStatus status = registry.get(statusId).orElse(null);
         ItemStack cursor = status == null
                 ? null
                 : ItemBuilder.of(status.getIcon())
@@ -333,7 +331,7 @@ public class StatusLayoutMenu extends Menu {
     }
 
     private @Nullable WorldStatusImpl statusAtSlot(int slot) {
-        return registry.getStatuses().stream()
+        return registry.getAll().stream()
                 .filter(status -> status.isShown() && status.getSlot() == slot)
                 .map(status -> (WorldStatusImpl) status)
                 .findFirst()
@@ -341,7 +339,7 @@ public class StatusLayoutMenu extends Menu {
     }
 
     private @Nullable WorldStatusImpl currentHeld() {
-        return (WorldStatusImpl) registry.getStatus(held.getStatusId()).orElse(null);
+        return (WorldStatusImpl) registry.get(held.getStatusId()).orElse(null);
     }
 
     private static boolean isSlotValid(int slot) {

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/test/TestData.java
@@ -33,6 +33,7 @@ import de.eintosti.buildsystem.menu.Prompts;
 import de.eintosti.buildsystem.player.PlayerLookupService;
 import de.eintosti.buildsystem.player.PlayerServiceImpl;
 import de.eintosti.buildsystem.util.TaskScheduler;
+import de.eintosti.buildsystem.world.BuildWorldImpl;
 import de.eintosti.buildsystem.world.WorldContext;
 import de.eintosti.buildsystem.world.data.WorldStatusImpl;
 import de.eintosti.buildsystem.world.data.WorldStatusRegistryImpl;
@@ -134,14 +135,13 @@ public final class TestData {
      * Wires a mocked plugin's {@link WorldStatusRegistryImpl} to resolve the built-in statuses by id, defaulting to
      * {@link #NOT_STARTED}. Uses lenient stubbing so tests that never touch the registry do not fail strict-stub checks.
      *
-     * @param plugin The mocked plugin to wire
      * @return The mocked registry, for further stubbing if needed
      */
     public static WorldStatusRegistryImpl statusRegistry() {
         WorldStatusRegistryImpl registry = mock(WorldStatusRegistryImpl.class);
-        lenient().when(registry.getStatuses()).thenReturn(List.copyOf(STATUSES));
-        lenient().when(registry.getDefaultStatus()).thenReturn(NOT_STARTED);
-        lenient().when(registry.getStatus(anyString())).thenAnswer(invocation -> byId(invocation.getArgument(0)));
+        lenient().when(registry.getAll()).thenReturn(List.copyOf(STATUSES));
+        lenient().when(registry.getDefault()).thenReturn(NOT_STARTED);
+        lenient().when(registry.get(anyString())).thenAnswer(invocation -> byId(invocation.getArgument(0)));
         return registry;
     }
 
@@ -149,16 +149,13 @@ public final class TestData {
      * Wires a mocked plugin's {@link NavigatorCategoryRegistryImpl} to resolve the built-in categories by id, defaulting
      * to {@link #PUBLIC}.
      *
-     * @param plugin The mocked plugin to wire
      * @return The mocked registry, for further stubbing if needed
      */
     public static NavigatorCategoryRegistryImpl categoryRegistry() {
         NavigatorCategoryRegistryImpl registry = mock(NavigatorCategoryRegistryImpl.class);
-        lenient().when(registry.getCategories()).thenReturn(List.copyOf(CATEGORIES));
-        lenient().when(registry.getDefaultCategory()).thenReturn(PUBLIC);
-        lenient()
-                .when(registry.getCategory(anyString()))
-                .thenAnswer(invocation -> categoryById(invocation.getArgument(0)));
+        lenient().when(registry.getAll()).thenReturn(List.copyOf(CATEGORIES));
+        lenient().when(registry.getDefault()).thenReturn(PUBLIC);
+        lenient().when(registry.get(anyString())).thenAnswer(invocation -> categoryById(invocation.getArgument(0)));
         return registry;
     }
 

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
@@ -76,7 +76,7 @@ class WorldStatusRegistryImplTest {
 
     @Test
     void createStatus_addsCustomStatusWithUniqueId() {
-        BuildWorldStatus created = registry.createStatus("Needs Review");
+        BuildWorldStatus created = registry.create("Needs Review");
 
         assertEquals("needs_review", created.getId());
         assertFalse(created.isBuiltIn());
@@ -85,34 +85,34 @@ class WorldStatusRegistryImplTest {
 
     @Test
     void createStatus_twiceYieldsDistinctIds() {
-        BuildWorldStatus first = registry.createStatus("Review");
-        BuildWorldStatus second = registry.createStatus("Review");
+        BuildWorldStatus first = registry.create("Review");
+        BuildWorldStatus second = registry.create("Review");
 
         assertNotEquals(first.getId(), second.getId());
     }
 
     @Test
     void deleteStatus_removesCustomStatus() {
-        BuildWorldStatus created = registry.createStatus("Temporary");
+        BuildWorldStatus created = registry.create("Temporary");
 
-        assertTrue(registry.deleteStatus(created.getId()));
+        assertTrue(registry.delete(created.getId()));
         assertFalse(registry.get(created.getId()).isPresent());
     }
 
     @Test
     void deleteStatus_allowsBuiltIn() {
-        assertTrue(registry.deleteStatus(WorldStatusRegistry.NOT_STARTED_ID));
+        assertTrue(registry.delete(WorldStatusRegistry.NOT_STARTED_ID));
         assertFalse(registry.get(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
     }
 
     @Test
     void deleteStatus_clearsDanglingProgressionTarget() {
-        WorldStatusImpl source = registry.createStatus("Source");
-        WorldStatusImpl target = registry.createStatus("Target");
+        WorldStatusImpl source = registry.create("Source");
+        WorldStatusImpl target = registry.create("Target");
         source.setProgressesTo(target.getId());
         registry.persist(source);
 
-        assertTrue(registry.deleteStatus(target.getId()));
+        assertTrue(registry.delete(target.getId()));
 
         BuildWorldStatus survivor = registry.get(source.getId()).orElseThrow();
         assertTrue(survivor.getProgressesTo().isEmpty(), "progressesTo should be cleared, not left dangling");
@@ -122,16 +122,16 @@ class WorldStatusRegistryImplTest {
     void deleteStatus_refusesLastRemaining() {
         // Delete down to a single status; the final one must never be removable.
         for (BuildWorldStatus status : List.copyOf(registry.getAll())) {
-            registry.deleteStatus(status.getId());
+            registry.delete(status.getId());
         }
         assertEquals(1, registry.getAll().size());
         String lastId = registry.getAll().iterator().next().getId();
-        assertFalse(registry.deleteStatus(lastId));
+        assertFalse(registry.delete(lastId));
     }
 
     @Test
     void resetToDefaults_restoresBuiltIns() {
-        registry.deleteStatus(WorldStatusRegistry.NOT_STARTED_ID);
+        registry.delete(WorldStatusRegistry.NOT_STARTED_ID);
         registry.resetToDefaults();
         assertEquals(6, registry.getAll().size());
         assertTrue(registry.get(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
@@ -139,7 +139,7 @@ class WorldStatusRegistryImplTest {
 
     @Test
     void createdStatus_survivesReload() {
-        registry.createStatus("Persisted");
+        registry.create("Persisted");
 
         WorldStatusRegistryImpl reloaded = reloadRegistry();
         assertTrue(reloaded.get("persisted").isPresent());
@@ -156,7 +156,7 @@ class WorldStatusRegistryImplTest {
 
     @Test
     void createStatus_isPlacedInThePicker() {
-        BuildWorldStatus created = registry.createStatus("Needs Review");
+        BuildWorldStatus created = registry.create("Needs Review");
         assertTrue(created.getSlot() >= 0);
         assertTrue(created.isShown());
     }
@@ -167,9 +167,9 @@ class WorldStatusRegistryImplTest {
                 registry.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
         notStarted.setSlot(25);
         registry.persist(notStarted);
-        WorldStatusImpl custom = registry.createStatus("Custom");
+        WorldStatusImpl custom = registry.create("Custom");
 
-        registry.resetStatusLayout();
+        registry.resetLayout();
 
         assertEquals(
                 10,

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
@@ -64,15 +64,14 @@ class WorldStatusRegistryImplTest {
 
     @Test
     void seedsTheSixBuiltInStatuses() {
-        assertEquals(6, registry.getStatuses().size());
-        assertTrue(registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
-        assertTrue(registry.getStatus(WorldStatusRegistry.ARCHIVE_ID).isPresent());
+        assertEquals(6, registry.getAll().size());
+        assertTrue(registry.get(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
+        assertTrue(registry.get(WorldStatusRegistry.ARCHIVE_ID).isPresent());
     }
 
     @Test
     void defaultStatusIsNotStarted() {
-        assertEquals(
-                WorldStatusRegistry.NOT_STARTED_ID, registry.getDefaultStatus().getId());
+        assertEquals(WorldStatusRegistry.NOT_STARTED_ID, registry.getDefault().getId());
     }
 
     @Test
@@ -81,7 +80,7 @@ class WorldStatusRegistryImplTest {
 
         assertEquals("needs_review", created.getId());
         assertFalse(created.isBuiltIn());
-        assertTrue(registry.getStatus("needs_review").isPresent());
+        assertTrue(registry.get("needs_review").isPresent());
     }
 
     @Test
@@ -97,13 +96,13 @@ class WorldStatusRegistryImplTest {
         BuildWorldStatus created = registry.createStatus("Temporary");
 
         assertTrue(registry.deleteStatus(created.getId()));
-        assertFalse(registry.getStatus(created.getId()).isPresent());
+        assertFalse(registry.get(created.getId()).isPresent());
     }
 
     @Test
     void deleteStatus_allowsBuiltIn() {
         assertTrue(registry.deleteStatus(WorldStatusRegistry.NOT_STARTED_ID));
-        assertFalse(registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
+        assertFalse(registry.get(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
     }
 
     @Test
@@ -115,18 +114,18 @@ class WorldStatusRegistryImplTest {
 
         assertTrue(registry.deleteStatus(target.getId()));
 
-        BuildWorldStatus survivor = registry.getStatus(source.getId()).orElseThrow();
+        BuildWorldStatus survivor = registry.get(source.getId()).orElseThrow();
         assertTrue(survivor.getProgressesTo().isEmpty(), "progressesTo should be cleared, not left dangling");
     }
 
     @Test
     void deleteStatus_refusesLastRemaining() {
         // Delete down to a single status; the final one must never be removable.
-        for (BuildWorldStatus status : List.copyOf(registry.getStatuses())) {
+        for (BuildWorldStatus status : List.copyOf(registry.getAll())) {
             registry.deleteStatus(status.getId());
         }
-        assertEquals(1, registry.getStatuses().size());
-        String lastId = registry.getStatuses().iterator().next().getId();
+        assertEquals(1, registry.getAll().size());
+        String lastId = registry.getAll().iterator().next().getId();
         assertFalse(registry.deleteStatus(lastId));
     }
 
@@ -134,8 +133,8 @@ class WorldStatusRegistryImplTest {
     void resetToDefaults_restoresBuiltIns() {
         registry.deleteStatus(WorldStatusRegistry.NOT_STARTED_ID);
         registry.resetToDefaults();
-        assertEquals(6, registry.getStatuses().size());
-        assertTrue(registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
+        assertEquals(6, registry.getAll().size());
+        assertTrue(registry.get(WorldStatusRegistry.NOT_STARTED_ID).isPresent());
     }
 
     @Test
@@ -143,16 +142,16 @@ class WorldStatusRegistryImplTest {
         registry.createStatus("Persisted");
 
         WorldStatusRegistryImpl reloaded = reloadRegistry();
-        assertTrue(reloaded.getStatus("persisted").isPresent());
+        assertTrue(reloaded.get("persisted").isPresent());
     }
 
     @Test
     void seededStatuses_getDefaultPickerSlots() {
         BuildWorldStatus notStarted =
-                registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
+                registry.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
         assertEquals(10, notStarted.getSlot());
         assertTrue(notStarted.isShown());
-        assertEquals(15, registry.getStatus("hidden").orElseThrow().getSlot());
+        assertEquals(15, registry.get("hidden").orElseThrow().getSlot());
     }
 
     @Test
@@ -165,7 +164,7 @@ class WorldStatusRegistryImplTest {
     @Test
     void resetStatusLayout_restoresBuiltInSlotsAndHidesCustom() {
         WorldStatusImpl notStarted = (WorldStatusImpl)
-                registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
+                registry.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
         notStarted.setSlot(25);
         registry.persist(notStarted);
         WorldStatusImpl custom = registry.createStatus("Custom");
@@ -174,24 +173,20 @@ class WorldStatusRegistryImplTest {
 
         assertEquals(
                 10,
-                registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID)
-                        .orElseThrow()
-                        .getSlot());
-        assertFalse(registry.getStatus(custom.getId()).orElseThrow().isShown());
+                registry.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow().getSlot());
+        assertFalse(registry.get(custom.getId()).orElseThrow().isShown());
     }
 
     @Test
     void unplacedStatus_isGivenASlotOnReload() {
         WorldStatusImpl notStarted = (WorldStatusImpl)
-                registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
+                registry.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
         notStarted.setSlot(-1);
         registry.persist(notStarted);
 
         WorldStatusRegistryImpl reloaded = reloadRegistry();
-        assertTrue(reloaded.getStatus(WorldStatusRegistry.NOT_STARTED_ID)
-                        .orElseThrow()
-                        .getSlot()
-                >= 0);
+        assertTrue(
+                reloaded.get(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow().getSlot() >= 0);
     }
 
     private WorldStatusRegistryImpl reloadRegistry() {

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/data/WorldStatusRegistryImplTest.java
@@ -150,23 +150,23 @@ class WorldStatusRegistryImplTest {
     void seededStatuses_getDefaultPickerSlots() {
         BuildWorldStatus notStarted =
                 registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
-        assertEquals(10, notStarted.getStatusSlot());
-        assertTrue(notStarted.isShownInStatusMenu());
-        assertEquals(15, registry.getStatus("hidden").orElseThrow().getStatusSlot());
+        assertEquals(10, notStarted.getSlot());
+        assertTrue(notStarted.isShown());
+        assertEquals(15, registry.getStatus("hidden").orElseThrow().getSlot());
     }
 
     @Test
     void createStatus_isPlacedInThePicker() {
         BuildWorldStatus created = registry.createStatus("Needs Review");
-        assertTrue(created.getStatusSlot() >= 0);
-        assertTrue(created.isShownInStatusMenu());
+        assertTrue(created.getSlot() >= 0);
+        assertTrue(created.isShown());
     }
 
     @Test
     void resetStatusLayout_restoresBuiltInSlotsAndHidesCustom() {
         WorldStatusImpl notStarted = (WorldStatusImpl)
                 registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
-        notStarted.setStatusSlot(25);
+        notStarted.setSlot(25);
         registry.persist(notStarted);
         WorldStatusImpl custom = registry.createStatus("Custom");
 
@@ -176,21 +176,21 @@ class WorldStatusRegistryImplTest {
                 10,
                 registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID)
                         .orElseThrow()
-                        .getStatusSlot());
-        assertFalse(registry.getStatus(custom.getId()).orElseThrow().isShownInStatusMenu());
+                        .getSlot());
+        assertFalse(registry.getStatus(custom.getId()).orElseThrow().isShown());
     }
 
     @Test
     void unplacedStatus_isGivenASlotOnReload() {
         WorldStatusImpl notStarted = (WorldStatusImpl)
                 registry.getStatus(WorldStatusRegistry.NOT_STARTED_ID).orElseThrow();
-        notStarted.setStatusSlot(-1);
+        notStarted.setSlot(-1);
         registry.persist(notStarted);
 
         WorldStatusRegistryImpl reloaded = reloadRegistry();
         assertTrue(reloaded.getStatus(WorldStatusRegistry.NOT_STARTED_ID)
                         .orElseThrow()
-                        .getStatusSlot()
+                        .getSlot()
                 >= 0);
     }
 

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImplTest.java
@@ -78,7 +78,7 @@ class NavigatorCategoryRegistryImplTest {
 
     @Test
     void createCategory_addsCustomCategory() {
-        NavigatorCategory created = registry.createCategory("Administration");
+        NavigatorCategory created = registry.create("Administration");
 
         assertEquals("administration", created.getId());
         assertFalse(created.isBuiltIn());
@@ -87,35 +87,35 @@ class NavigatorCategoryRegistryImplTest {
 
     @Test
     void deleteCategory_removesCustomCategory() {
-        NavigatorCategory created = registry.createCategory("Temporary");
+        NavigatorCategory created = registry.create("Temporary");
 
-        assertTrue(registry.deleteCategory(created.getId()));
+        assertTrue(registry.delete(created.getId()));
         assertFalse(registry.get(created.getId()).isPresent());
     }
 
     @Test
     void deleteCategory_allowsBuiltIn() {
-        assertTrue(registry.deleteCategory(NavigatorCategoryRegistry.PUBLIC_ID));
+        assertTrue(registry.delete(NavigatorCategoryRegistry.PUBLIC_ID));
         assertFalse(registry.get(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
     }
 
     @Test
     void deleteCategory_allowsDeletingEveryCategory() {
         for (NavigatorCategory category : List.copyOf(registry.getAll())) {
-            assertTrue(registry.deleteCategory(category.getId()));
+            assertTrue(registry.delete(category.getId()));
         }
         assertEquals(0, registry.getAll().size());
     }
 
     @Test
     void deleteCategory_returnsFalseForUnknownId() {
-        assertFalse(registry.deleteCategory("does-not-exist"));
+        assertFalse(registry.delete("does-not-exist"));
     }
 
     @Test
     void getDefault_reseedsBuiltInsWhenEmpty() {
         for (NavigatorCategory category : List.copyOf(registry.getAll())) {
-            registry.deleteCategory(category.getId());
+            registry.delete(category.getId());
         }
         assertEquals(0, registry.getAll().size());
 
@@ -126,7 +126,7 @@ class NavigatorCategoryRegistryImplTest {
 
     @Test
     void resetToDefaults_restoresBuiltIns() {
-        registry.deleteCategory(NavigatorCategoryRegistry.PUBLIC_ID);
+        registry.delete(NavigatorCategoryRegistry.PUBLIC_ID);
         registry.resetToDefaults();
         assertEquals(3, registry.getAll().size());
         assertTrue(registry.get(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImplTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/display/NavigatorCategoryRegistryImplTest.java
@@ -57,23 +57,21 @@ class NavigatorCategoryRegistryImplTest {
 
     @Test
     void seedsThreeBuiltInCategories() {
-        assertEquals(3, registry.getCategories().size());
-        assertTrue(registry.getCategory(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
-        assertTrue(registry.getCategory(NavigatorCategoryRegistry.PRIVATE_ID).isPresent());
-        assertTrue(registry.getCategory(NavigatorCategoryRegistry.ARCHIVE_ID).isPresent());
+        assertEquals(3, registry.getAll().size());
+        assertTrue(registry.get(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
+        assertTrue(registry.get(NavigatorCategoryRegistry.PRIVATE_ID).isPresent());
+        assertTrue(registry.get(NavigatorCategoryRegistry.ARCHIVE_ID).isPresent());
     }
 
     @Test
     void defaultCategoryIsPublic() {
-        assertEquals(
-                NavigatorCategoryRegistry.PUBLIC_ID,
-                registry.getDefaultCategory().getId());
+        assertEquals(NavigatorCategoryRegistry.PUBLIC_ID, registry.getDefault().getId());
     }
 
     @Test
     void privateCategoryGroupsAddedPlayers() {
         NavigatorCategory privateCategory =
-                registry.getCategory(NavigatorCategoryRegistry.PRIVATE_ID).orElseThrow();
+                registry.get(NavigatorCategoryRegistry.PRIVATE_ID).orElseThrow();
         assertTrue(privateCategory.getVisibilities().contains(Visibility.ADDED_PLAYERS));
         assertFalse(privateCategory.getVisibilities().contains(Visibility.EVERYONE));
     }
@@ -84,7 +82,7 @@ class NavigatorCategoryRegistryImplTest {
 
         assertEquals("administration", created.getId());
         assertFalse(created.isBuiltIn());
-        assertTrue(registry.getCategory("administration").isPresent());
+        assertTrue(registry.get("administration").isPresent());
     }
 
     @Test
@@ -92,21 +90,21 @@ class NavigatorCategoryRegistryImplTest {
         NavigatorCategory created = registry.createCategory("Temporary");
 
         assertTrue(registry.deleteCategory(created.getId()));
-        assertFalse(registry.getCategory(created.getId()).isPresent());
+        assertFalse(registry.get(created.getId()).isPresent());
     }
 
     @Test
     void deleteCategory_allowsBuiltIn() {
         assertTrue(registry.deleteCategory(NavigatorCategoryRegistry.PUBLIC_ID));
-        assertFalse(registry.getCategory(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
+        assertFalse(registry.get(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
     }
 
     @Test
     void deleteCategory_allowsDeletingEveryCategory() {
-        for (NavigatorCategory category : List.copyOf(registry.getCategories())) {
+        for (NavigatorCategory category : List.copyOf(registry.getAll())) {
             assertTrue(registry.deleteCategory(category.getId()));
         }
-        assertEquals(0, registry.getCategories().size());
+        assertEquals(0, registry.getAll().size());
     }
 
     @Test
@@ -115,32 +113,30 @@ class NavigatorCategoryRegistryImplTest {
     }
 
     @Test
-    void getDefaultCategory_reseedsBuiltInsWhenEmpty() {
-        for (NavigatorCategory category : List.copyOf(registry.getCategories())) {
+    void getDefault_reseedsBuiltInsWhenEmpty() {
+        for (NavigatorCategory category : List.copyOf(registry.getAll())) {
             registry.deleteCategory(category.getId());
         }
-        assertEquals(0, registry.getCategories().size());
+        assertEquals(0, registry.getAll().size());
 
         // Folders always need a home category, so the default reseeds the built-ins on demand.
-        assertEquals(
-                NavigatorCategoryRegistry.PUBLIC_ID,
-                registry.getDefaultCategory().getId());
-        assertEquals(3, registry.getCategories().size());
+        assertEquals(NavigatorCategoryRegistry.PUBLIC_ID, registry.getDefault().getId());
+        assertEquals(3, registry.getAll().size());
     }
 
     @Test
     void resetToDefaults_restoresBuiltIns() {
         registry.deleteCategory(NavigatorCategoryRegistry.PUBLIC_ID);
         registry.resetToDefaults();
-        assertEquals(3, registry.getCategories().size());
-        assertTrue(registry.getCategory(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
+        assertEquals(3, registry.getAll().size());
+        assertTrue(registry.get(NavigatorCategoryRegistry.PUBLIC_ID).isPresent());
     }
 
     @Test
     void addStatusToDefaultCategory_makesItReachable() {
         registry.addStatusToDefaultCategory("custom_status");
 
-        assertTrue(registry.getDefaultCategory().getStatusIds().contains("custom_status"));
+        assertTrue(registry.getDefault().getStatusIds().contains("custom_status"));
     }
 
     @Test
@@ -148,6 +144,6 @@ class NavigatorCategoryRegistryImplTest {
         registry.addStatusToDefaultCategory("custom_status");
         registry.removeStatusFromCategories("custom_status");
 
-        assertFalse(registry.getDefaultCategory().getStatusIds().contains("custom_status"));
+        assertFalse(registry.getDefault().getStatusIds().contains("custom_status"));
     }
 }


### PR DESCRIPTION
`BuildWorldStatus` and `NavigatorCategory` described the same thing in different words, and the divergence ran all the way down: into the registries that manage them, and into the two 400-500 line editors that arrange them.

Both interfaces had an id, a display name, a colour, a styled name (identical default method), an icon, and a built-in flag. Both had a menu slot and a shown flag — named differently for no semantic reason:

| Concept | Status | Category |
| --- | --- | --- |
| slot | `getStatusSlot()` | `getNavigatorSlot()` |
| visible | `isShownInStatusMenu()` | `isShownInNavigator()` |

Nothing distinguishes a status's slot from a category's slot except which menu it happens to live in.

## `RegistryEntry`

The shared half moves to a new `RegistryEntry`: `getId`, `getDisplayName`, `getColor`, `getStyledName`, `getIcon`, `getSlot`, `isShown`, `isBuiltIn`, plus `setSlot`/`setShown`. Both interfaces now carry only what is genuinely theirs — `getOrder`/`getPermission`/`isBuildingAllowed`/`getProgressesTo` for statuses, `getVisibilities`/`getStatusIds`/`groups`/`getIconSkullTexture` for categories.

`RegistryEntry` deliberately does **not** extend `Displayable`. A displayable renders per viewer (`getDisplayName(Player)`, `getLore(Player)`); a registry entry is static configuration whose name and colour do not depend on who is looking. They are different concepts that happen to share the word "display".

## `Registry<T>`

The two registry interfaces declared the same operations under different names, so they now inherit them:

| Was | Now |
| --- | --- |
| `getStatuses()` / `getCategories()` | `getAll()` |
| `getStatus(id)` / `getCategory(id)` | `get(id)` |
| `getDefaultStatus()` / `getDefaultCategory()` | `getDefault()` |

`Registry<T>` also gained the write half it already had in practice: `create`, `delete`, `persist`, `resetLayout`, `resetToDefaults`. Exposing `setSlot`/`setShown` without a way to persist would make them useless — a plugin's changes would vanish on restart. A side effect is that a third-party plugin can now ship its own status or category, which was not previously possible.

`NavigatorCategoryRegistry` keeps `getCategoryForWorld(world)`, which has no status counterpart.

## `LayoutEditorMenu<T>`

`NavigatorLayoutMenu` and `StatusLayoutMenu` implemented the same drag-and-drop state machine twice — pick up, place, swap with an occupant, drop outside to hide, drop on the bin to delete, cursor tracking, and the player-inventory takeover.

| | Before | After |
| --- | --- | --- |
| `StatusLayoutMenu` | 387 | **97** |
| `NavigatorLayoutMenu` | 513 | **267** |
| `LayoutEditorMenu` | — | 589 |

`StatusLayoutMenu` is now a registry, an icon, a table of message keys, and where shift-click goes.

The navigator keeps more because it drags a **settings button**, which is not a registry entry: it occupies a navigator slot, can be picked up and placed like a category, and returns to the palette when dropped outside. The hooks for it (`isReserved`, `renderPreviewExtras`, `renderPaletteExtras`, `onExtraPreviewClick`, `onExtraPaletteClick`, `onExtraOutsideDrop`, `displaceReserved`, `afterCreate`) all default to doing nothing — the status editor overrides none of them.

## Breaking

The four entry renames and the six registry accessor renames. All pre-4.0, and this is the last window — after release these names are fixed for a major version.

`Folder.getCategory()` is untouched; only the id-taking registry overload was renamed.

## Testing

Verified by hand in `/setup`: both editors drag, swap, hide, delete and reset, and the navigator's settings button moves both ways.

There are no automated tests for these two menus, and there cannot easily be: both call `ItemBuilder.skull(...)`, whose XSeries initializer reflects into NMS internals MockBukkit does not provide, and `refresh()` hits it after every state transition. Making them testable needs a `MenuItems.renderSkull(...)` seam first, which is worth doing separately.
