### PR TITLE
refactor: add Codec.putIfPresent for optional fields

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/Codec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/Codec.java
@@ -20,6 +20,7 @@ package de.eintosti.buildsystem.storage.codec;
 import java.util.Map;
 import org.bukkit.configuration.ConfigurationSection;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Maps a single entity of type {@code T} to and from its persisted YAML form, isolating the (de)serialization concern
@@ -52,6 +53,20 @@ public interface Codec<T> {
      * @return The persisted map form, round-trippable by {@link #deserialize(String, ConfigurationSection)}
      */
     Map<String, Object> serialize(T value);
+
+    /**
+     * Puts {@code value} under {@code key} unless it is {@code null}, so an absent field is simply omitted. Lets a
+     * codec keep one line per field without ever putting a null into the map.
+     *
+     * @param serialized The map being built
+     * @param key The field key
+     * @param value The value, or {@code null} to omit the field
+     */
+    static void putIfPresent(Map<String, Object> serialized, String key, @Nullable Object value) {
+        if (value != null) {
+            serialized.put(key, value);
+        }
+    }
 
     /**
      * Reconstructs an entity from the section stored under {@code key}.

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/FolderCodec.java
@@ -80,14 +80,12 @@ public final class FolderCodec implements Codec<Folder> {
         serialized.put(CREATOR, folder.getCreator().toString());
         serialized.put(CREATION, folder.getCreation());
         serialized.put(CATEGORY, folder.getCategory().getId());
-        if (folder.hasParent()) {
-            serialized.put(PARENT, folder.getParent().getUniqueId().toString());
-        }
+        Codec.putIfPresent(
+                serialized,
+                PARENT,
+                folder.hasParent() ? folder.getParent().getUniqueId().toString() : null);
         serialized.put(MATERIAL, folder.getIcon().name());
-        String skullTexture = folder.getIconSkullTexture();
-        if (skullTexture != null) {
-            serialized.put(ICON_SKULL_TEXTURE, skullTexture);
-        }
+        Codec.putIfPresent(serialized, ICON_SKULL_TEXTURE, folder.getIconSkullTexture());
         serialized.put(PERMISSION, folder.getPermission());
         serialized.put(PROJECT, folder.getProject());
         serialized.put(

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/PlayerCodec.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/storage/codec/PlayerCodec.java
@@ -87,9 +87,10 @@ public final class PlayerCodec implements Codec<BuildPlayer> {
 
         serialized.put(SETTINGS, serializeSettings(player.getSettings()));
         LogoutLocation logoutLocation = player.getLogoutLocation();
-        if (logoutLocation != null) {
-            serialized.put(LOGOUT_LOCATION, LogoutLocationCodec.format(logoutLocation));
-        }
+        Codec.putIfPresent(
+                serialized,
+                LOGOUT_LOCATION,
+                logoutLocation == null ? null : LogoutLocationCodec.format(logoutLocation));
 
         return serialized;
     }


### PR DESCRIPTION
Follow-up to #511.

Making the serialize maps null-free cost each codec an `if` block per optional field — `FolderCodec` went from 2 lines to 6. That verbosity was the only real argument for the alternative design (let the map hold nulls, have the storage strip them).

`Codec.putIfPresent` removes the trade-off: one line per field, and the map still never holds a null.

```java
Codec.putIfPresent(serialized, ICON_SKULL_TEXTURE, folder.getIconSkullTexture());
```

Keeping the map null-free matters beyond tidiness — `Map.of()` rejects null values, `get()` can't distinguish absent from present-but-null, and `getOrDefault` returns null rather than the default for a null-valued key.