### PR TITLE
feat: load unloaded build worlds for EssentialsX warps

### DIFF
--- a/buildsystem-core/build.gradle.kts
+++ b/buildsystem-core/build.gradle.kts
@@ -22,6 +22,10 @@ repositories {
         url = uri("https://maven.enginehub.org/repo/")
     }
     maven {
+        name = "EssentialsX"
+        url = uri("https://repo.essentialsx.net/releases/")
+    }
+    maven {
         name = "PlaceholderAPI"
         url = uri("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     }
@@ -56,6 +60,7 @@ dependencies {
         exclude(group = "com.google.guava")
         exclude(group = "com.google.code.gson")
     }
+    compileOnly(libs.essentialsx) { isTransitive = false }
     compileOnly(libs.luckperms)
     compileOnly(libs.placeholderapi)
     compileOnly(libs.worldedit) {
@@ -145,7 +150,7 @@ bukkit {
 
     main = "de.eintosti.buildsystem.BuildSystemPlugin"
     apiVersion = "26.1"
-    softDepend = listOf("LuckPerms", "PlaceholderAPI", "WorldEdit", "AxiomPaper")
+    softDepend = listOf("Essentials", "LuckPerms", "PlaceholderAPI", "WorldEdit", "AxiomPaper")
 
     commands {
         register("back") {

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/essentials/WarpWorldLoadListener.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/integration/essentials/WarpWorldLoadListener.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018-2026, Thomas Meaney
+ * Copyright (c) contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.eintosti.buildsystem.integration.essentials;
+
+import com.earth2me.essentials.utils.StringUtil;
+import de.eintosti.buildsystem.api.world.BuildWorld;
+import de.eintosti.buildsystem.storage.WorldStorageImpl;
+import java.io.File;
+import java.util.logging.Logger;
+import net.ess3.api.events.UserWarpEvent;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Loads the build world a warp points at before EssentialsX resolves it.
+ *
+ * <p>EssentialsX turns a warp into a {@link org.bukkit.Location} through {@link org.bukkit.Bukkit#getWorld}, which
+ * returns {@code null} for a world BuildSystem has unloaded, failing the warp. {@link UserWarpEvent} fires before that
+ * lookup, so loading the world here makes the warp resolve normally.
+ *
+ * <p>Only registered if EssentialsX is available.
+ */
+@NullMarked
+public class WarpWorldLoadListener implements Listener {
+
+    private final WorldStorageImpl worldStorage;
+    private final File warpsFolder;
+
+    public WarpWorldLoadListener(WorldStorageImpl worldStorage, Plugin essentials, Logger logger) {
+        this.worldStorage = worldStorage;
+        this.warpsFolder = new File(essentials.getDataFolder(), "warps");
+        logger.info("EssentialsX warp world loading has been enabled.");
+    }
+
+    /**
+     * Runs at the last priority before EssentialsX reads the event back, so the warp name is final and a warp another
+     * plugin cancelled never loads a world.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onUserWarp(UserWarpEvent event) {
+        // World creation is main-thread only, so an off-thread warp is beyond saving here.
+        if (event.isCancelled() || event.isAsynchronous()) {
+            return;
+        }
+
+        String worldName = readWarpWorld(event.getWarp());
+        if (worldName == null) {
+            return;
+        }
+
+        BuildWorld buildWorld = worldStorage.getBuildWorld(worldName);
+        if (buildWorld == null || buildWorld.isLoaded()) {
+            return;
+        }
+
+        // Blocking on purpose: EssentialsX resolves the location as soon as this returns.
+        buildWorld.getLoader().load();
+    }
+
+    /**
+     * Reads the world a warp points at straight off disk, because EssentialsX only exposes warps as already-resolved
+     * locations - the very lookup that fails for an unloaded world. Warp files are named after the sanitized warp name,
+     * so the target file is known without scanning the folder.
+     *
+     * @param warp The warp name
+     * @return The world's name, or {@code null} if the warp is unknown or stores no usable name
+     */
+    private @Nullable String readWarpWorld(String warp) {
+        File warpFile = new File(warpsFolder, StringUtil.sanitizeFileName(warp) + ".yml");
+        if (!warpFile.isFile()) {
+            return null;
+        }
+
+        // Since EssentialsX 2.19 "world" holds the world's uuid and "world-name" its name; older warps only have
+        // "world", holding the name.
+        YamlConfiguration warpConfig = YamlConfiguration.loadConfiguration(warpFile);
+        String worldName = warpConfig.getString("world-name");
+        return worldName != null && !worldName.isEmpty() ? worldName : warpConfig.getString("world");
+    }
+}

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/ListenerRegistrar.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/listener/ListenerRegistrar.java
@@ -23,6 +23,7 @@ import de.eintosti.buildsystem.api.world.data.WorldStatusRegistry;
 import de.eintosti.buildsystem.config.ConfigService;
 import de.eintosti.buildsystem.i18n.Messages;
 import de.eintosti.buildsystem.integration.axiom.WorldManipulateByAxiomListener;
+import de.eintosti.buildsystem.integration.essentials.WarpWorldLoadListener;
 import de.eintosti.buildsystem.integration.worldedit.EditSessionListener;
 import de.eintosti.buildsystem.listener.color.AsyncPlayerChatListener;
 import de.eintosti.buildsystem.listener.color.SignChangeListener;
@@ -47,6 +48,7 @@ import de.eintosti.buildsystem.util.TaskScheduler;
 import de.eintosti.buildsystem.util.UpdateChecker;
 import de.eintosti.buildsystem.world.spawn.SpawnService;
 import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.jspecify.annotations.NullMarked;
 
@@ -153,6 +155,11 @@ public final class ListenerRegistrar {
     private void registerIntegrations(ConfigService configService) {
         if (pluginManager.getPlugin("AxiomPaper") != null) {
             register(new WorldManipulateByAxiomListener(services.world().getWorldStorage(), plugin.getLogger()));
+        }
+
+        Plugin essentials = pluginManager.getPlugin("Essentials");
+        if (essentials != null) {
+            register(new WarpWorldLoadListener(services.world().getWorldStorage(), essentials, plugin.getLogger()));
         }
 
         boolean isWorldEdit =

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/WorldServiceImpl.java
@@ -216,6 +216,15 @@ public class WorldServiceImpl implements WorldService {
 
     @Override
     public CompletableFuture<Void> unimportWorld(BuildWorld buildWorld, SaveBehavior saveBehavior) {
+        return unimportWorldQuietly(buildWorld, saveBehavior)
+                .thenRun(() -> plugin.getLogger().info("*** Unimported world \"" + buildWorld.getName() + "\" ***"));
+    }
+
+    /**
+     * Unimports without logging, so a deletion (which unimports as its first step) is reported as a single
+     * operation.
+     */
+    private CompletableFuture<Void> unimportWorldQuietly(BuildWorld buildWorld, SaveBehavior saveBehavior) {
         buildWorld.getUnloader().forceUnload(saveBehavior);
         this.worldStorage.removeBuildWorld(buildWorld);
         Bukkit.getServer().getPluginManager().callEvent(new BuildWorldUnimportEvent(buildWorld));
@@ -294,11 +303,12 @@ public class WorldServiceImpl implements WorldService {
         // Registry removal and metadata persistence are awaited before folder deletion so a crash mid-delete leaves an
         // orphaned folder (re-importable) rather than an orphaned registry entry pointing at a deleted folder. The
         // directory delete is disk I/O, so it runs on the shared background pool.
-        return unimportWorld(buildWorld, SaveBehavior.DISCARD)
+        return unimportWorldQuietly(buildWorld, SaveBehavior.DISCARD)
                 .thenRunAsync(
                         () -> {
                             try {
                                 FileUtils.deleteDirectory(deleteFolder);
+                                plugin.getLogger().info("*** Deleted world \"" + worldName + "\" ***");
                             } catch (IOException e) {
                                 throw new CompletionException(new WorldDeletionException(
                                         "An unexpected error occurred during directory deletion for world: %s"

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImporterImpl.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/creation/WorldImporterImpl.java
@@ -109,6 +109,7 @@ public class WorldImporterImpl extends AbstractWorldCreator implements WorldImpo
 
         buildWorld = createAndRegisterBuildWorld();
         generateBukkitWorld(true);
+        context.logger().info("*** Imported world \"" + worldName + "\" ***");
         return buildWorld;
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ luckperms = "5.5"
 worldedit = "7.4.5"
 placeholderapi = "2.12.3"
 axiompaper = "5.0.4+26.1"
+essentialsx = "2.21.2"
 
 # Third Party
 annotations = "26.1.0"
@@ -46,6 +47,7 @@ luckperms = { group = "net.luckperms", name = "api", version.ref = "luckperms" }
 placeholderapi = { group = "me.clip", name = "placeholderapi", version.ref = "placeholderapi" }
 worldedit = { group = "com.sk89q.worldedit", name = "worldedit-core", version.ref = "worldedit" }
 axiompaper = { group = "maven.modrinth.workaround", name = "axiom-paper-plugin", version.ref = "axiompaper" }
+essentialsx = { group = "net.essentialsx", name = "EssentialsX", version.ref = "essentialsx" }
 
 # Third Party
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }


### PR DESCRIPTION
An EssentialsX warp pointing into a build world that BuildSystem had unloaded failed with "That warp does not exist". EssentialsX resolves the stored location through `Bukkit#getWorld`, which returns null while the world is unloaded, and `Warps#getWarp` reports that the same way as an unknown warp.

`UserWarpEvent` fires before that lookup, so a new listener reads the warp's target world from the warp file and loads it if it is an unloaded build world. The world name is read from disk because EssentialsX only exposes warps as already resolved locations, which is the lookup that fails here. The listener is only registered when EssentialsX is installed.

Also adds console logging for importing, unimporting and deleting a world. Loading and unloading were already logged, but these operations left no trace. Deletion unimports as its first step and uses a quiet variant so a delete logs as one line plus the unload.

Closes #528