### PR TITLE
chore: declare the real minimum API version

### DIFF
--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -144,7 +144,7 @@ bukkit {
     website = "https://buildsystem.eintosti.de"
 
     main = "de.eintosti.buildsystem.BuildSystemPlugin"
-    apiVersion = "1.13"
+    apiVersion = "26.1"
     softDepend = listOf("LuckPerms", "PlaceholderAPI", "WorldEdit", "AxiomPaper")
 
     commands {


### PR DESCRIPTION
`api-version` was still `1.13`, left over from long before the plugin required Paper's 26.1 world layout.

Two things already made that untrue:

- **World storage.** `FileUtils.worldFolder` resolves worlds as `<level-name>/dimensions/minecraft/<name>`, which is Paper 26.1+. The default-world backup handling depends on that layout directly.
- **`PersistentDataContainer`** (1.14+) is used unconditionally in `ItemBuilder`, `NavigatorItems`, `CustomBlock` and others, so the plugin could never have started on 1.13 regardless.

The practical effect of the stale value was that a server on an unsupported version would happily load the plugin and then fail somewhere less obvious. It now refuses up front.

Matches what the docs already state: "Requires Java 25 and supports Minecraft 26.1 through 26.2".