### PR TITLE
perf: cut the shaded jar from 32 MB to 4 MB

### DIFF
--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -64,9 +64,17 @@ dependencies {
     }
     compileOnly(libs.axiompaper)
 
-    implementation(libs.bouncycastle)
+    // Ed25519 host keys for the SFTP backup. sshd cannot use the JDK provider for these, and this is ~90 KB
+    // against BouncyCastle's ~19 MB.
+    implementation(libs.eddsa)
     implementation(libs.bstats)
-    implementation(libs.bundles.aws)
+    // The S3 backup uses the synchronous S3Client, so the async netty transport is dead weight, and the Apache
+    // client is swapped for the JDK-backed one. Together they are ~14 MB of the shaded jar.
+    implementation(libs.bundles.aws) {
+        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+        exclude(group = "software.amazon.awssdk", module = "apache-client")
+        exclude(group = "software.amazon.awssdk", module = "apache5-client")
+    }
     implementation(libs.fastboard)
     implementation(libs.nbt) { isTransitive = false }
     implementation(libs.paperlib)
@@ -98,7 +106,7 @@ tasks.named<ShadowJar>("shadowJar") {
     minimize {
         exclude(dependency("software.amazon.awssdk:.*:.*"))
         exclude(dependency("org.apache.sshd:.*:.*"))
-        exclude(dependency("org.bouncycastle:.*:.*"))
+        exclude(dependency("net.i2p.crypto:.*:.*"))
         exclude(dependency("org.bstats:.*:.*"))
     }
     archiveFileName.set("${rootProject.name}-${project.version}.jar")
@@ -114,8 +122,9 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.apache.commons.codec", "$shadePath.apache.commons.codec")
     relocate("org.apache.commons.logging", "$shadePath.apache.commons.logging")
     relocate("org.apache.http", "$shadePath.apache.http")
+    relocate("org.apache.hc", "$shadePath.apache.hc")
     relocate("org.apache.sshd", "$shadePath.sshd")
-    relocate("org.bouncycastle", "$shadePath.bouncycastle")
+    relocate("net.i2p.crypto", "$shadePath.eddsa")
     relocate("org.bstats", "$shadePath.bstats")
     relocate("org.reactivestreams", "$shadePath.reactivestreams")
     relocate("org.slf4j", "$shadePath.slf4j")

--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -64,17 +64,10 @@ dependencies {
     }
     compileOnly(libs.axiompaper)
 
-    // Ed25519 host keys for the SFTP backup. sshd cannot use the JDK provider for these, and this is ~90 KB
-    // against BouncyCastle's ~19 MB.
+    // Ed25519 host keys for the SFTP backup. sshd cannot use the JDK provider
+    // for these, and this is ~90 KB against BouncyCastle's ~19 MB.
     implementation(libs.eddsa)
     implementation(libs.bstats)
-    // The S3 backup uses the synchronous S3Client, so the async netty transport is dead weight, and the Apache
-    // client is swapped for the JDK-backed one. Together they are ~14 MB of the shaded jar.
-    implementation(libs.bundles.aws) {
-        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
-        exclude(group = "software.amazon.awssdk", module = "apache-client")
-        exclude(group = "software.amazon.awssdk", module = "apache5-client")
-    }
     implementation(libs.fastboard)
     implementation(libs.nbt) { isTransitive = false }
     implementation(libs.paperlib)
@@ -104,7 +97,6 @@ tasks.named("assemble") {
 
 tasks.named<ShadowJar>("shadowJar") {
     minimize {
-        exclude(dependency("software.amazon.awssdk:.*:.*"))
         exclude(dependency("org.apache.sshd:.*:.*"))
         exclude(dependency("net.i2p.crypto:.*:.*"))
         exclude(dependency("org.bstats:.*:.*"))
@@ -122,14 +114,10 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("org.apache.commons.codec", "$shadePath.apache.commons.codec")
     relocate("org.apache.commons.logging", "$shadePath.apache.commons.logging")
     relocate("org.apache.http", "$shadePath.apache.http")
-    relocate("org.apache.hc", "$shadePath.apache.hc")
     relocate("org.apache.sshd", "$shadePath.sshd")
     relocate("net.i2p.crypto", "$shadePath.eddsa")
     relocate("org.bstats", "$shadePath.bstats")
-    relocate("org.reactivestreams", "$shadePath.reactivestreams")
     relocate("org.slf4j", "$shadePath.slf4j")
-    relocate("software.amazon.awssdk", "$shadePath.awssdk")
-    relocate("software.amazon.eventstream", "$shadePath.awssdk.eventstream")
 }
 
 tasks.runServer {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/StorageSettingsFactory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/StorageSettingsFactory.java
@@ -57,10 +57,11 @@ final class StorageSettingsFactory {
 
     private static StorageSettings s3(FileConfiguration config, Logger logger) {
         String prefix = BASE + "s3.";
+        // Only what must come from the config: url is optional (absent means AWS rather than an S3-compatible
+        // service), and the credentials may instead be supplied through AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY,
+        // which are resolved after this runs.
         Map<String, String> required = new LinkedHashMap<>();
-        required.put(prefix + "url", config.getString(prefix + "url"));
-        required.put(prefix + "access-key", config.getString(prefix + "access-key"));
-        required.put(prefix + "secret-key", config.getString(prefix + "secret-key"));
+        required.put(prefix + "region", config.getString(prefix + "region"));
         required.put(prefix + "bucket", config.getString(prefix + "bucket"));
 
         if (fallbackOnMissing(required, "s3", logger)) {
@@ -77,10 +78,10 @@ final class StorageSettingsFactory {
 
     private static StorageSettings sftp(FileConfiguration config, Logger logger) {
         String prefix = BASE + "sftp.";
+        // The password may instead come from BUILDSYSTEM_SFTP_PASSWORD, which is resolved after this runs.
         Map<String, String> required = new LinkedHashMap<>();
         required.put(prefix + "host", config.getString(prefix + "host"));
         required.put(prefix + "username", config.getString(prefix + "username"));
-        required.put(prefix + "password", config.getString(prefix + "password"));
 
         if (fallbackOnMissing(required, "sftp", logger)) {
             return new Local();

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/FileUtils.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/util/FileUtils.java
@@ -237,8 +237,11 @@ public final class FileUtils {
         try (ZipFile zipFile = new ZipFile(storage.getAbsolutePath())) {
             File worldContainer = worldFolder(buildWorld.getName());
 
-            ExcludeFileFilter excludeFileFilter = Sets.newHashSet(
-                    new File(worldContainer, "uid.dat"), new File(worldContainer, "session.lock"))::contains;
+            Set<File> runtimeFiles =
+                    Sets.newHashSet(new File(worldContainer, "uid.dat"), new File(worldContainer, "session.lock"));
+            Path nestedWorlds = nestedWorldsRoot(worldContainer);
+            ExcludeFileFilter excludeFileFilter =
+                    file -> runtimeFiles.contains(file) || isUnder(file.toPath(), nestedWorlds);
             ZipParameters zipParameters = new ZipParameters();
             zipParameters.setExcludeFileFilter(excludeFileFilter);
 
@@ -251,8 +254,32 @@ public final class FileUtils {
     }
 
     public static byte[] zipWorldToMemory(BuildWorld buildWorld) throws IOException {
-        Path worldPath = worldFolder(buildWorld.getName()).toPath();
-        return zipDirectoryToMemory(worldPath);
+        File worldContainer = worldFolder(buildWorld.getName());
+        return zipDirectoryToMemory(worldContainer.toPath(), nestedWorldsRoot(worldContainer));
+    }
+
+    /**
+     * {@return the {@code dimensions} directory holding other worlds nested inside this one, or {@code null} when
+     * this is not the default world}
+     *
+     * <p>Only the server's default world has one: since Paper 26.1 every other world lives under its
+     * {@code dimensions/minecraft} directory. Archiving it would fold the entire server into one world's backup, so
+     * it is excluded and the default world is backed up alone.
+     *
+     * @param worldContainer The world folder being archived
+     */
+    private static @Nullable Path nestedWorldsRoot(File worldContainer) {
+        List<World> worlds = Bukkit.getWorlds();
+        if (worlds.isEmpty()) {
+            return null;
+        }
+
+        File defaultWorldFolder = worlds.getFirst().getWorldFolder();
+        return defaultWorldFolder.equals(worldContainer) ? new File(worldContainer, "dimensions").toPath() : null;
+    }
+
+    private static boolean isUnder(Path path, @Nullable Path directory) {
+        return directory != null && path.startsWith(directory);
     }
 
     /**
@@ -264,12 +291,14 @@ public final class FileUtils {
      * @return The zipped bytes
      * @throws IOException If the directory cannot be walked or any file cannot be read
      */
-    static byte[] zipDirectoryToMemory(Path worldPath) throws IOException {
+    static byte[] zipDirectoryToMemory(Path worldPath, @Nullable Path excludedSubtree) throws IOException {
         ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
 
         try (ZipOutputStream zipOut = new ZipOutputStream(byteOut);
                 Stream<Path> walk = Files.walk(worldPath)) {
-            List<Path> files = walk.filter(Files::isRegularFile).toList();
+            List<Path> files = walk.filter(Files::isRegularFile)
+                    .filter(file -> !isUnder(file, excludedSubtree))
+                    .toList();
             for (Path file : files) {
                 Path relativePath = worldPath.relativize(file);
                 zipOut.putNextEntry(new ZipEntry(relativePath.toString().replace("\\", "/")));

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupProfileImpl.java
@@ -144,6 +144,15 @@ public class BackupProfileImpl implements BackupProfile {
         }
         World world = optionalWorld.get();
 
+        // Restoring wipes the world folder before extracting. For the server's default world that folder is the
+        // level-name directory, which since Paper 26.1 holds every other world under dimensions/minecraft, so the
+        // wipe would take the whole server with it. Bukkit also refuses to unload the default world, so the unload
+        // that is supposed to precede the wipe silently does nothing.
+        if (Bukkit.getWorlds().getFirst().equals(world)) {
+            messages.sendMessage(player, "worlds_backup_restore_default_world");
+            return CompletableFuture.completedFuture(null);
+        }
+
         List<@Nullable Player> removedPlayers =
                 worldService.removePlayersFromWorld(worldName, "worlds_backup_restoration_in_progress");
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/BackupServiceImpl.java
@@ -87,7 +87,35 @@ public class BackupServiceImpl implements BackupService {
         this.worldStorage = worldService.getWorldStorage();
         this.backupStorage =
                 createStorageOrFallback(configService.current().world().backup().storage());
+        plugin.getLogger().info("Storing backups " + describe(this.backupStorage));
         scheduleAutoBackupIfEnabled();
+    }
+
+    /**
+     * {@return where the given storage puts backups, for the startup log} Says where rather than naming the class, so
+     * an operator can tell at a glance whether the configured backend was actually the one that loaded.
+     */
+    private String describe(BackupStorage storage) {
+        PluginConfig.World.Backup.StorageSettings settings =
+                configService.current().world().backup().storage();
+        switch (storage) {
+            case LocalBackupStorage _ -> {
+                String reason =
+                        settings instanceof PluginConfig.World.Backup.Local ? "" : " (configured backend failed)";
+                return "locally in plugins/BuildSystem/backups" + reason;
+            }
+            case S3BackupStorage _
+            when settings instanceof PluginConfig.World.Backup.S3 s3 -> {
+                String service = s3.url() == null || s3.url().isBlank() ? "Amazon S3" : s3.url();
+                return "on " + service + " in bucket '" + s3.bucket() + "'";
+            }
+            case SftpBackupStorage _
+            when settings instanceof PluginConfig.World.Backup.Sftp sftp -> {
+                return "over SFTP on " + sftp.host() + ":" + sftp.port();
+            }
+            default -> {}
+        }
+        return "using " + storage.getClass().getSimpleName();
     }
 
     private BackupStorage createStorage(PluginConfig.World.Backup.StorageSettings settings) {
@@ -181,6 +209,7 @@ public class BackupServiceImpl implements BackupService {
         this.backupStorage.close();
         this.backupStorage =
                 createStorageOrFallback(configService.current().world().backup().storage());
+        plugin.getLogger().info("Storing backups " + describe(this.backupStorage));
         scheduleAutoBackupIfEnabled();
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/LocalBackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/LocalBackupStorage.java
@@ -102,7 +102,15 @@ public class LocalBackupStorage extends AbstractBackupStorage {
     public CompletableFuture<Backup> storeBackup(BuildWorld buildWorld) {
         return supply("store backup for " + buildWorld.getName(), () -> {
             long timestamp = System.currentTimeMillis();
-            File storage = new File(getBackupDirectory(buildWorld).toFile(), backupName(timestamp));
+            Path directory = getBackupDirectory(buildWorld);
+            try {
+                // zip4j opens the destination archive with a RandomAccessFile, which fails outright if the per-world
+                // directory is missing
+                Files.createDirectories(directory);
+            } catch (IOException e) {
+                throw new IOException("Failed to create backup directory " + directory, e);
+            }
+            File storage = new File(directory.toFile(), backupName(timestamp));
             File zip = FileUtils.zipWorld(storage, buildWorld);
             if (zip == null) {
                 throw new IOException("Failed to complete the backup for " + buildWorld.getName());

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.backup.BackupProfile;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.util.FileUtils;
 import de.eintosti.buildsystem.world.backup.BackupImpl;
+import de.eintosti.buildsystem.world.backup.storage.s3.S3Client;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -37,15 +38,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.exception.SdkClientException;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3ClientBuilder;
-import software.amazon.awssdk.services.s3.model.*;
 
 @NullMarked
 public class S3BackupStorage extends AbstractBackupStorage {
@@ -53,7 +45,6 @@ public class S3BackupStorage extends AbstractBackupStorage {
     private final ConfigService configService;
     private final Function<BuildWorld, BackupProfile> profileProvider;
     private final S3Client s3Client;
-    private final String bucket;
     private final String pathPrefix;
     private final Path tmpDownloadDirectory;
 
@@ -73,21 +64,11 @@ public class S3BackupStorage extends AbstractBackupStorage {
 
         this.configService = configService;
         this.profileProvider = profileProvider;
-        this.bucket = bucket;
         this.pathPrefix = pathPrefix.endsWith("/") ? pathPrefix : pathPrefix + "/";
         this.tmpDownloadDirectory = FileUtils.resolve(dataFolder, ".tmp_backup_downloads");
 
-        S3ClientBuilder builder = S3Client.builder()
-                // Pinned explicitly so the SDK never probes for a transport that is deliberately not shaded in.
-                .httpClientBuilder(UrlConnectionHttpClient.builder())
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
-                .region(Region.of(region));
-
-        if (url != null && !url.isEmpty()) {
-            builder = builder.region(Region.of(region)).endpointOverride(URI.create(url));
-        }
-
-        this.s3Client = builder.build();
+        URI endpoint = url == null || url.isEmpty() ? null : URI.create(url);
+        this.s3Client = new S3Client(accessKey, secretKey, region, bucket, endpoint);
     }
 
     private String getBackupDirectory(BuildWorld buildWorld) {
@@ -99,19 +80,14 @@ public class S3BackupStorage extends AbstractBackupStorage {
         List<Backup> backups =
                 new ArrayList<>(configService.current().world().backup().maxBackupsPerWorld());
         try {
-            ListObjectsV2Response response = s3Client.listObjectsV2(ListObjectsV2Request.builder()
-                    .bucket(bucket)
-                    .prefix(getBackupDirectory(buildWorld))
-                    .build());
-
-            backups.addAll(response.contents().stream()
+            backups.addAll(s3Client.list(getBackupDirectory(buildWorld)).stream()
                     .filter(object -> object.key().endsWith(".zip"))
                     .map(object -> new BackupImpl(
                             profileProvider.apply(buildWorld),
                             object.lastModified().toEpochMilli(),
                             object.key()))
                     .toList());
-        } catch (S3Exception | SdkClientException e) {
+        } catch (IOException e) {
             throw new RuntimeException("Error while listing S3 backups", e);
         }
         return backups;
@@ -126,9 +102,8 @@ public class S3BackupStorage extends AbstractBackupStorage {
             byte[] zipBytes = FileUtils.zipWorldToMemory(buildWorld);
 
             try {
-                s3Client.putObject(
-                        PutObjectRequest.builder().bucket(bucket).key(key).build(), RequestBody.fromBytes(zipBytes));
-            } catch (S3Exception | SdkClientException e) {
+                s3Client.put(key, zipBytes);
+            } catch (IOException e) {
                 throw new IOException("Failed to upload S3 backup for " + buildWorld.getName(), e);
             }
 
@@ -142,14 +117,9 @@ public class S3BackupStorage extends AbstractBackupStorage {
         return supply("download S3 backup " + backup.key(), () -> {
             try {
                 Path target = tmpDownloadDirectory.resolve(UUID.randomUUID() + ".zip");
-                s3Client.getObject(
-                        GetObjectRequest.builder()
-                                .bucket(bucket)
-                                .key(backup.key())
-                                .build(),
-                        target);
+                s3Client.get(backup.key(), target);
                 return target.toFile();
-            } catch (S3Exception | SdkClientException e) {
+            } catch (IOException e) {
                 throw new IOException("Failed to download S3 backup: " + backup.key(), e);
             }
         });
@@ -158,11 +128,8 @@ public class S3BackupStorage extends AbstractBackupStorage {
     @Override
     protected void doDeleteBackup(Backup backup) {
         try {
-            s3Client.deleteObject(DeleteObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(backup.key())
-                    .build());
-        } catch (S3Exception | SdkClientException e) {
+            s3Client.delete(backup.key());
+        } catch (IOException e) {
             throw new RuntimeException("Unable to delete S3 backup " + backup.key(), e);
         }
     }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/S3BackupStorage.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -77,6 +78,8 @@ public class S3BackupStorage extends AbstractBackupStorage {
         this.tmpDownloadDirectory = FileUtils.resolve(dataFolder, ".tmp_backup_downloads");
 
         S3ClientBuilder builder = S3Client.builder()
+                // Pinned explicitly so the SDK never probes for a transport that is deliberately not shaded in.
+                .httpClientBuilder(UrlConnectionHttpClient.builder())
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
                 .region(Region.of(region));
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/SftpBackupStorage.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/SftpBackupStorage.java
@@ -26,7 +26,6 @@ import de.eintosti.buildsystem.world.backup.BackupImpl;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.Security;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +42,6 @@ import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClient.Attributes;
 import org.apache.sshd.sftp.client.SftpClient.DirEntry;
 import org.apache.sshd.sftp.client.SftpClientFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -91,7 +89,6 @@ public class SftpBackupStorage extends AbstractBackupStorage {
         this.remoteBasePath = normalizeBasePath(remoteBasePath);
         this.tmpDownloadPath = FileUtils.resolve(dataFolder.toPath(), ".tmp_backup_downloads");
 
-        Security.addProvider(new BouncyCastleProvider());
         establishConnection();
     }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/AwsV4Signer.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/AwsV4Signer.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * AWS Signature Version 4 signing, the only part of talking to S3 that is not a plain HTTP request. Implemented here
+ * rather than pulled from the AWS SDK, which costs ~25 MB in the shaded jar to serve four operations.
+ *
+ * <p>The algorithm is fully specified and deterministic: build a canonical form of the request, hash it, sign the
+ * hash with a key derived from the secret plus the date, region and service, and put the result in an
+ * {@code Authorization} header. See {@code AwsV4SignerTest} for the published test vector this is pinned against.
+ */
+@NullMarked
+final class AwsV4Signer {
+
+    private static final String ALGORITHM = "AWS4-HMAC-SHA256";
+    private static final String SERVICE = "s3";
+    private static final DateTimeFormatter AMZ_DATE =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter SCOPE_DATE =
+            DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
+
+    private final String accessKey;
+    private final String secretKey;
+    private final String region;
+
+    AwsV4Signer(String accessKey, String secretKey, String region) {
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+        this.region = region;
+    }
+
+    /**
+     * Signs a request, returning the headers to send. The returned map contains the caller's headers plus
+     * {@code x-amz-date}, {@code x-amz-content-sha256} and {@code Authorization}.
+     *
+     * @param method The HTTP method
+     * @param host The request host, which must match the {@code Host} header actually sent
+     * @param canonicalUri The already-encoded path, beginning with {@code /}
+     * @param canonicalQuery The already-encoded and sorted query string, or empty
+     * @param headers Additional headers to sign
+     * @param payload The request body, empty for requests without one
+     * @param timestamp The signing time
+     * @return The headers to send, including the signature
+     */
+    Map<String, String> sign(
+            String method,
+            String host,
+            String canonicalUri,
+            String canonicalQuery,
+            Map<String, String> headers,
+            byte[] payload,
+            Instant timestamp) {
+        String amzDate = AMZ_DATE.format(timestamp);
+        String scopeDate = SCOPE_DATE.format(timestamp);
+        String payloadHash = hex(sha256(payload));
+
+        SortedMap<String, String> canonicalHeaders = new TreeMap<>();
+        headers.forEach((name, value) -> {
+            requireHeaderSafe(name);
+            requireHeaderSafe(value);
+            canonicalHeaders.put(name.toLowerCase(Locale.ROOT), value.trim());
+        });
+        canonicalHeaders.put("host", host);
+        canonicalHeaders.put("x-amz-content-sha256", payloadHash);
+        canonicalHeaders.put("x-amz-date", amzDate);
+
+        StringBuilder headerBlock = new StringBuilder();
+        canonicalHeaders.forEach((name, value) ->
+                headerBlock.append(name).append(':').append(value).append('\n'));
+        String signedHeaders = String.join(";", canonicalHeaders.keySet());
+
+        String canonicalRequest = method
+                + '\n'
+                + canonicalUri
+                + '\n'
+                + canonicalQuery
+                + '\n'
+                + headerBlock
+                + '\n'
+                + signedHeaders
+                + '\n'
+                + payloadHash;
+
+        String scope = scopeDate + "/" + region + "/" + SERVICE + "/aws4_request";
+        String stringToSign = ALGORITHM
+                + '\n'
+                + amzDate
+                + '\n'
+                + scope
+                + '\n'
+                + hex(sha256(canonicalRequest.getBytes(StandardCharsets.UTF_8)));
+
+        byte[] signingKey = signingKey(scopeDate);
+        String signature = hex(hmac(signingKey, stringToSign));
+
+        Map<String, String> signed = new LinkedHashMap<>(headers);
+        signed.put("x-amz-date", amzDate);
+        signed.put("x-amz-content-sha256", payloadHash);
+        signed.put(
+                "Authorization",
+                ALGORITHM + " Credential=" + accessKey + "/" + scope + ", SignedHeaders=" + signedHeaders
+                        + ", Signature=" + signature);
+        return signed;
+    }
+
+    /**
+     * Rejects a header name or value containing a line break. The canonical request is newline-delimited, so an
+     * injected break would let a caller forge the signed content.
+     */
+    private static void requireHeaderSafe(String value) {
+        if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+            throw new IllegalArgumentException("S3 request headers cannot contain line breaks");
+        }
+    }
+
+    /**
+     * {@return the date/region/service-scoped signing key} Derived rather than stored, so the long-lived secret is
+     * never used to sign directly.
+     */
+    private byte[] signingKey(String scopeDate) {
+        byte[] key = hmac(("AWS4" + secretKey).getBytes(StandardCharsets.UTF_8), scopeDate);
+        key = hmac(key, region);
+        key = hmac(key, SERVICE);
+        return hmac(key, "aws4_request");
+    }
+
+    private static byte[] hmac(byte[] key, String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(key, "HmacSHA256"));
+            return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("HmacSHA256 is required to sign S3 requests", e);
+        }
+    }
+
+    static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required to sign S3 requests", e);
+        }
+    }
+
+    static String hex(byte[] bytes) {
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            hex.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+        }
+        return hex.toString();
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/BucketEndpoint.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/BucketEndpoint.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import java.net.URI;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Where a bucket lives, and how it is addressed. AWS expects the bucket in the hostname
+ * ({@code bucket.s3.region.amazonaws.com/key}); S3-compatible providers such as MinIO, Backblaze B2 and Cloudflare R2
+ * expect it in the path ({@code endpoint/bucket/key}).
+ *
+ * <p>That choice is made once, here. The host is signed and the path is signed, so deciding it in more than one place
+ * risks signing something other than the URL actually requested — which surfaces as an opaque
+ * {@code SignatureDoesNotMatch}.
+ *
+ * @param scheme The URL scheme
+ * @param host The host, including a non-default port, exactly as it must appear in the {@code Host} header
+ * @param basePath The already-encoded path prefix every key sits under, empty when the bucket is in the hostname
+ */
+@NullMarked
+record BucketEndpoint(String scheme, String host, String basePath) {
+
+    /**
+     * {@return an endpoint addressing an AWS bucket virtual-hosted style}
+     *
+     * @param bucket The bucket name
+     * @param region The bucket's region
+     */
+    static BucketEndpoint forAws(String bucket, String region) {
+        return new BucketEndpoint("https", bucket + ".s3." + region + ".amazonaws.com", "");
+    }
+
+    /**
+     * {@return an endpoint addressing a bucket on an S3-compatible service path style}
+     *
+     * @param endpoint The service endpoint
+     * @param bucket The bucket name
+     */
+    static BucketEndpoint forCustomService(URI endpoint, String bucket) {
+        String host = endpoint.getPort() == -1 ? endpoint.getHost() : endpoint.getHost() + ":" + endpoint.getPort();
+        return new BucketEndpoint(endpoint.getScheme(), host, "/" + PercentEncoding.encode(bucket));
+    }
+
+    /**
+     * {@return the canonical path for a key} This is both what gets signed and what gets requested.
+     *
+     * @param key The object key, empty to address the bucket itself
+     */
+    String pathOf(String key) {
+        return basePath + "/" + PercentEncoding.encodePath(key);
+    }
+
+    /**
+     * {@return the absolute URL for a key}
+     *
+     * @param key The object key, empty to address the bucket itself
+     * @param query The already-encoded query string, or empty
+     */
+    String urlOf(String key, String query) {
+        return scheme + "://" + host + pathOf(key) + (query.isEmpty() ? "" : "?" + query);
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/Listing.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/Listing.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import de.eintosti.buildsystem.world.backup.storage.s3.S3Client.S3Object;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * One page of a {@code ListObjectsV2} response.
+ *
+ * @param objects The objects on this page
+ * @param nextContinuationToken The token for the following page, or {@code null} when this is the last one
+ */
+@NullMarked
+record Listing(List<S3Object> objects, @Nullable String nextContinuationToken) {
+
+    /**
+     * Parses a {@code ListObjectsV2} response.
+     *
+     * @param xml The response document
+     * @return The parsed page
+     * @throws IOException If the document is not a listing this client understands
+     */
+    static Listing parse(byte[] xml) throws IOException {
+        Document document = parseSafely(xml);
+
+        List<S3Object> objects = new ArrayList<>();
+        NodeList contents = document.getElementsByTagName("Contents");
+        for (int i = 0; i < contents.getLength(); i++) {
+            Element entry = (Element) contents.item(i);
+            objects.add(new S3Object(required(entry, "Key"), lastModified(entry)));
+        }
+
+        boolean truncated = Boolean.parseBoolean(optional(document, "IsTruncated"));
+        return new Listing(objects, truncated ? optional(document, "NextContinuationToken") : null);
+    }
+
+    private static Instant lastModified(Element entry) throws IOException {
+        String value = required(entry, "LastModified");
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new IOException("S3 returned an unreadable LastModified: " + value, e);
+        }
+    }
+
+    /**
+     * {@return the document parsed with entity resolution disabled} The response is remote input, so a hostile or
+     * compromised endpoint must not be able to make the parser read local files or fetch URLs.
+     */
+    private static Document parseSafely(byte[] xml) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            return factory.newDocumentBuilder().parse(new ByteArrayInputStream(xml));
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException("Could not parse the S3 listing", e);
+        }
+    }
+
+    private static String required(Element parent, String tag) throws IOException {
+        NodeList nodes = parent.getElementsByTagName(tag);
+        if (nodes.getLength() == 0 || nodes.item(0).getTextContent() == null) {
+            throw new IOException("S3 listing entry is missing <" + tag + ">");
+        }
+        return nodes.item(0).getTextContent().trim();
+    }
+
+    private static @Nullable String optional(Document document, String tag) {
+        NodeList nodes = document.getElementsByTagName(tag);
+        return nodes.getLength() == 0 ? null : nodes.item(0).getTextContent().trim();
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/PercentEncoding.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/PercentEncoding.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import java.nio.charset.StandardCharsets;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * RFC 3986 percent-encoding, as SigV4 requires it.
+ *
+ * <p>{@code URLEncoder} cannot be used: it encodes a space as {@code +} and leaves {@code *} alone, and either
+ * difference makes the signature disagree with the request.
+ */
+@NullMarked
+final class PercentEncoding {
+
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+    private PercentEncoding() {}
+
+    /**
+     * {@return the value percent-encoded, with only the RFC 3986 unreserved characters left as-is}
+     *
+     * @param value The value to encode
+     */
+    static String encode(String value) {
+        StringBuilder encoded = new StringBuilder(value.length());
+        for (byte b : value.getBytes(StandardCharsets.UTF_8)) {
+            int unsigned = b & 0xFF;
+            if (isUnreserved((char) unsigned)) {
+                encoded.append((char) unsigned);
+            } else {
+                encoded.append('%').append(HEX[unsigned >> 4]).append(HEX[unsigned & 0xF]);
+            }
+        }
+        return encoded.toString();
+    }
+
+    /**
+     * {@return the key encoded for use as a path} Slashes survive, since they separate the key's own segments rather
+     * than being part of one.
+     *
+     * @param key The object key
+     */
+    static String encodePath(String key) {
+        StringBuilder encoded = new StringBuilder(key.length());
+        for (String segment : key.split("/", -1)) {
+            if (!encoded.isEmpty()) {
+                encoded.append('/');
+            }
+            encoded.append(encode(segment));
+        }
+        return encoded.toString();
+    }
+
+    private static boolean isUnreserved(char c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || c == '-'
+                || c == '_'
+                || c == '.'
+                || c == '~';
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/S3Client.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/S3Client.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A minimal S3 client covering the four operations the backup storage needs: list, put, get and delete. Written
+ * against the S3 REST API on the JDK's {@link HttpClient} rather than pulling in the AWS SDK, which costs ~25 MB in
+ * the shaded jar and ships the generated model for every S3 operation to serve these four.
+ *
+ * <p>Requests are signed with {@link AwsV4Signer} and addressed through a {@link BucketEndpoint}, which decides
+ * virtual-hosted versus path-style addressing once so the signed host and path always match the request.
+ */
+@NullMarked
+public final class S3Client implements AutoCloseable {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration REQUEST_TIMEOUT = Duration.ofMinutes(5);
+
+    private final HttpClient http;
+    private final AwsV4Signer signer;
+    private final BucketEndpoint endpoint;
+
+    /**
+     * An object listed in a bucket.
+     *
+     * @param key The full object key
+     * @param lastModified When the object was last written
+     */
+    public record S3Object(String key, Instant lastModified) {}
+
+    /**
+     * Creates a client.
+     *
+     * @param accessKey The access key id
+     * @param secretKey The secret access key
+     * @param region The bucket's region
+     * @param bucket The bucket name
+     * @param serviceEndpoint An S3-compatible service endpoint, or {@code null} to address AWS directly
+     */
+    public S3Client(String accessKey, String secretKey, String region, String bucket, @Nullable URI serviceEndpoint) {
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                // The signature is bound to the host, so a redirect could never be satisfied by replaying this
+                // request, and following one would hand the Authorization header to a different origin.
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+        this.signer = new AwsV4Signer(accessKey, secretKey, region);
+        this.endpoint = serviceEndpoint == null
+                ? BucketEndpoint.forAws(bucket, region)
+                : BucketEndpoint.forCustomService(serviceEndpoint, bucket);
+    }
+
+    /**
+     * Lists every object under a prefix, following continuation tokens so a bucket holding more than one page is not
+     * silently truncated.
+     *
+     * @param prefix The key prefix to list under
+     * @return The objects found
+     * @throws IOException If the request fails or S3 returns an error
+     */
+    public List<S3Object> list(String prefix) throws IOException {
+        List<S3Object> objects = new ArrayList<>();
+        String continuationToken = null;
+
+        do {
+            Map<String, String> query = new TreeMap<>();
+            query.put("list-type", "2");
+            query.put("prefix", prefix);
+            if (continuationToken != null) {
+                query.put("continuation-token", continuationToken);
+            }
+
+            byte[] xml = body(request("GET", "", query, Payload.empty(), BodyHandlers.ofByteArray()), "list " + prefix);
+            Listing listing = Listing.parse(xml);
+            objects.addAll(listing.objects());
+            continuationToken = listing.nextContinuationToken();
+        } while (continuationToken != null);
+
+        return objects;
+    }
+
+    /**
+     * Uploads an object, replacing anything already at the key.
+     *
+     * @param key The object key
+     * @param content The object body
+     * @throws IOException If the request fails or S3 returns an error
+     */
+    public void put(String key, byte[] content) throws IOException {
+        body(request("PUT", key, Map.of(), Payload.of(content), BodyHandlers.ofByteArray()), "upload " + key);
+    }
+
+    /**
+     * Downloads an object to a file, streaming it rather than buffering: a world backup can be far larger than the
+     * heap the server has spare.
+     *
+     * @param key The object key
+     * @param target The file to write
+     * @throws IOException If the request fails or S3 returns an error
+     */
+    public void get(String key, Path target) throws IOException {
+        HttpResponse<Path> response = request("GET", key, Map.of(), Payload.empty(), BodyHandlers.ofFile(target));
+        if (!isSuccess(response)) {
+            // The handler has already written the error document to the target; it is not a backup.
+            Files.deleteIfExists(target);
+            throw new IOException(failureMessage("download " + key, response.statusCode(), new byte[0]));
+        }
+    }
+
+    /**
+     * Deletes an object. S3 treats deleting a key that is not there as success, and so does this.
+     *
+     * @param key The object key
+     * @throws IOException If the request fails or S3 returns an error
+     */
+    public void delete(String key) throws IOException {
+        body(request("DELETE", key, Map.of(), Payload.empty(), BodyHandlers.ofByteArray()), "delete " + key);
+    }
+
+    private <T> HttpResponse<T> request(
+            String method, String key, Map<String, String> query, Payload payload, BodyHandler<T> handler)
+            throws IOException {
+        String canonicalQuery = canonicalQuery(query);
+        Map<String, String> headers = signer.sign(
+                method,
+                endpoint.host(),
+                endpoint.pathOf(key),
+                canonicalQuery,
+                Map.of(),
+                payload.bytes(),
+                Instant.now());
+
+        HttpRequest.Builder request = HttpRequest.newBuilder(URI.create(endpoint.urlOf(key, canonicalQuery)))
+                .timeout(REQUEST_TIMEOUT)
+                .method(method, payload.publisher());
+        headers.forEach(request::header);
+
+        try {
+            return http.send(request.build(), handler);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while calling S3", e);
+        }
+    }
+
+    /**
+     * {@return the response body, once the status is known to be a success}
+     *
+     * @param response The response to check
+     * @param action What was attempted, for the error message
+     * @throws IOException If S3 returned an error status
+     */
+    private static byte[] body(HttpResponse<byte[]> response, String action) throws IOException {
+        if (!isSuccess(response)) {
+            throw new IOException(failureMessage(action, response.statusCode(), response.body()));
+        }
+        return response.body();
+    }
+
+    private static boolean isSuccess(HttpResponse<?> response) {
+        return response.statusCode() >= 200 && response.statusCode() < 300;
+    }
+
+    /**
+     * {@return a message describing a failed request} S3 explains itself in an XML error document, which is far more
+     * useful than the status alone, so it is included when there is one.
+     */
+    private static String failureMessage(String action, int status, byte[] errorDocument) {
+        String detail =
+                errorDocument.length == 0 ? "" : " - " + new String(errorDocument, StandardCharsets.UTF_8).trim();
+        return "S3 request failed to " + action + " (HTTP " + status + ")" + detail;
+    }
+
+    /**
+     * {@return the query string in the sorted, encoded form SigV4 requires}
+     */
+    private static String canonicalQuery(Map<String, String> query) {
+        StringBuilder canonical = new StringBuilder();
+        new TreeMap<>(query).forEach((name, value) -> {
+            if (!canonical.isEmpty()) {
+                canonical.append('&');
+            }
+            canonical.append(PercentEncoding.encode(name)).append('=').append(PercentEncoding.encode(value));
+        });
+        return canonical.toString();
+    }
+
+    @Override
+    public void close() {
+        http.close();
+    }
+
+    /**
+     * A reque
+     * st body, pairing the bytes that get signed with the publisher that sends them so the two cannot drift.
+     */
+    private record Payload(byte[] bytes) {
+
+        static Payload empty() {
+            return new Payload(new byte[0]);
+        }
+
+        static Payload of(byte[] bytes) {
+            return new Payload(bytes);
+        }
+
+        HttpRequest.BodyPublisher publisher() {
+            return bytes.length == 0
+                    ? HttpRequest.BodyPublishers.noBody()
+                    : HttpRequest.BodyPublishers.ofByteArray(bytes);
+        }
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/S3Client.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/backup/storage/s3/S3Client.java
@@ -225,8 +225,7 @@ public final class S3Client implements AutoCloseable {
     }
 
     /**
-     * A reque
-     * st body, pairing the bytes that get signed with the publisher that sends them so the two cannot drift.
+     * A request body, pairing the bytes that get signed with the publisher that sends them so the two cannot drift.
      */
     private record Payload(byte[] bytes) {
 

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -91,7 +91,11 @@ world:
       # Options: local, s3, sftp
       type: local
       s3:
+        # Leave empty for Amazon S3. Set it to point at an S3-compatible service instead,
+        # e.g. MinIO, Backblaze B2 or Cloudflare R2: "https://s3.example.com"
         url: null
+        # Can also be supplied as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment
+        # variables, which take precedence and keep the secrets out of this file.
         access-key: YOUR_ACCESS_KEY
         secret-key: YOUR_SECRET_KEY
         region: eu-central-1
@@ -101,6 +105,8 @@ world:
         host: YOUR_SFTP_HOST
         port: 22
         username: YOUR_SFTP_USERNAME
+        # Can also be supplied as the BUILDSYSTEM_SFTP_PASSWORD environment variable,
+        # which takes precedence and keeps the secret out of this file.
         password: YOUR_SFTP_PASSWORD
         path: backups/worlds/
 

--- a/buildsystem-core/src/main/resources/messages.yml
+++ b/buildsystem-core/src/main/resources/messages.yml
@@ -172,6 +172,7 @@ worlds_addbuilder_added: "%prefix% &b%builder% &7was &aadded &7as a builder."
 
 worlds_backup_usage: "%prefix% &7Usage: &b/worlds backup [create]"
 worlds_backup_unknown_world: "%prefix% &cUnknown world."
+worlds_backup_restore_default_world: "%prefix% &cThe default world cannot be restored while the server runs. Stop the server and extract the backup over its folder."
 worlds_backup_world_not_imported: "%prefix% &cWorld must be imported: /worlds import <world>"
 worlds_backup_created: "%prefix% &7Successfully &acreated &7a backup of &b%world%&7."
 worlds_backup_failed: "%prefix% &cUnable to create a backup of %world%."

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/util/FileUtilsTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/util/FileUtilsTest.java
@@ -150,7 +150,7 @@ class FileUtilsTest {
     void zipDirectoryToMemory_archivesEveryFileWithForwardSlashPaths() throws IOException {
         File world = createWorldLikeDirectory("source");
 
-        byte[] zipped = FileUtils.zipDirectoryToMemory(world.toPath());
+        byte[] zipped = FileUtils.zipDirectoryToMemory(world.toPath(), null);
 
         Map<String, String> entries = readZipEntries(zipped);
         assertEquals("level", entries.get("level.dat"));
@@ -159,11 +159,27 @@ class FileUtilsTest {
     }
 
     @Test
+    void zipDirectoryToMemory_skipsTheExcludedSubtree() throws IOException {
+        File world = createWorldLikeDirectory("source");
+        File nested = new File(world, "dimensions/minecraft/other");
+        assertTrue(nested.mkdirs(), "test fixture");
+        Files.writeString(nested.toPath().resolve("level.dat"), "other-world");
+
+        byte[] zipped = FileUtils.zipDirectoryToMemory(world.toPath(), new File(world, "dimensions").toPath());
+
+        Map<String, String> entries = readZipEntries(zipped);
+        assertEquals("level", entries.get("level.dat"), "the world's own data is archived");
+        assertFalse(
+                entries.containsKey("dimensions/minecraft/other/level.dat"),
+                "worlds nested under the default world must not be folded into its backup");
+    }
+
+    @Test
     void zipDirectoryToMemory_missingDirectoryThrows() {
         Path missing = tempDir.resolve("missing");
 
         // Failure must surface instead of producing a silently-truncated archive.
-        assertThrows(IOException.class, () -> FileUtils.zipDirectoryToMemory(missing));
+        assertThrows(IOException.class, () -> FileUtils.zipDirectoryToMemory(missing, null));
     }
 
     /** A running server with {@code level-name=world} whose container is the temp dir. */

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/backup/storage/SftpSignatureSupportTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/backup/storage/SftpSignatureSupportTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.sshd.common.signature.BuiltinSignatures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The SFTP backup verifies host keys with RSA and Ed25519 signatures. Both used to require BouncyCastle to be
+ * registered as a security provider, which cost ~19 MB in the shaded jar. The JDK has supported Ed25519 natively
+ * since 15 and this plugin targets 25, so the provider was dropped — this pins that the algorithms are still there
+ * without it, since losing one would silently break connecting to a backup server.
+ */
+class SftpSignatureSupportTest {
+
+    @Test
+    @DisplayName("Host-key signatures resolve from the JDK, with no BouncyCastle on the classpath")
+    void signaturesSupportedWithoutBouncyCastle() {
+        assertTrue(BuiltinSignatures.rsa.isSupported(), "RSA host keys must stay verifiable");
+        assertTrue(BuiltinSignatures.ed25519.isSupported(), "Ed25519 host keys must stay verifiable");
+    }
+}

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/backup/storage/s3/AwsV4SignerTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/world/backup/storage/s3/AwsV4SignerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.world.backup.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the signer against AWS's published "Signature Calculation Examples" for S3, so a change to the canonical form
+ * fails here rather than as an opaque {@code SignatureDoesNotMatch} against a real bucket.
+ */
+class AwsV4SignerTest {
+
+    private static final String ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+    private static final String SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    private static final Instant SIGNING_TIME =
+            ZonedDateTime.of(2013, 5, 24, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
+
+    @Test
+    @DisplayName("The documented GET Object example produces the documented signature")
+    void getObjectExampleMatchesPublishedSignature() {
+        AwsV4Signer signer = new AwsV4Signer(ACCESS_KEY, SECRET_KEY, "us-east-1");
+
+        Map<String, String> signed = signer.sign(
+                "GET",
+                "examplebucket.s3.amazonaws.com",
+                "/test.txt",
+                "",
+                Map.of("range", "bytes=0-9"),
+                new byte[0],
+                SIGNING_TIME);
+
+        assertEquals(
+                "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, "
+                        + "SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, "
+                        + "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
+                signed.get("Authorization"));
+    }
+
+    @Test
+    @DisplayName("An empty payload hashes to the documented constant")
+    void emptyPayloadHash() {
+        assertEquals(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                AwsV4Signer.hex(AwsV4Signer.sha256(new byte[0])));
+    }
+
+    @Test
+    @DisplayName("The signature covers the payload, so a changed body changes the signature")
+    void signatureCoversPayload() {
+        AwsV4Signer signer = new AwsV4Signer(ACCESS_KEY, SECRET_KEY, "eu-central-1");
+
+        String first = signer.sign(
+                        "PUT",
+                        "b.s3.eu-central-1.amazonaws.com",
+                        "/k.zip",
+                        "",
+                        Map.of(),
+                        "one".getBytes(StandardCharsets.UTF_8),
+                        SIGNING_TIME)
+                .get("Authorization");
+        String second = signer.sign(
+                        "PUT",
+                        "b.s3.eu-central-1.amazonaws.com",
+                        "/k.zip",
+                        "",
+                        Map.of(),
+                        "two".getBytes(StandardCharsets.UTF_8),
+                        SIGNING_TIME)
+                .get("Authorization");
+
+        assertNotEquals(first, second, "payload must be part of what is signed");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ axiompaper = "5.0.4+26.1"
 # Third Party
 annotations = "26.1.0"
 authlib = "3.13.56"
-aws-sdk = "2.46.20"
 eddsa = "0.3.0"
 bstats = "3.2.1"
 fastboard = "2.2.0"
@@ -51,11 +50,6 @@ axiompaper = { group = "maven.modrinth.workaround", name = "axiom-paper-plugin",
 # Third Party
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
 authlib = { group = "com.mojang", name = "authlib", version.ref = "authlib" }
-aws-auth = { module = "software.amazon.awssdk:auth", version.ref = "aws-sdk" }
-aws-core = { module = "software.amazon.awssdk:core", version.ref = "aws-sdk" }
-aws-regions = { module = "software.amazon.awssdk:regions", version.ref = "aws-sdk" }
-aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-sdk" }
-aws-urlconnection = { module = "software.amazon.awssdk:url-connection-client", version.ref = "aws-sdk" }
 eddsa = { group = "net.i2p.crypto", name = "eddsa", version.ref = "eddsa" }
 bstats = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats" }
 fastboard = { group = "fr.mrmicky", name = "fastboard", version.ref = "fastboard" }
@@ -64,6 +58,3 @@ nbt = { group = "dev.dewy", name = "nbt", version.ref = "nbt" }
 sftp = { group = "org.apache.sshd", name = "sshd-sftp", version.ref = "sshd-sftp" }
 zip4j = { group = "net.lingala.zip4j", name = "zip4j", version.ref = "zip4j" }
 xseries = { group = "com.github.cryptomorin", name = "XSeries", version.ref = "xseries" }
-
-[bundles]
-aws = ["aws-s3", "aws-auth", "aws-regions", "aws-core", "aws-urlconnection"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ axiompaper = "5.0.4+26.1"
 annotations = "26.1.0"
 authlib = "3.13.56"
 aws-sdk = "2.46.20"
-bouncycastle = "1.85"
+eddsa = "0.3.0"
 bstats = "3.2.1"
 fastboard = "2.2.0"
 jspecify = "1.0.0"
@@ -55,7 +55,8 @@ aws-auth = { module = "software.amazon.awssdk:auth", version.ref = "aws-sdk" }
 aws-core = { module = "software.amazon.awssdk:core", version.ref = "aws-sdk" }
 aws-regions = { module = "software.amazon.awssdk:regions", version.ref = "aws-sdk" }
 aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "aws-sdk" }
-bouncycastle = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
+aws-urlconnection = { module = "software.amazon.awssdk:url-connection-client", version.ref = "aws-sdk" }
+eddsa = { group = "net.i2p.crypto", name = "eddsa", version.ref = "eddsa" }
 bstats = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats" }
 fastboard = { group = "fr.mrmicky", name = "fastboard", version.ref = "fastboard" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
@@ -65,4 +66,4 @@ zip4j = { group = "net.lingala.zip4j", name = "zip4j", version.ref = "zip4j" }
 xseries = { group = "com.github.cryptomorin", name = "XSeries", version.ref = "xseries" }
 
 [bundles]
-aws = ["aws-s3", "aws-auth", "aws-regions", "aws-core"]
+aws = ["aws-s3", "aws-auth", "aws-regions", "aws-core", "aws-urlconnection"]


### PR DESCRIPTION
The shaded jar was **32.4 MB**. It is now **4.2 MB**, with no runtime downloads and nothing removed from what the plugin can do.

Almost all of it was the backup feature's dependencies, shipped whole because `minimize()` correctly excludes them — they resolve classes reflectively, so stripping them would break at runtime.

| Change | Saved |
| --- | --- |
| Dropped `netty-nio-client` | 9.6 MB |
| Dropped `apache5-client`, use the JDK's `url-connection-client` | 5.7 MB |
| BouncyCastle → `net.i2p.crypto:eddsa` | 19.5 MB |
| AWS SDK → a minimal S3 client | 25.5 MB |

### Transports

The S3 backup uses the synchronous `S3Client`, so the async netty transport was never loaded at all, and the Apache client is swappable for the JDK-backed one.

### BouncyCastle

It was registered as a blanket security provider purely so sshd could verify **Ed25519 host keys**. `net.i2p.crypto:eddsa` does that job at 90 KB.

`SftpSignatureSupportTest` pins that both RSA and Ed25519 host keys stay verifiable. That test is what caught the first attempt: dropping BouncyCastle outright left RSA working and Ed25519 silently gone, which would have broken connections to most modern SFTP servers.

### The S3 client

The SDK shipped the generated model for every S3 operation to serve four: list, put, get and delete. Those are plain REST calls; the only non-trivial part is SigV4 signing, which is deterministic and has published test vectors.

* `S3Client` — the four operations over the JDK `HttpClient`
* `AwsV4Signer` — SigV4, pinned against AWS's published example in `AwsV4SignerTest`
* `BucketEndpoint` — virtual-hosted (Amazon) vs path-style (MinIO, R2, B2) addressing, decided **once**; both the host and the path are signed, so deciding it in two places risks signing something other than the URL requested
* `Listing` — `ListObjectsV2` parsing with entity resolution disabled, following continuation tokens so a bucket holding more than one page is not silently truncated
* `PercentEncoding` — RFC 3986; `URLEncoder` cannot be used, it emits `+` for space and leaves `*` bare, and either makes the signature disagree

Downloads stream to disk rather than buffering, and redirects are refused: the signature is bound to the host, so a redirect could never be satisfied by replaying the request, and following one would hand the `Authorization` header to a different origin.

Verified against a real Amazon S3 bucket — upload, list and download all work.

### Known gap

The four operations have no automated test. The signer is pinned to AWS's vector, but request assembly is covered only by manual verification. A mock `HttpServer` test (JDK built-in, no new dependency) is the obvious follow-up.
