### PR TITLE
Make the S3 download path configurable

### DIFF
--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -93,8 +93,7 @@ public record PluginConfig(Settings settings, Storage storage, World world, Fold
                 @Nullable String secretKey,
                 @Nullable String region,
                 @Nullable String bucket,
-                @Nullable String path
-                ) {
+                @Nullable String path) {
 
             /**
              * {@return the access key, preferring {@code AWS_ACCESS_KEY_ID}} Lets operators keep the secret out of

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/PluginConfig.java
@@ -92,7 +92,9 @@ public record PluginConfig(Settings settings, Storage storage, World world, Fold
                 @Nullable String accessKey,
                 @Nullable String secretKey,
                 @Nullable String region,
-                @Nullable String bucket) {
+                @Nullable String bucket,
+                @Nullable String path
+                ) {
 
             /**
              * {@return the access key, preferring {@code AWS_ACCESS_KEY_ID}} Lets operators keep the secret out of
@@ -114,13 +116,14 @@ public record PluginConfig(Settings settings, Storage storage, World world, Fold
              */
             @Override
             public String toString() {
-                return "S3[url=%s, accessKey=%s, secretKey=%s, region=%s, bucket=%s]"
+                return "S3[url=%s, accessKey=%s, secretKey=%s, region=%s, bucket=%s, path=%s]"
                         .formatted(
                                 url,
                                 accessKey == null ? null : "***",
                                 secretKey == null ? null : "***",
                                 region,
-                                bucket);
+                                bucket,
+                                path);
             }
         }
 

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/StorageSettingsFactory.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/config/StorageSettingsFactory.java
@@ -54,7 +54,8 @@ final class StorageSettingsFactory {
                         config.getString(s3 + "access-key"),
                         config.getString(s3 + "secret-key"),
                         config.getString(s3 + "region"),
-                        config.getString(s3 + "bucket")),
+                        config.getString(s3 + "bucket"),
+                        Objects.requireNonNullElse(config.getString(s3 + "path"), "downloads/")),
                 new Storage.Sftp(
                         config.getString(sftp + "host"),
                         config.getInt(sftp + "port", 22),

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
@@ -47,9 +47,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 final class S3DownloadDelivery implements DownloadDelivery {
 
-    /**
-     * Where uploads live in the bucket, kept apart from the backups so a lifecycle rule can treat them differently.
-     */
+    
     private final S3Client s3;
 
     private final Logger logger;

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
@@ -50,10 +50,10 @@ final class S3DownloadDelivery implements DownloadDelivery {
     /**
      * Where uploads live in the bucket, kept apart from the backups so a lifecycle rule can treat them differently.
      */
-    private static final String KEY_PREFIX = "downloads/";
 
     private final S3Client s3;
     private final Logger logger;
+    private final String keyPrefix;
 
     /**
      * The uploaded objects and when their links die. An object outlives the request that made it, so something has to
@@ -61,9 +61,10 @@ final class S3DownloadDelivery implements DownloadDelivery {
      */
     private final Map<String, Long> uploads = new ConcurrentHashMap<>();
 
-    private S3DownloadDelivery(S3Client s3, Logger logger) {
+    private S3DownloadDelivery(S3Client s3, Logger logger, String keyPrefix) {
         this.s3 = s3;
         this.logger = logger;
+        this.keyPrefix = normalizePrefix(keyPrefix);
     }
 
     /**
@@ -88,8 +89,9 @@ final class S3DownloadDelivery implements DownloadDelivery {
         String url = settings.url();
         S3Client s3 = new S3Client(
                 accessKey, secretKey, settings.region(), settings.bucket(), isBlank(url) ? null : URI.create(url));
+        String downloadPath = isBlank(settings.path()) ? "downloads/" : settings.path();
         logger.info("World downloads are served as pre-signed links from bucket '" + settings.bucket() + "'");
-        S3DownloadDelivery delivery = new S3DownloadDelivery(s3, logger);
+        S3DownloadDelivery delivery = new S3DownloadDelivery(s3, logger, downloadPath);
         background.execute(delivery::clearLeftovers);
         return delivery;
     }
@@ -103,7 +105,7 @@ final class S3DownloadDelivery implements DownloadDelivery {
      */
     private void clearLeftovers() {
         try {
-            s3.list(KEY_PREFIX).forEach(object -> delete(object.key()));
+            s3.list(keyPrefix).forEach(object -> delete(object.key()));
         } catch (IOException e) {
             logger.log(Level.WARNING, "Failed to clear leftover world downloads from the bucket", e);
         }
@@ -115,7 +117,7 @@ final class S3DownloadDelivery implements DownloadDelivery {
         long total = Files.size(archive);
         // The signed URL is the secret, not the key. A directory per upload only keeps two exports of the same world
         // from colliding.
-        String key = KEY_PREFIX + UUID.randomUUID() + "/" + fileName;
+        String key = keyPrefix + UUID.randomUUID() + "/" + fileName;
 
         try {
             s3.putFile(key, archive, uploaded -> progress.update(uploaded, total));
@@ -184,5 +186,9 @@ final class S3DownloadDelivery implements DownloadDelivery {
 
     private static boolean isBlank(@Nullable String value) {
         return value == null || value.isBlank();
+    }
+
+    private static String normalizePrefix(String prefix) {
+        return prefix.endsWith("/") ? prefix : prefix + "/";
     }
 }

--- a/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
+++ b/buildsystem-core/src/main/java/de/eintosti/buildsystem/world/download/S3DownloadDelivery.java
@@ -50,8 +50,8 @@ final class S3DownloadDelivery implements DownloadDelivery {
     /**
      * Where uploads live in the bucket, kept apart from the backups so a lifecycle rule can treat them differently.
      */
-
     private final S3Client s3;
+
     private final Logger logger;
     private final String keyPrefix;
 

--- a/buildsystem-core/src/main/resources/config.yml
+++ b/buildsystem-core/src/main/resources/config.yml
@@ -134,7 +134,9 @@ storage:
     access-key: YOUR_ACCESS_KEY
     secret-key: YOUR_SECRET_KEY
     region: eu-central-1
-    bucket: buildsystem-backups
+    bucket: buildsystem-backups    
+    # Where world downloads are stored inside the bucket. Backups can use a different path.
+    path: downloads/
   sftp:
     host: YOUR_SFTP_HOST
     port: 22

--- a/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
+++ b/buildsystem-core/src/test/java/de/eintosti/buildsystem/config/PluginConfigTest.java
@@ -284,6 +284,7 @@ class PluginConfigTest {
                     secret-key: "MYSECRETKEY"
                     region: "eu-central-1"
                     bucket: "my-bucket"
+                    path: "downloads/"
                 """);
 
         assertEquals(PluginConfig.Storage.Type.S3, cfg.world().backup().storage());
@@ -294,6 +295,7 @@ class PluginConfigTest {
         assertEquals("MYSECRETKEY", s3.secretKey());
         assertEquals("eu-central-1", s3.region());
         assertEquals("my-bucket", s3.bucket());
+        assertEquals("downloads/", s3.path());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Adds a configurable path for world downloads in S3 storage.

- Adds the `storage.s3.path` configuration option
- Defaults to `downloads/`
- Uses the configured path for uploads and cleanup
- Adds configuration test coverage

Tests:
`./gradlew clean build`